### PR TITLE
Update TNL to v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,23 @@
 
 ## Info
 
-**Document version:** 2.0.2
+**Document version:** 2.2.0
 
-**Last updated:** 07/01/2018
+**Last updated:** 08/27/2018
 
 **Author:** Nolan O'Brien
 
 ## History
+
+### 2.2.0
+- drop iOS 7 support
+  - removes some compatibility check APIs that are no longer necessary too
+
+### 2.1.0
+
+- revise `TNLRetryPolicyProvider` interface to optionally provide a new `TNLRequestConfiguration` when retrying
+  - prior interface only permitted updating the _idleTimeout_ which was not sufficient for more use cases
+  - example use case: provide a custom content encoder that fails to encode a request, the retry policy and update the configuration to remove the custom content encoder to try again without encoding
 
 ### 2.0.2
 

--- a/Source/NSDictionary+TNLAdditions.m
+++ b/Source/NSDictionary+TNLAdditions.m
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
     TNLAssert([key isKindOfClass:[NSString class]]);
     if ([key isKindOfClass:[NSString class]]) {
         for (NSString *otherKey in self.allKeys) {
-            TNLAssert([key isKindOfClass:[NSString class]]);
+            TNLAssert([otherKey isKindOfClass:[NSString class]]);
             if ([otherKey caseInsensitiveCompare:key] == NSOrderedSame) { // TWITTER_STYLE_CASE_INSENSITIVE_COMPARE_NIL_PRECHECKED
                 if (!keys) {
                     keys = [NSMutableSet set];

--- a/Source/NSHTTPCookieStorage+TNLAdditions.m
+++ b/Source/NSHTTPCookieStorage+TNLAdditions.m
@@ -23,11 +23,7 @@ NSHTTPCookieStorage *TNLGetHTTPCookieStorageDemuxProxy()
     static TNLHTTPCookieStorageDemuxProxy *sProxy;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        if (@available(macOS 10.10, iOS 8, tvOS 9, watchOS 2, *)) {
-            sProxy = [TNLHTTPCookieStorageDemuxProxy alloc];
-        } else {
-            TNLAssertNever();
-        }
+        sProxy = [TNLHTTPCookieStorageDemuxProxy alloc];
     });
     return (id)sProxy;
 }

--- a/Source/NSURLCredentialStorage+TNLAdditions.m
+++ b/Source/NSURLCredentialStorage+TNLAdditions.m
@@ -34,11 +34,7 @@ NSURLCredentialStorage *TNLGetURLCredentialStorageDemuxProxy()
     static TNLSharedCredentialStorageProxy *sProxy;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        if (@available(macOS 10.10, iOS 8, tvOS 9, watchOS 2, *)) {
-            sProxy = [TNLSharedCredentialStorageProxy alloc];
-        } else {
-            TNLAssertNever();
-        }
+        sProxy = [TNLSharedCredentialStorageProxy alloc];
     });
     return (id)sProxy;
 }

--- a/Source/NSURLSessionConfiguration+TNLAdditions.h
+++ b/Source/NSURLSessionConfiguration+TNLAdditions.h
@@ -16,42 +16,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface NSURLSessionConfiguration (TNLAdditions)
 
 /**
- Cement the provided _config_.
-
- `NSURLSessionConfiguration` objects, by default, lazily generate certain properties.
- These lazy generated values are not persisted in the underlying ivar though and subsequent calls to
- those properties will yield new objects.
- `tnl_cementConfiguration:` provides a mechanism to avoid this implementation detail by sending the
- return value for a property's getter to its setter.  This effectively caches that property for
- reuse and "cements" that property.  Since `NSURLSessionConfiguration` is a class cluster, we
- provide the functionality with a class method instead of an instance method.
-
- The properties are `URLCache`, `URLCredentialStorage` and `HTTPCookieStorage`
-
- @discussion __See Also:__ `[NSURLSessionConfiguration URLCache]`,
- `[NSURLSessionConfiguration URLCredentialStorage]` and
- `[NSURLSessionConfiguration HTTPCookieStorage]`
-
- @note The issue of needing to cement these properties was fixed in __iOS 8__ so this method is a
- no-op on iOS 8+.
- */
-+ (void)tnl_cementConfiguration:(NSURLSessionConfiguration *)config;
-
-/**
- Unifies between the two constructors for background session configurations on iOS 7 and iOS 8.
-
- __See Also:__ `[NSURLSessionConfiguration backgroundSessionConfiguration:]` (iOS 7) and
- `[NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:]` (iOS 8+)
- */
-+ (instancetype)tnl_backgroundSessionConfigurationWithIdentifier:(NSString *)identifier;
-
-/**
- Returns `YES` if `NSURLSessionConfiguration` supports the shared container identifier.
- Since `NSURLSessionConfiguration` is a class cluster, you can't use `instancesRespondToSelector:`
- */
-+ (BOOL)tnl_supportsSharedContainerIdentifier;
-
-/**
  Returns `NO` if the current OS has a critical bug where
  `URLSession:dataTask:didReceiveResponse:completionHandler:` being implemented in a delegate while
  using an `NSURLProtocol` will render the `NSURLSessionTask` completely unuseable. radar://19494690

--- a/Source/NSURLSessionTaskMetrics+TNLAdditions.m
+++ b/Source/NSURLSessionTaskMetrics+TNLAdditions.m
@@ -56,14 +56,6 @@ NS_ASSUME_NONNULL_BEGIN
 
     d[@"statusCode"] = @([(NSHTTPURLResponse *)self.response statusCode]);
 
-    if (self.request.URL) {
-        d[@"URL"] = self.request.URL;
-    }
-
-    if (self.networkProtocolName) {
-        d[@"protocol"] = self.networkProtocolName;
-    }
-
 #define APPLY_VALUE(key, value) \
     do { \
         id valueObj = (value); \
@@ -72,6 +64,8 @@ NS_ASSUME_NONNULL_BEGIN
         } \
     } while (NO)
 
+    APPLY_VALUE(@"URL", self.request.URL);
+    APPLY_VALUE(@"protocol", self.networkProtocolName);
 
     APPLY_VALUE(@"dns", [self tnl_domainLookupDuration]);
     APPLY_VALUE(@"connect", [self tnl_connectDuration]);
@@ -122,87 +116,122 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable NSNumber *)tnl_domainLookupDuration
 {
-    if (self.domainLookupEndDate) {
-        TNLAssert(self.domainLookupStartDate != nil);
-        return @([self.domainLookupEndDate timeIntervalSinceDate:self.domainLookupStartDate]);
+    NSDate *endDate = self.domainLookupEndDate;
+    if (!endDate) {
+        return nil;
     }
-    return nil;
+
+    NSDate *startDate = self.domainLookupStartDate;
+    TNLAssert(startDate != nil);
+    return @([endDate timeIntervalSinceDate:startDate]);
 }
 
 - (nullable NSNumber *)tnl_connectDuration
 {
-    if (self.connectEndDate) {
-        TNLAssert(self.connectStartDate != nil);
-        return @([self.connectEndDate timeIntervalSinceDate:self.connectStartDate]);
+    NSDate *endDate = self.connectEndDate;
+    if (!endDate) {
+        return nil;
     }
-    return nil;
+
+    NSDate *startDate = self.connectStartDate;
+    TNLAssert(startDate != nil);
+    return @([endDate timeIntervalSinceDate:startDate]);
 }
 
 - (nullable NSNumber *)tnl_transportConnectionDuration
 {
     NSDate *startDate = self.tnl_transportConnectionStartDate;
-    NSDate *endDate = self.tnl_transportConnectionEndDate;
-    if (startDate && endDate) {
-        return @([endDate timeIntervalSinceDate:startDate]);
+    if (!startDate) {
+        return nil;
     }
-    return nil;
+    NSDate *endDate = self.tnl_transportConnectionEndDate;
+    if (!endDate) {
+        return nil;
+    }
+
+    return @([endDate timeIntervalSinceDate:startDate]);
 }
 
 - (nullable NSNumber *)tnl_secureConnectionDuration
 {
-    if (self.secureConnectionEndDate) {
-        TNLAssert(self.secureConnectionStartDate != nil);
-        return @([self.secureConnectionEndDate timeIntervalSinceDate:self.secureConnectionStartDate]);
+    NSDate *endDate = self.secureConnectionEndDate;
+    if (!endDate) {
+        return nil;
     }
-    return nil;
+
+    NSDate *startDate = self.secureConnectionStartDate;
+    TNLAssert(startDate != nil);
+    return @([endDate timeIntervalSinceDate:startDate]);
 }
 
 - (nullable NSNumber *)tnl_requestSendDuration
 {
-    if (self.requestEndDate) {
-        TNLAssert(self.requestStartDate != nil);
-        return @([self.requestEndDate timeIntervalSinceDate:self.requestStartDate]);
+    NSDate *endDate = self.requestEndDate;
+    if (!endDate) {
+        return nil;
     }
-    return nil;
+
+    NSDate *startDate = self.requestStartDate;
+    TNLAssert(startDate != nil);
+    return @([endDate timeIntervalSinceDate:startDate]);
 }
 
 - (nullable NSNumber *)tnl_serverTimeDuration
 {
-    if (self.requestEndDate && self.responseStartDate) {
-        return @([self.responseStartDate timeIntervalSinceDate:self.requestEndDate]);
+    NSDate *requestEndDate = self.requestEndDate;
+    if (!requestEndDate) {
+        return nil;
     }
-    return nil;
+    NSDate *responseStartDate = self.responseStartDate;
+    if (!responseStartDate) {
+        return nil;
+    }
+
+    return @([responseStartDate timeIntervalSinceDate:requestEndDate]);
 }
 
 - (nullable NSNumber *)tnl_responseReceiveDuration
 {
-    if (self.responseEndDate) {
-        TNLAssert(self.responseStartDate != nil);
-        return @([self.responseEndDate timeIntervalSinceDate:self.responseStartDate]);
+    NSDate *endDate = self.responseEndDate;
+    if (!endDate) {
+        return nil;
     }
-    return nil;
+
+    NSDate *startDate = self.responseStartDate;
+    TNLAssert(startDate != nil);
+    return @([endDate timeIntervalSinceDate:startDate]);
 }
 
 - (nullable NSNumber *)tnl_totalDuration
 {
-    if (self.fetchStartDate && self.responseEndDate) {
-        return @([self.responseEndDate timeIntervalSinceDate:self.fetchStartDate]);
+    NSDate *fetchStartDate = self.fetchStartDate;
+    if (!fetchStartDate) {
+        return nil;
     }
-    return nil;
+    NSDate *responseEndDate = self.responseEndDate;
+    if (!responseEndDate) {
+        return nil;
+    }
+
+    return @([responseEndDate timeIntervalSinceDate:fetchStartDate]);
 }
 
 - (nullable NSNumber *)tnl_secureConnectionDurationExt
 {
-    if (!self.connectEndDate) {
+    NSDate *connectEndDate = self.connectEndDate;
+    if (!connectEndDate) {
         return self.tnl_secureConnectionDuration;
     }
-
     NSDate *startDate = self.secureConnectionStartDate;
-    NSDate *endDate = [self.secureConnectionEndDate laterDate:self.connectEndDate];
-    if (startDate && endDate) {
-        return @([endDate timeIntervalSinceDate:startDate]);
+    if (!startDate) {
+        return nil;
     }
-    return nil;
+    NSDate *endDate = [self.secureConnectionEndDate laterDate:connectEndDate];
+    if (!endDate) {
+        return nil;
+    }
+
+    return @([endDate timeIntervalSinceDate:startDate]);
 }
 
 @end

--- a/Source/TNLAttemptMetrics.h
+++ b/Source/TNLAttemptMetrics.h
@@ -68,6 +68,7 @@ static const NSInteger TNLAttemptCompleteDispositionCount = 3;
 /** The associated `TNLAttemptMetaData` (if any) */
 @property (nonatomic, readonly, nullable) TNLAttemptMetaData *metaData;
 
+#if !TARGET_OS_WATCH
 /** attempt reachability status */
 @property (nonatomic, readonly) TNLNetworkReachabilityStatus reachabilityStatus;
 /** attempt reachability flags */
@@ -76,6 +77,7 @@ static const NSInteger TNLAttemptCompleteDispositionCount = 3;
 @property (nonatomic, copy, readonly, nullable) NSString *WWANRadioAccessTechnology;
 /** attempt carrier info. Note: `nil` for macOS since there is no cellular carrier information */
 @property (nonatomic, readonly, nullable) id<TNLCarrierInfo> carrierInfo;
+#endif // !TARGET_OS_WATCH
 
 /** The related request for this attempt */
 @property (nonatomic, readonly, copy) NSURLRequest *URLRequest;

--- a/Source/TNLAttemptMetrics.m
+++ b/Source/TNLAttemptMetrics.m
@@ -63,7 +63,9 @@ TNLStaticAssert(TNLAttemptCompleteDispositionCount == TNLAttemptTypeCount, ATTEM
                    operationError:(nullable NSError *)error
 {
     if (self = [super init]) {
+#if !TARGET_OS_WATCH
         _reachabilityStatus = TNLNetworkReachabilityUndetermined;
+#endif
         _attemptId = attemptId;
         _attemptType = type;
         _startMachTime = startMachTime;
@@ -103,14 +105,18 @@ TNLStaticAssert(TNLAttemptCompleteDispositionCount == TNLAttemptTypeCount, ATTEM
         _responseBodyParseError = [aDecoder decodeObjectOfClass:[NSError class]
                                                          forKey:@"parseError"];
 
+#if !TARGET_OS_WATCH
         _reachabilityStatus = [(NSNumber *)[aDecoder decodeObjectOfClass:[NSNumber class]
                                                                   forKey:@"reachabilityStatus"] integerValue];
         _reachabilityFlags = [(NSNumber *)[aDecoder decodeObjectOfClass:[NSNumber class]
                                                                  forKey:@"reachabilityFlags"] unsignedIntValue];
         _WWANRadioAccessTechnology = [aDecoder decodeObjectOfClass:[NSString class]
                                                             forKey:@"WWANRadioAccessTechnology"];
+#endif
+#if TARGET_OS_IOS
         _carrierInfo = TNLCarrierInfoFromDictionary([aDecoder decodeObjectOfClass:[NSDictionary class]
                                                                            forKey:@"carrierInfo"]);
+#endif
     }
     return self;
 }
@@ -128,10 +134,14 @@ TNLStaticAssert(TNLAttemptCompleteDispositionCount == TNLAttemptTypeCount, ATTEM
     [aCoder encodeObject:_APIErrors forKey:@"APIErrors"];
     [aCoder encodeObject:_responseBodyParseError forKey:@"parseError"];
 
+#if !TARGET_OS_WATCH
     [aCoder encodeObject:@(_reachabilityStatus) forKey:@"reachabilityStatus"];
     [aCoder encodeObject:@(_reachabilityFlags) forKey:@"reachabilityFlags"];
     [aCoder encodeObject:_WWANRadioAccessTechnology forKey:@"WWANRadioAccessTechnology"];
+#endif
+#if TARGET_OS_IOS
     [aCoder encodeObject:TNLCarrierInfoToDictionary(_carrierInfo) forKey:@"carrierInfo"];
+#endif
 }
 
 - (void)finalizeMetrics
@@ -143,11 +153,13 @@ TNLStaticAssert(TNLAttemptCompleteDispositionCount == TNLAttemptTypeCount, ATTEM
     [_metaData finalizeMetaData];
 }
 
+#if !TARGET_OS_WATCH
 - (void)setCommunicationMetricsWithAgent:(nullable TNLCommunicationAgent *)agent
 {
     if (!agent) {
         return;
     }
+
     if (_reachabilityStatus != TNLNetworkReachabilityUndetermined) {
         return;
     }
@@ -157,6 +169,7 @@ TNLStaticAssert(TNLAttemptCompleteDispositionCount == TNLAttemptTypeCount, ATTEM
     _WWANRadioAccessTechnology = [agent.currentWWANRadioAccessTechnology copy];
     _carrierInfo = agent.currentCarrierInfo;
 }
+#endif
 
 - (NSString *)description
 {
@@ -231,6 +244,7 @@ TNLStaticAssert(TNLAttemptCompleteDispositionCount == TNLAttemptTypeCount, ATTEM
         }
     }
 
+#if !TARGET_OS_WATCH
     if (self.reachabilityFlags != other.reachabilityFlags) {
         return NO;
     }
@@ -244,6 +258,7 @@ TNLStaticAssert(TNLAttemptCompleteDispositionCount == TNLAttemptTypeCount, ATTEM
             return NO;
         }
     }
+#endif // !WATCH
 
     if (self.APIErrors != other.APIErrors) {
         if (![self.APIErrors isEqualToArray:other.APIErrors]) {
@@ -257,6 +272,7 @@ TNLStaticAssert(TNLAttemptCompleteDispositionCount == TNLAttemptTypeCount, ATTEM
         }
     }
 
+#if !TARGET_OS_WATCH
     id<TNLCarrierInfo> carrierInfo = self.carrierInfo;
     id<TNLCarrierInfo> otherCarrierInfo = other.carrierInfo;
     if (carrierInfo != otherCarrierInfo) {
@@ -282,6 +298,7 @@ TNLStaticAssert(TNLAttemptCompleteDispositionCount == TNLAttemptTypeCount, ATTEM
             }
         }
     }
+#endif // !WATCH
 
     return YES;
 }
@@ -300,7 +317,9 @@ TNLStaticAssert(TNLAttemptCompleteDispositionCount == TNLAttemptTypeCount, ATTEM
         return;
     }
     _endMachTime = time;
+#if !TARGET_OS_WATCH
     [self setCommunicationMetricsWithAgent:[TNLGlobalConfiguration sharedInstance].metricProvidingCommunicationAgent];
+#endif
 }
 
 - (void)setOperationError:(nullable NSError *)error
@@ -370,10 +389,12 @@ TNLStaticAssert(TNLAttemptCompleteDispositionCount == TNLAttemptTypeCount, ATTEM
     dupeSubmetric->_taskTransactionMetrics = _taskTransactionMetrics;
     dupeSubmetric->_APIErrors = _APIErrors;
     dupeSubmetric->_responseBodyParseError = _responseBodyParseError;
+#if !TARGET_OS_WATCH
     dupeSubmetric->_reachabilityStatus = _reachabilityStatus;
     dupeSubmetric->_reachabilityFlags = _reachabilityFlags;
     dupeSubmetric->_WWANRadioAccessTechnology = [_WWANRadioAccessTechnology copyWithZone:zone];
     dupeSubmetric->_carrierInfo = _carrierInfo;
+#endif
     dupeSubmetric->_final = NO;
     return dupeSubmetric;
 }

--- a/Source/TNLAttemptMetrics_Project.h
+++ b/Source/TNLAttemptMetrics_Project.h
@@ -14,7 +14,9 @@ NS_ASSUME_NONNULL_BEGIN
  * NOTE: this header is private to TNL
  */
 
+#if !TARGET_OS_WATCH
 @class TNLCommunicationAgent;
+#endif
 
 @interface TNLAttemptMetrics (Project)
 
@@ -23,7 +25,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setURLResponse:(nullable NSHTTPURLResponse *)response;
 - (void)setOperationError:(nullable NSError *)error;
 - (void)setTaskTransactionMetrics:(nullable NSURLSessionTaskTransactionMetrics *)taskMetrics NS_AVAILABLE(10_12, 10_0);
+#if !TARGET_OS_WATCH
 - (void)setCommunicationMetricsWithAgent:(nullable TNLCommunicationAgent *)agent;
+#endif
 - (void)updateRequest:(NSURLRequest *)request;
 - (void)finalizeMetrics;
 

--- a/Source/TNLBackgroundURLSessionTaskOperationManager.m
+++ b/Source/TNLBackgroundURLSessionTaskOperationManager.m
@@ -78,11 +78,13 @@ static TNLBackgroundRequestContext * __nullable _getBackgroundRequestContext(SEL
 
 #pragma mark NSURLSessionDelegate
 
+#if TARGET_OS_IPHONE // == IOS + WATCH + TV
 - (void)URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession *)session
 {
     TNLAssert(nil != session.configuration.identifier);
     [[TNLURLSessionManager sharedInstance] URLSessionDidCompleteBackgroundEvents:session];
 }
+#endif
 
 - (void)URLSession:(NSURLSession *)session
         task:(NSURLSessionTask *)task

--- a/Source/TNLBackgroundURLSessionTaskOperationManager.m
+++ b/Source/TNLBackgroundURLSessionTaskOperationManager.m
@@ -100,10 +100,7 @@ static TNLBackgroundRequestContext * __nullable _getBackgroundRequestContext(SEL
         context.URLResponse = (id)task.response;
     }
 
-    NSString *sharedContainerIdentifier = nil;
-    if ([NSURLSessionConfiguration tnl_supportsSharedContainerIdentifier]) {
-        sharedContainerIdentifier = _URLSession.configuration.sharedContainerIdentifier;
-    }
+    NSString *sharedContainerIdentifier = _URLSession.configuration.sharedContainerIdentifier;
 
     TNLResponseInfo *info = [[TNLResponseInfo alloc] initWithFinalURLRequest:task.currentRequest
                                                                  URLResponse:context.URLResponse

--- a/Source/TNLCommunicationAgent.h
+++ b/Source/TNLCommunicationAgent.h
@@ -7,6 +7,9 @@
 //
 
 #import <Foundation/Foundation.h>
+
+#if !TARGET_OS_WATCH // no communication agent for watchOS
+
 #import <SystemConfiguration/SystemConfiguration.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -263,3 +266,5 @@ typedef void(^TNLCommunicationAgentIdentifyWWANRadioAccessTechnologyCallback)(NS
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif // !TARGET_OS_WATCH

--- a/Source/TNLCommunicationAgent.m
+++ b/Source/TNLCommunicationAgent.m
@@ -9,6 +9,8 @@
 #import "TNL_Project.h"
 #import "TNLCommunicationAgent_Project.h"
 
+#if !TARGET_OS_WATCH // no communication agent for watchOS
+
 #define SELF_ARG PRIVATE_SELF(TNLCommunicationAgent)
 
 static void _ReachabilityCallback(__unused SCNetworkReachabilityRef target,
@@ -744,6 +746,8 @@ NSString *TNLNetworkReachabilityStatusToString(TNLNetworkReachabilityStatus stat
     return @"undetermined";
 }
 
+#if TARGET_OS_IOS
+
 NSDictionary * __nullable TNLCarrierInfoToDictionary(id<TNLCarrierInfo> __nullable carrierInfo)
 {
     if (!carrierInfo) {
@@ -780,6 +784,8 @@ id<TNLCarrierInfo> __nullable TNLCarrierInfoFromDictionary(NSDictionary * __null
                                                     allowsVOIP:[dict[@"allowsVOIP"] boolValue]];
 }
 
+#endif // TARGET_OS_IOS
+
 NS_INLINE const char _DebugCharFromReachabilityFlag(SCNetworkReachabilityFlags flags, uint32_t flag, const char presentChar)
 {
     return TNL_BITMASK_HAS_SUBSET_FLAGS(flags, flag) ? presentChar : '_';
@@ -806,3 +812,5 @@ NSString *TNLDebugStringFromNetworkReachabilityFlags(SCNetworkReachabilityFlags 
 #endif
             ];
 }
+
+#endif // !TARGET_OS_WATCH

--- a/Source/TNLCommunicationAgent_Project.h
+++ b/Source/TNLCommunicationAgent_Project.h
@@ -6,13 +6,19 @@
 //  Copyright © 2018 Twitter. All rights reserved.
 //
 
-#import <CoreTelephony/CTCarrier.h>
-#import <CoreTelephony/CTTelephonyNetworkInfo.h>
+
+#pragma mark Primary import
+
 #import <TwitterNetworkLayer/TNLCommunicationAgent.h>
 
-NS_ASSUME_NONNULL_BEGIN
-
 #if TARGET_OS_IOS
+
+#pragma mark IOS only imports
+
+#import <CoreTelephony/CTCarrier.h>
+#import <CoreTelephony/CTTelephonyNetworkInfo.h>
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface TNLCarrierInfoInternal : NSObject <TNLCarrierInfo>
 
@@ -32,6 +38,6 @@ NS_ASSUME_NONNULL_BEGIN
 FOUNDATION_EXTERN NSDictionary * __nullable TNLCarrierInfoToDictionary(id<TNLCarrierInfo> __nullable carrierInfo);
 FOUNDATION_EXTERN id<TNLCarrierInfo> __nullable TNLCarrierInfoFromDictionary(NSDictionary * __nullable dict);
 
-#endif // TARGET_OS_IOS
-
 NS_ASSUME_NONNULL_END
+
+#endif // TARGET_OS_IOS

--- a/Source/TNLCommunicationAgent_Project.h
+++ b/Source/TNLCommunicationAgent_Project.h
@@ -12,7 +12,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
 
 @interface TNLCarrierInfoInternal : NSObject <TNLCarrierInfo>
 
@@ -32,6 +32,6 @@ NS_ASSUME_NONNULL_BEGIN
 FOUNDATION_EXTERN NSDictionary * __nullable TNLCarrierInfoToDictionary(id<TNLCarrierInfo> __nullable carrierInfo);
 FOUNDATION_EXTERN id<TNLCarrierInfo> __nullable TNLCarrierInfoFromDictionary(NSDictionary * __nullable dict);
 
-#endif
+#endif // TARGET_OS_IOS
 
 NS_ASSUME_NONNULL_END

--- a/Source/TNLError.m
+++ b/Source/TNLError.m
@@ -144,6 +144,8 @@ BOOL TNLErrorIsNetworkSecurityError(NSError * __nullable error)
         // SSL error
         return YES;
     } else if (-2000 == code) {
+
+#if !TARGET_OS_WATCH
         // cannot load from network - is it due to SSL?
 
         if (nil != error.userInfo[(NSString *)kCFStreamPropertySSLPeerTrust]) {
@@ -163,6 +165,7 @@ BOOL TNLErrorIsNetworkSecurityError(NSError * __nullable error)
                 return YES;
             }
         }
+#endif // !WATCH
     }
 
     NSError * const underlyingError = error.userInfo[NSUnderlyingErrorKey];

--- a/Source/TNLGlobalConfiguration.h
+++ b/Source/TNLGlobalConfiguration.h
@@ -16,7 +16,10 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol TNLLogger;
 @protocol TNLNetworkObserver;
 @class TNLRequestOperation;
+
+#if !TARGET_OS_WATCH
 @class TNLCommunicationAgent;
+#endif
 
 ///! The default duration for the request operation callback timeout
 FOUNDATION_EXTERN const NSTimeInterval TNLGlobalConfigurationRequestOperationCallbackTimeoutDefault;
@@ -137,12 +140,14 @@ typedef NS_ENUM(NSInteger, TNLGlobalConfigurationServiceUnavailableBackoffMode)
  */
 - (NSArray<id<TNLHTTPHeaderProvider>> *)allHeaderProviders;
 
+#if !TARGET_OS_WATCH
 /**
  The specified `TNLCommunicationAgent` will be used for all `TNLAttemptMetrics` to capture the best
  guess network state at attempt completion.
  Ideally, network state would be provided in task transaction metrics by Apple.
  */
 @property (atomic, nullable) TNLCommunicationAgent *metricProvidingCommunicationAgent;
+#endif
 
 #pragma mark Settings
 

--- a/Source/TNLGlobalConfiguration.m
+++ b/Source/TNLGlobalConfiguration.m
@@ -38,7 +38,7 @@ const NSTimeInterval TNLGlobalConfigurationRequestOperationCallbackTimeoutDefaul
     dispatch_queue_t _backgroundTaskQueue;
     NSArray<id<TNLAuthenticationChallengeHandler>> *_authHandlers;
 
-#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
+#if TARGET_OS_IOS || TARGET_OS_TV
     UIBackgroundTaskIdentifier _sharedUIApplicationBackgroundTaskIdentifier;
 #endif
 }
@@ -76,7 +76,7 @@ const NSTimeInterval TNLGlobalConfigurationRequestOperationCallbackTimeoutDefaul
         _timeoutIntervalBetweenDataTransfer = 0.0;
         _operationAutomaticDependencyPriorityThreshold = (TNLPriority)NSIntegerMax;
 
-#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
+#if TARGET_OS_IOS || TARGET_OS_TV
         _sharedUIApplicationBackgroundTaskIdentifier = 0;
         const Class UIApplicationClass = TNLDynamicUIApplicationClass();
         if (UIApplicationClass != Nil) {
@@ -119,12 +119,12 @@ const NSTimeInterval TNLGlobalConfigurationRequestOperationCallbackTimeoutDefaul
                 _lastApplicationState = UIApplicationStateBackground;
             }
         }
-#endif // TARGET_OS_IPHONE
+#endif // IOS + TV
     }
     return self;
 }
 
-#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
+#if TARGET_OS_IOS || TARGET_OS_TV
 
 - (void)_tnl_applicationDidFinishLaunching:(NSNotification *)note
 {
@@ -152,7 +152,7 @@ const NSTimeInterval TNLGlobalConfigurationRequestOperationCallbackTimeoutDefaul
     self.lastApplicationState = UIApplicationStateBackground;
 }
 
-#endif // TARGET_OS_IPHONE
+#endif // IOS + TV
 
 - (void)addNetworkObserver:(id<TNLNetworkObserver>)observer
 {
@@ -307,7 +307,7 @@ const NSTimeInterval TNLGlobalConfigurationRequestOperationCallbackTimeoutDefaul
 
 static void _main_ensureSharedBackgroundTask(SELF_ARG)
 {
-#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
+#if TARGET_OS_IOS || TARGET_OS_TV
     if (!self) {
         return;
     }
@@ -320,12 +320,12 @@ static void _main_ensureSharedBackgroundTask(SELF_ARG)
             }];
         }
     }
-#endif
+#endif // IOS + TV
 }
 
 static void _main_cleanUpSharedBackgroundTaskIfNecessary(SELF_ARG)
 {
-#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
+#if TARGET_OS_IOS || TARGET_OS_TV
     if (!self) {
         return;
     }
@@ -338,12 +338,12 @@ static void _main_cleanUpSharedBackgroundTaskIfNecessary(SELF_ARG)
             [sharedUIApplication endBackgroundTask:identifier];
         }
     }
-#endif
+#endif // IOS + TV
 }
 
+#if TARGET_OS_IOS || TARGET_OS_TV
 static void _handleExpiration(SELF_ARG)
 {
-#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
     if (!self) {
         return;
     }
@@ -367,8 +367,8 @@ static void _handleExpiration(SELF_ARG)
             tnl_dispatch_async_autoreleasing(dispatch_get_main_queue(), block);
         }
     }
-#endif
 }
+#endif // IOS + TV
 
 @end
 

--- a/Source/TNLGlobalConfiguration_Project.h
+++ b/Source/TNLGlobalConfiguration_Project.h
@@ -27,7 +27,7 @@ FOUNDATION_EXTERN const TNLBackgroundTaskIdentifier TNLBackgroundTaskInvalid;
 @property (atomic, nullable) id<TNLLogger> internalLogger;
 @property (atomic, copy, nullable, readonly) NSArray<id<TNLAuthenticationChallengeHandler>> * internalAuthenticationChallengeHandlers;
 
-#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
+#if TARGET_OS_IOS || TARGET_OS_TV
 @property (atomic) UIApplicationState lastApplicationState;
 #endif
 

--- a/Source/TNLGlobalConfiguration_Project.h
+++ b/Source/TNLGlobalConfiguration_Project.h
@@ -27,7 +27,7 @@ FOUNDATION_EXTERN const TNLBackgroundTaskIdentifier TNLBackgroundTaskInvalid;
 @property (atomic, nullable) id<TNLLogger> internalLogger;
 @property (atomic, copy, nullable, readonly) NSArray<id<TNLAuthenticationChallengeHandler>> * internalAuthenticationChallengeHandlers;
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
 @property (atomic) UIApplicationState lastApplicationState;
 #endif
 

--- a/Source/TNLParameterCollection.m
+++ b/Source/TNLParameterCollection.m
@@ -497,7 +497,7 @@ static void _addParametersUsingJSONEncoding(PRIVATE_SELF(TNLMutableParameterColl
 
     dictionary = TNLURLEncodableDictionary(dictionary, TNLURLEncodableDictionaryOptionReplaceArraysWithArraysOfEncodableStrings | TNLURLEncodableDictionaryOptionReplaceDictionariesWithDictionariesOfEncodableStrings);
     NSJSONWritingOptions options = 0;
-    if (@available(iOS 11.0, macos 10.13, watchos 4.0, tvos 11.0, *)) {
+    if (tnl_available_ios_11) {
         options = NSJSONWritingSortedKeys;
     }
     NSData *data = [NSJSONSerialization dataWithJSONObject:dictionary

--- a/Source/TNLPriority.h
+++ b/Source/TNLPriority.h
@@ -34,10 +34,9 @@ typedef NS_ENUM(NSInteger, TNLPriority) {
  A mapping from app features to priority values
  */
 typedef NS_ENUM(NSInteger, TNLFeaturePriority) {
-    TNLFeaturePriorityPolling = TNLPriorityVeryLow,
-    TNLFeaturePriorityPrefetching = TNLPriorityVeryLow,
-    TNLFeaturePriorityContentImage = TNLPriorityLow,
-    TNLFeaturePrioritySpecificImage = TNLPriorityNormal,
+    TNLFeaturePriorityPolling = TNLPriorityLow,
+    TNLFeaturePriorityPrefetching = TNLPriorityLow,
+    TNLFeaturePriorityContentImage = TNLPriorityNormal,
     TNLFeaturePriorityCurrentViewLoad = TNLPriorityHigh,
     TNLFeaturePriorityUserInitiated = TNLPriorityVeryHigh,
 };

--- a/Source/TNLRequestConfiguration.m
+++ b/Source/TNLRequestConfiguration.m
@@ -180,9 +180,11 @@ static const NSTimeInterval kConfigurationDeferrableIntervalDefault = 0.0;
 
 - (NSURLSessionMultipathServiceType)multipathServiceType
 {
-    if (tnl_available_multipath_service_type) {
-        return (NSURLSessionMultipathServiceType)_ivars.multipathServiceType;
+#if TARGET_OS_IOS
+    if (tnl_available_ios_11) {
+        return _ivars.multipathServiceType;
     }
+#endif
     return 0;
 }
 
@@ -220,9 +222,11 @@ static const NSTimeInterval kConfigurationDeferrableIntervalDefault = 0.0;
         _URLCache = config->_URLCache;
         _cookieStorage = config->_cookieStorage;
         _sharedContainerIdentifier = [config->_sharedContainerIdentifier copy];
-        if (tnl_available_multipath_service_type) {
+#if TARGET_OS_IOS
+        if (tnl_available_ios_11) {
             _ivars.multipathServiceType = NSURLSessionMultipathServiceTypeNone;
         }
+#endif
         _ivars.connectivityOptions = TNLRequestConnectivityOptionsDefault;
 
         memcpy(&_ivars, &(config->_ivars), sizeof(_ivars));
@@ -298,9 +302,11 @@ static const NSTimeInterval kConfigurationDeferrableIntervalDefault = 0.0;
     D_SET(isDiscretionary);
     D_SET(shouldLaunchAppForBackgroundEvents);
     D_SET(shouldSetCookies);
-    if (tnl_available_multipath_service_type) {
+#if TARGET_OS_IOS
+    if (tnl_available_ios_11) {
         D_SET(multipathServiceType);
     }
+#endif
 
 #undef D_SET
 #define D_SET(prop) \
@@ -538,9 +544,11 @@ PROP_RETAIN_ASSIGN_IMP(cookieStorage);
 
 - (void)setMultipathServiceType:(NSURLSessionMultipathServiceType)multipathServiceType
 {
-    if (tnl_available_multipath_service_type) {
+#if TARGET_OS_IOS
+    if (tnl_available_ios_11) {
         _ivars.multipathServiceType = multipathServiceType;
     }
+#endif
 }
 
 - (void)configureAsLowPriority
@@ -640,9 +648,11 @@ PROP_RETAIN_ASSIGN_IMP(cookieStorage);
 
     PULL_VALUE(TNLRequestConfigurationPropertyKeyShouldLaunchAppForBackgroundEvents, shouldLaunchAppForBackgroundEvents, boolValue, BOOL);
 
-    if (tnl_available_multipath_service_type) {
+#if TARGET_OS_IOS
+    if (tnl_available_ios_11) {
         PULL_VALUE(TNLRequestConfigurationPropertyKeyMultipathServiceType, multipathServiceType, integerValue, NSURLSessionMultipathServiceType);
     }
+#endif
 
     mConfig.sharedContainerIdentifier = params[TNLRequestConfigurationPropertyKeySharedContainerIdentifier];
 
@@ -735,12 +745,14 @@ TNLMutableParameterCollection * __nullable TNLMutableParametersFromRequestConfig
     params[TNLRequestConfigurationPropertyKeyIdleTimeout] = @(config.idleTimeout);
     params[TNLRequestConfigurationPropertyKeyAttemptTimeout] = @(config.attemptTimeout);
     params[TNLRequestConfigurationPropertyKeyShouldLaunchAppForBackgroundEvents] = @(config.shouldLaunchAppForBackgroundEvents);
-    if (tnl_available_multipath_service_type) {
+#if TARGET_OS_IOS
+    if (tnl_available_ios_11) {
         const NSURLSessionMultipathServiceType type = config.multipathServiceType;
         if (type != 0) {
             params[TNLRequestConfigurationPropertyKeyMultipathServiceType] = @(type);
         }
     }
+#endif
 
     // Other properties
 

--- a/Source/TNLRequestConfiguration.m
+++ b/Source/TNLRequestConfiguration.m
@@ -180,7 +180,7 @@ static const NSTimeInterval kConfigurationDeferrableIntervalDefault = 0.0;
 
 - (NSURLSessionMultipathServiceType)multipathServiceType
 {
-    if (@available(iOS 11, *)) {
+    if (tnl_available_multipath_service_type) {
         return (NSURLSessionMultipathServiceType)_ivars.multipathServiceType;
     }
     return 0;
@@ -219,10 +219,8 @@ static const NSTimeInterval kConfigurationDeferrableIntervalDefault = 0.0;
         _URLCredentialStorage = config->_URLCredentialStorage;
         _URLCache = config->_URLCache;
         _cookieStorage = config->_cookieStorage;
-        if ([NSURLSessionConfiguration tnl_supportsSharedContainerIdentifier]) {
-            _sharedContainerIdentifier = [config->_sharedContainerIdentifier copy];
-        }
-        if (@available(iOS 11, *)) {
+        _sharedContainerIdentifier = [config->_sharedContainerIdentifier copy];
+        if (tnl_available_multipath_service_type) {
             _ivars.multipathServiceType = NSURLSessionMultipathServiceTypeNone;
         }
         _ivars.connectivityOptions = TNLRequestConnectivityOptionsDefault;
@@ -300,7 +298,7 @@ static const NSTimeInterval kConfigurationDeferrableIntervalDefault = 0.0;
     D_SET(isDiscretionary);
     D_SET(shouldLaunchAppForBackgroundEvents);
     D_SET(shouldSetCookies);
-    if (@available(iOS 11, *)) {
+    if (tnl_available_multipath_service_type) {
         D_SET(multipathServiceType);
     }
 
@@ -521,9 +519,6 @@ PROP_COPY_IMP(additionalContentDecoders);
 
 - (void)setSharedContainerIdentifier:(nullable NSString *)sharedContainerIdentifier
 {
-    if (![NSURLSessionConfiguration tnl_supportsSharedContainerIdentifier]) {
-        return;
-    }
     PROP_COPY_IMP(sharedContainerIdentifier);
 }
 
@@ -543,7 +538,7 @@ PROP_RETAIN_ASSIGN_IMP(cookieStorage);
 
 - (void)setMultipathServiceType:(NSURLSessionMultipathServiceType)multipathServiceType
 {
-    if (@available(iOS 11, *)) {
+    if (tnl_available_multipath_service_type) {
         _ivars.multipathServiceType = multipathServiceType;
     }
 }
@@ -645,12 +640,11 @@ PROP_RETAIN_ASSIGN_IMP(cookieStorage);
 
     PULL_VALUE(TNLRequestConfigurationPropertyKeyShouldLaunchAppForBackgroundEvents, shouldLaunchAppForBackgroundEvents, boolValue, BOOL);
 
-    if (@available(iOS 11, *)) {
+    if (tnl_available_multipath_service_type) {
         PULL_VALUE(TNLRequestConfigurationPropertyKeyMultipathServiceType, multipathServiceType, integerValue, NSURLSessionMultipathServiceType);
     }
 
     mConfig.sharedContainerIdentifier = params[TNLRequestConfigurationPropertyKeySharedContainerIdentifier];
-    TNLAssert(!mConfig.sharedContainerIdentifier || [NSURLSessionConfiguration tnl_supportsSharedContainerIdentifier]);
 
     // These cannot loaded from the params so it's best to have them be nil.
     // Having them be the default shared objects could hide that this constructor
@@ -741,7 +735,7 @@ TNLMutableParameterCollection * __nullable TNLMutableParametersFromRequestConfig
     params[TNLRequestConfigurationPropertyKeyIdleTimeout] = @(config.idleTimeout);
     params[TNLRequestConfigurationPropertyKeyAttemptTimeout] = @(config.attemptTimeout);
     params[TNLRequestConfigurationPropertyKeyShouldLaunchAppForBackgroundEvents] = @(config.shouldLaunchAppForBackgroundEvents);
-    if (@available(iOS 11, *)) {
+    if (tnl_available_multipath_service_type) {
         const NSURLSessionMultipathServiceType type = config.multipathServiceType;
         if (type != 0) {
             params[TNLRequestConfigurationPropertyKeyMultipathServiceType] = @(type);
@@ -763,7 +757,6 @@ TNLMutableParameterCollection * __nullable TNLMutableParametersFromRequestConfig
 
     value = config.sharedContainerIdentifier;
     if (value) {
-        TNLAssert([NSURLSessionConfiguration tnl_supportsSharedContainerIdentifier]);
         params[TNLRequestConfigurationPropertyKeySharedContainerIdentifier] = value;
     }
 

--- a/Source/TNLRequestOperationQueue.h
+++ b/Source/TNLRequestOperationQueue.h
@@ -171,7 +171,7 @@ FOUNDATION_EXTERN NSString * const TNLBackgroundRequestURLSessionSharedContainer
 
 @end
 
-#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
+#if TARGET_OS_IPHONE // == IOS + WATCH + TV
 /**
  __TNLRequestOperationQueue (Background)__
 

--- a/Source/TNLRequestOperationQueue.h
+++ b/Source/TNLRequestOperationQueue.h
@@ -171,7 +171,7 @@ FOUNDATION_EXTERN NSString * const TNLBackgroundRequestURLSessionSharedContainer
 
 @end
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
 /**
  __TNLRequestOperationQueue (Background)__
 

--- a/Source/TNLRequestOperationQueue.m
+++ b/Source/TNLRequestOperationQueue.m
@@ -142,6 +142,9 @@ static void _GlobalApplyAutoDependenciesToOperation(TNLRequestOperation *op)
         sGlobalRequestOperationQueue = [[NSOperationQueue alloc] init];
         sGlobalRequestOperationQueue.name = @"com.TNL.global.request.operation.queue";
         sGlobalRequestOperationQueue.maxConcurrentOperationCount = NSOperationQueueDefaultMaxConcurrentOperationCount;
+        if ([sGlobalRequestOperationQueue respondsToSelector:@selector(setQualityOfService:)]) {
+            sGlobalRequestOperationQueue.qualityOfService = (NSQualityOfServiceUtility + NSQualityOfServiceUserInitiated / 2);
+        }
     });
 }
 
@@ -265,7 +268,7 @@ static void _GlobalApplyAutoDependenciesToOperation(TNLRequestOperation *op)
 
 #pragma mark Background Events
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
 + (BOOL)handleBackgroundURLSessionEvents:(nullable NSString *)identifier
                        completionHandler:(dispatch_block_t)completionHandler
 {

--- a/Source/TNLRequestOperationQueue.m
+++ b/Source/TNLRequestOperationQueue.m
@@ -268,7 +268,7 @@ static void _GlobalApplyAutoDependenciesToOperation(TNLRequestOperation *op)
 
 #pragma mark Background Events
 
-#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
+#if TARGET_OS_IPHONE // == IOS + WATCH + TV
 + (BOOL)handleBackgroundURLSessionEvents:(nullable NSString *)identifier
                        completionHandler:(dispatch_block_t)completionHandler
 {

--- a/Source/TNLRequestRetryPolicyConfiguration.h
+++ b/Source/TNLRequestRetryPolicyConfiguration.h
@@ -24,9 +24,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  A default configuration
- @return a configuration that permits retries on HTTP `GET` request that return `503`
+ @return a configuration that permits retries on HTTP `GET` requests that return `503`
  */
 + (instancetype)defaultConfiguration; // GET on 503
+
+/**
+ A standard configuration more advanced than the default configuration
+ @return a configuration that permits retries on HTTP `GET` requests that either return `503`, or
+ fail with a `NSURLErrorDomain` error from `TNLStandardRetriableURLErrorCodes()`, or
+ fail with a `NSPOSIXErrorDomain` error from `TNLStandardRetriablePOSIXErrorCodes()`
+ */
++ (instancetype)standardConfiguration; // GET w/ 503, TNLStandardRetriableURLErrorCodes() or TNLStandardRetriablePOSIXErrorCodes()
 
 /**
  Default initializer (designated)

--- a/Source/TNLRequestRetryPolicyConfiguration.m
+++ b/Source/TNLRequestRetryPolicyConfiguration.m
@@ -84,7 +84,18 @@ NS_INLINE NSUInteger _URLErrorCodeToIndex(NSInteger code)
 
 + (instancetype)defaultConfiguration
 {
-    return [[self alloc] initWithRetriableMethods:@[@"GET"] statusCodes:@[@503] URLErrorCodes:nil POSIXErrorCodes:nil];
+    return [[self alloc] initWithRetriableMethods:@[@"GET"]
+                                      statusCodes:@[@503]
+                                    URLErrorCodes:nil
+                                  POSIXErrorCodes:nil];
+}
+
++ (instancetype)standardConfiguration
+{
+    return [[self alloc] initWithRetriableMethods:@[@"GET"]
+                                      statusCodes:@[@503]
+                                    URLErrorCodes:TNLStandardRetriableURLErrorCodes()
+                                  POSIXErrorCodes:TNLStandardRetriablePOSIXErrorCodes()];
 }
 
 - (instancetype)initWithRetriableMethods:(nullable NSArray *)methods

--- a/Source/TNLRequestRetryPolicyProvider.h
+++ b/Source/TNLRequestRetryPolicyProvider.h
@@ -49,17 +49,19 @@ NS_ASSUME_NONNULL_BEGIN
                                              withResponse:(TNLResponse *)response;
 
 /**
- Callback for new idle timeout of next retry (optional)
+ Callback for new request configuration of next retry (optional)
 
- By default, `op.requestConfiguration.idleTimeout` will be used
+ By default, `op.requestConfiguration` will be used (aka _priorConfig_)
 
  @param op The `TNLRequestOperation` that will retry
  @param response the temporary `TNLResponse` composed for this retry query
- @return the new idle timeout of next retry.  The minimum value is `0.1` seconds, anything smaller
- will be treated as _never_.
+ @param priorConfig the `TNLRequestConfiguration` of the prior attempt
+ @return the new `TNLRequestConfiguration` of next retry.  `nil` will use _priorConfig_.
+ @note Recommend taking the _priorConfig_ and modifying a mutable copy.
  */
-- (NSTimeInterval)tnl_idleTimeoutOfRetryForRequestOperation:(TNLRequestOperation *)op
-                                               withResponse:(TNLResponse *)response;
+- (nullable TNLRequestConfiguration *)tnl_configurationOfRetryForRequestOperation:(TNLRequestOperation *)op
+                                                                     withResponse:(TNLResponse *)response
+                                                               priorConfiguration:(TNLRequestConfiguration *)priorConfig;
 
 /**
  The operation will retry

--- a/Source/TNLSafeOperation.m
+++ b/Source/TNLSafeOperation.m
@@ -6,6 +6,7 @@
 //  Copyright © 2017 Twitter. All rights reserved.
 //
 
+#import "TNL_Project.h"
 #import "TNLSafeOperation.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -15,21 +16,16 @@ static BOOL _NSOperationHasCompletionBlockBug(void)
     static BOOL sHasBug = NO;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        NSProcessInfo *processInfo = [NSProcessInfo processInfo];
-        if (![processInfo respondsToSelector:@selector(isOperatingSystemAtLeastVersion:)]) {
-            // Technically, on iOS 7 and lower, it's not a bug but rather by design...
-            // For our purposes though, we'll treat it as a bug so we can use our "safety" support
-            sHasBug = YES;
-            return;
-        }
-#if TARGET_OS_WATCH
-        // fixed watchOS 4
-        sHasBug = ![processInfo isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){ 4, 0 , 0}];
-#elif TARGET_OS_IOS || TARGET_OS_TV
-        // fixed iOS/tvOS 11
-        sHasBug = ![processInfo isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){ 11, 0 , 0}];
+#if TARGET_OS_OSX
+        // no bug on macOS
+        sHasBug = NO;
 #else
-        // macOS or newer OSes, no bug
+        // bug fixed iOS 11
+        if (tnl_available_ios_11) {
+            sHasBug = NO;
+        } else {
+            sHasBug = YES;
+        }
 #endif
     });
     return sHasBug;
@@ -58,7 +54,7 @@ static BOOL _NSOperationHasCompletionBlockBug(void)
 
 - (void)tnl_clearCompletionBlock
 {
-    [super setCompletionBlock:NULL];
+    [super setCompletionBlock:nil];
 }
 
 @end

--- a/Source/TNLTimeoutOperation.h
+++ b/Source/TNLTimeoutOperation.h
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Twitter. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import "TNLSafeOperation.h"
 
 /*
  * NOTE: this header is private to TNL
@@ -14,7 +14,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface TNLTimeoutOperation : NSOperation
+@interface TNLTimeoutOperation : TNLSafeOperation
 
 @property (nonatomic, readonly) NSTimeInterval timeoutDuration;
 

--- a/Source/TNLURLSessionManager.m
+++ b/Source/TNLURLSessionManager.m
@@ -228,7 +228,7 @@ static void _executeOnSynchronizeGCDQueueFromSynchronizeOperationQueue(dispatch_
 - (BOOL)handleBackgroundURLSessionEvents:(NSString *)identifier
                        completionHandler:(dispatch_block_t)completionHandler
 {
-#if !TARGET_OS_IPHONE
+#if !TARGET_OS_IPHONE // == !(IOS + WATCHOS + TVOS)
     return NO;
 #else
     if (!TNLURLSessionIdentifierIsTaggedForTNL(identifier)) {
@@ -254,7 +254,7 @@ static void _executeOnSynchronizeGCDQueueFromSynchronizeOperationQueue(dispatch_
     });
 
     return YES;
-#endif
+#endif // TARGET_OS_IPHONE
 }
 
 - (void)URLSessionDidCompleteBackgroundEvents:(NSURLSession *)session
@@ -498,17 +498,10 @@ static TNLURLSessionContext * __nullable _synchronize_getSessionContextWithQueue
     NSURLCredentialStorage *canonicalCredentialStorage = nil;
     NSHTTPCookieStorage *canonicalCookieStorage = nil;
 
-    if (@available(macOS 10.10, iOS 8, tvOS 9, watchOS 2, *)) {
-        // Modern OS versions can use demuxers for increased NSURLSession reuse
-        canonicalCache = TNLGetURLCacheDemuxProxy();
-        canonicalCredentialStorage = TNLGetURLCredentialStorageDemuxProxy();
-        canonicalCookieStorage = TNLGetHTTPCookieStorageDemuxProxy();
-    } else {
-        // Legacy OS versions cannot use a demuxer, so we will live with extra NSURLSessions
-        canonicalCache = TNLUnwrappedURLCache(requestConfiguration.URLCache);
-        canonicalCredentialStorage = TNLUnwrappedURLCredentialStorage(requestConfiguration.URLCredentialStorage);
-        canonicalCookieStorage = TNLUnwrappedCookieStorage(requestConfiguration.cookieStorage);
-    }
+    // use demuxers for increased NSURLSession reuse
+    canonicalCache = TNLGetURLCacheDemuxProxy();
+    canonicalCredentialStorage = TNLGetURLCredentialStorageDemuxProxy();
+    canonicalCookieStorage = TNLGetHTTPCookieStorageDemuxProxy();
 
     TNLMutableParameterCollection *params = TNLMutableParametersFromRequestConfiguration(requestConfiguration,
                                                                                          canonicalCache,
@@ -849,7 +842,7 @@ static void _synchronize_serviceUnavailableEncountered(PRIVATE_SELF(TNLURLSessio
         TNLURLSessionTaskOperation *op = [context operationForTask:task];
 
         if (op) {
-            if (@available(macos 10.13, ios 11.0, watchos 4.0, tvos 11.0, *)) {
+            if (tnl_available_ios_11) {
                 [op URLSession:session taskIsWaitingForConnectivity:task];
             }
         }
@@ -1214,9 +1207,7 @@ static volatile atomic_int_fast32_t sSessionContextCount = ATOMIC_VAR_INIT(0);
         _URLCredentialStorage = config.URLCredentialStorage;
         _URLCache = config.URLCache;
         _cookieStorage = config.HTTPCookieStorage;
-        if ([NSURLSessionConfiguration tnl_supportsSharedContainerIdentifier]) {
-            _sharedContainerIdentifier = [config.sharedContainerIdentifier copy];
-        }
+        _sharedContainerIdentifier = [config.sharedContainerIdentifier copy];
 
         _ivars.executionMode = TNLRequestExecutionModeDefault;
         _ivars.redirectPolicy = TNLRequestRedirectPolicyDefault;
@@ -1232,14 +1223,14 @@ static volatile atomic_int_fast32_t sSessionContextCount = ATOMIC_VAR_INIT(0);
         _ivars.networkServiceType = config.networkServiceType;
         _ivars.cookieAcceptPolicy = config.HTTPCookieAcceptPolicy;
         _ivars.allowsCellularAccess = (config.allowsCellularAccess != NO);
-        if (@available(macos 10.13, ios 11.0, watchos 4.0, tvos 11.0, *)) {
+        if (tnl_available_ios_11) {
             _ivars.connectivityOptions = (config.waitsForConnectivity != NO) ? TNLRequestConnectivityOptionWaitForConnectivity : TNLRequestConnectivityOptionsNone;
         } else {
             _ivars.connectivityOptions = TNLRequestConnectivityOptionsNone;
         }
         _ivars.discretionary = (config.isDiscretionary != NO);
         _ivars.shouldSetCookies = (config.HTTPShouldSetCookies != NO);
-#if TARGET_OS_IPHONE || TARGET_OS_WATCH || TARGET_OS_TV
+#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
         _ivars.shouldLaunchAppForBackgroundEvents = (config.sessionSendsLaunchEvents != NO);
 #endif
     }
@@ -1291,14 +1282,11 @@ static volatile atomic_int_fast32_t sSessionContextCount = ATOMIC_VAR_INIT(0);
 
     // Generate the config (based on execution mode)
     NSURLSessionConfiguration *config = (TNLRequestExecutionModeBackground == mode) ?
-                                            [NSURLSessionConfiguration tnl_backgroundSessionConfigurationWithIdentifier:identifier] :
+                                            [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:identifier] :
                                             [NSURLSessionConfiguration defaultSessionConfiguration];
 
     // Apply settings
     [self applySettingsToSessionConfiguration:config];
-
-    // Cement the config
-    [NSURLSessionConfiguration tnl_cementConfiguration:config];
 
     // Update the containers
 
@@ -1336,7 +1324,7 @@ static volatile atomic_int_fast32_t sSessionContextCount = ATOMIC_VAR_INIT(0);
 
     // TNL will control when to fail early if waiting for connectivity
 
-    if (@available(macos 10.13, ios 11.0, watchos 4.0, tvos 11.0, *)) {
+    if (tnl_available_ios_11) {
         config.waitsForConnectivity = YES;
     }
 
@@ -1359,17 +1347,16 @@ static volatile atomic_int_fast32_t sSessionContextCount = ATOMIC_VAR_INIT(0);
     if (requestConfig.executionMode == TNLRequestExecutionModeBackground) {
         _ConfigureSessionConfigurationWithRequestConfiguration(sessionConfig, requestConfig);
         TNLParameterCollection *params = TNLMutableParametersFromRequestConfiguration(requestConfig, nil, nil, nil);
-        sessionConfig = [NSURLSessionConfiguration tnl_backgroundSessionConfigurationWithIdentifier:params.stableURLEncodedStringValue];
+        sessionConfig = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:params.stableURLEncodedStringValue];
     }
     _ConfigureSessionConfigurationWithRequestConfiguration(sessionConfig, requestConfig);
-    [NSURLSessionConfiguration tnl_cementConfiguration:sessionConfig];
     return sessionConfig;
 }
 
 + (NSURLSessionConfiguration *)tnl_defaultSessionConfigurationWithNilPersistence
 {
     NSURLSessionConfiguration *config = [[NSURLSessionConfiguration defaultSessionConfiguration] copy];
-#if TARGET_OS_IPHONE || TARGET_OS_WATCH || TARGET_OS_TV
+#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
     config.sessionSendsLaunchEvents = YES;
 #endif
     config.URLCache = nil;
@@ -1480,10 +1467,10 @@ TNLMutableParameterCollection *TNLMutableParametersFromURLSessionConfiguration(N
     params[TNLSessionConfigurationPropertyKeyNetworkServiceType] = @(config.networkServiceType);
     params[TNLSessionConfigurationPropertyKeyAllowsCellularAccess] = @(config.allowsCellularAccess);
     params[TNLSessionConfigurationPropertyKeyDiscretionary] = @(config.isDiscretionary);
-    if (@available(macos 10.13, ios 11.0, watchos 4.0, tvos 11.0, *)) {
+    if (tnl_available_ios_11) {
         params[TNLSessionConfigurationPropertyKeyWaitsForConnectivity] = @(config.waitsForConnectivity);
     }
-#if TARGET_OS_IPHONE || TARGET_OS_WATCH || TARGET_OS_TV
+#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
     params[TNLSessionConfigurationPropertyKeySessionSendsLaunchEvents] = @(config.sessionSendsLaunchEvents);
 #endif
 
@@ -1533,11 +1520,9 @@ TNLMutableParameterCollection *TNLMutableParametersFromURLSessionConfiguration(N
         }
     }
 
-    if ([NSURLSessionConfiguration tnl_supportsSharedContainerIdentifier]) {
-        tempValue = config.sharedContainerIdentifier;
-        if (tempValue) {
-            params[TNLSessionConfigurationPropertyKeySharedContainerIdentifier] = tempValue;
-        }
+    tempValue = config.sharedContainerIdentifier;
+    if (tempValue) {
+        params[TNLSessionConfigurationPropertyKeySharedContainerIdentifier] = tempValue;
     }
 
     return params;
@@ -1616,7 +1601,7 @@ static void _ConfigureSessionConfigurationWithRequestConfiguration(NSURLSessionC
     sessionConfig.discretionary = requestConfig.isDiscretionary;
     sessionConfig.networkServiceType = requestConfig.networkServiceType;
     sessionConfig.requestCachePolicy = requestConfig.cachePolicy;
-    if (@available(macos 10.13, ios 11.0, watchos 4.0, tvos 11.0, *)) {
+    if (tnl_available_ios_11) {
         const TNLRequestConnectivityOptions connectivityOptions = requestConfig.connectivityOptions;
         if (TNL_BITMASK_INTERSECTS_FLAGS(connectivityOptions, TNLRequestConnectivityOptionWaitForConnectivity)) {
             sessionConfig.waitsForConnectivity = YES;
@@ -1626,15 +1611,13 @@ static void _ConfigureSessionConfigurationWithRequestConfiguration(NSURLSessionC
             sessionConfig.waitsForConnectivity = NO;
         }
     }
-#if TARGET_OS_IPHONE || TARGET_OS_WATCH || TARGET_OS_TV
+#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
     sessionConfig.sessionSendsLaunchEvents = requestConfig.shouldLaunchAppForBackgroundEvents;
 #endif
     sessionConfig.HTTPCookieAcceptPolicy = requestConfig.cookieAcceptPolicy;
     sessionConfig.HTTPShouldSetCookies = requestConfig.shouldSetCookies;
-    if ([NSURLSessionConfiguration tnl_supportsSharedContainerIdentifier]) {
-        sessionConfig.sharedContainerIdentifier = requestConfig.sharedContainerIdentifier;
-    }
-    if (@available(iOS 11, *)) {
+    sessionConfig.sharedContainerIdentifier = requestConfig.sharedContainerIdentifier;
+    if (tnl_available_multipath_service_type) {
         sessionConfig.multipathServiceType = requestConfig.multipathServiceType;
     }
 
@@ -1717,6 +1700,9 @@ static void _PrepareSessionManagement()
         sSynchronizeOperationQueue = [[NSOperationQueue alloc] init];
         sSynchronizeOperationQueue.name = @"TNLURLSessionManager.synchronize.operation.queue";
         sSynchronizeOperationQueue.maxConcurrentOperationCount = 1;
+        if ([sSynchronizeOperationQueue respondsToSelector:@selector(setQualityOfService:)]) {
+            sSynchronizeOperationQueue.qualityOfService = (NSQualityOfServiceUtility + NSQualityOfServiceUserInitiated / 2);
+        }
         if ([sSynchronizeOperationQueue respondsToSelector:@selector(setUnderlyingQueue:)]) {
             sSynchronizeOperationQueue.underlyingQueue = sSynchronizeQueue;
             sSynchronizeOperationQueueIsBackedBySynchronizeQueue = YES;
@@ -1724,6 +1710,9 @@ static void _PrepareSessionManagement()
         sURLSessionTaskOperationQueue = [[NSOperationQueue alloc] init];
         sURLSessionTaskOperationQueue.name = @"TNLURLSessionManager.task.operation.queue";
         sURLSessionTaskOperationQueue.maxConcurrentOperationCount = NSOperationQueueDefaultMaxConcurrentOperationCount;
+        if ([sURLSessionTaskOperationQueue respondsToSelector:@selector(setQualityOfService:)]) {
+            sURLSessionTaskOperationQueue.qualityOfService = (NSQualityOfServiceUtility + NSQualityOfServiceUserInitiated / 2);
+        }
 
         // State
 

--- a/Source/TNLURLSessionTaskOperation.m
+++ b/Source/TNLURLSessionTaskOperation.m
@@ -663,29 +663,21 @@ static void _handleTaskResponseObservation(SELF_ARG,
 {
     NSURLProtectionSpace *protectionSpace = challenge.protectionSpace;
     NSString *protectionSpaceHost = protectionSpace.host;
-    if (!protectionSpaceHost) {
-        return;
-    }
-
     NSURLRequest *currentRequest = self.currentURLRequest;
-    NSString *currentHost = currentRequest.URL.host;
-    if (!currentHost) {
-        return;
-    }
-
-    if (NSOrderedSame != [protectionSpaceHost caseInsensitiveCompare:currentHost]) { // TWITTER_STYLE_CASE_INSENSITIVE_COMPARE_NIL_PRECHECKED
-        // different host, unaffected
-        return;
-    }
-
     NSArray<NSString *> *certDescriptions = TNLSecTrustGetCertificateChainDescriptions(protectionSpace.serverTrust);
     NSString *authMethod = protectionSpace.authenticationMethod;
 
     tnl_dispatch_async_autoreleasing(tnl_network_queue(), ^{
         NSMutableDictionary *userInfo = [[NSMutableDictionary alloc] init];
-        userInfo[TNLErrorProtectionSpaceHostKey] = protectionSpaceHost;
-        userInfo[TNLErrorRequestKey] = currentRequest;
-        userInfo[TNLErrorAuthenticationChallengeMethodKey] = authMethod;
+        if (protectionSpaceHost) {
+            userInfo[TNLErrorProtectionSpaceHostKey] = protectionSpaceHost;
+        }
+        if (currentRequest) {
+            userInfo[TNLErrorRequestKey] = currentRequest;
+        }
+        if (authMethod) {
+            userInfo[TNLErrorAuthenticationChallengeMethodKey] = authMethod;
+        }
         if (certDescriptions) {
             userInfo[TNLErrorCertificateChainDescriptionsKey] = certDescriptions;
         }
@@ -1534,13 +1526,7 @@ static void _network_resumeSessionTask(SELF_ARG,
     // NSURLSessionTask's `resume` will capture the QOS of the calling queue for
     // reusing the same QOS for the execution of the task
 
-    long gcdIdentifier = DISPATCH_QUEUE_PRIORITY_DEFAULT;
-    if (@available(iOS 8, macOS 10.10, *)) {
-        gcdIdentifier = TNLConvertTNLPriorityToGCDQOS(self.requestPriority);
-    } else {
-        gcdIdentifier = TNLConvertTNLPriorityToGCDPriority(self.requestPriority);
-    }
-    dispatch_sync(dispatch_get_global_queue(gcdIdentifier, 0), ^{
+    dispatch_sync(dispatch_get_global_queue(TNLConvertTNLPriorityToGCDQOS(self.requestPriority), 0), ^{
         [task resume];
     });
 }
@@ -1553,10 +1539,7 @@ static void _network_didStartBackgroundTask(SELF_ARG)
 
     NSUInteger taskId = self.URLSessionTask.taskIdentifier;
     NSString *configId = self.URLSession.configuration.identifier;
-    NSString *sharedContainerIdentifier = nil;
-    if ([NSURLSessionConfiguration tnl_supportsSharedContainerIdentifier]) {
-        sharedContainerIdentifier = self->_URLSession.configuration.sharedContainerIdentifier;
-    }
+    NSString *sharedContainerIdentifier = self->_URLSession.configuration.sharedContainerIdentifier;
 
     [self->_requestOperation network_URLSessionTaskOperation:self
                     didStartBackgroundTaskWithTaskIdentifier:taskId
@@ -2149,10 +2132,7 @@ static void _network_transitionState(SELF_ARG,
         // Background Completion
 
         if (finishedDidChange && self->_executionMode == TNLRequestExecutionModeBackground && (self->_downloadTask != nil || self->_uploadTask != nil)) {
-            NSString *sharedContainerIdentifier = nil;
-            if ([NSURLSessionConfiguration tnl_supportsSharedContainerIdentifier]) {
-                sharedContainerIdentifier = self->_URLSession.configuration.sharedContainerIdentifier;
-            }
+            NSString *sharedContainerIdentifier = self->_URLSession.configuration.sharedContainerIdentifier;
             TNLAssert(self->_finalResponse);
             [self->_sessionManager URLSessionDidCompleteBackgroundTask:self.URLSessionTask.taskIdentifier
                                                sessionConfigIdentifier:self->_URLSession.configuration.identifier
@@ -2222,7 +2202,7 @@ static void _network_createTask(SELF_ARG,
         TNLRequestConfigurationAssociateWithRequest(self.requestConfiguration, task.originalRequest);
     }
 
-    TNLAssert((error == nil) ^ (task == nil));
+    TNLAssert((nil == error) ^ (nil == task));
     complete(task, error);
 }
 
@@ -2576,7 +2556,7 @@ static NSString *TNLSecCertificateDescription(SecCertificateRef cert)
 {
     NSString *serialNumber = nil;
     NSData *serialNumberData = nil;
-    if (@available(iOS 11.0, macOS 10.13.0, tvOS 11.0, watchOS 4.0, *)) {
+    if (tnl_available_ios_11) {
         serialNumberData = (NSData *)CFBridgingRelease(SecCertificateCopySerialNumberData(cert, NULL));
     } else {
         serialNumberData = (NSData *)CFBridgingRelease(SecCertificateCopySerialNumber(cert));

--- a/Source/TNLURLSessionTaskOperation.m
+++ b/Source/TNLURLSessionTaskOperation.m
@@ -2559,7 +2559,11 @@ static NSString *TNLSecCertificateDescription(SecCertificateRef cert)
     if (tnl_available_ios_11) {
         serialNumberData = (NSData *)CFBridgingRelease(SecCertificateCopySerialNumberData(cert, NULL));
     } else {
+#if TARGET_OS_OSX
+        serialNumberData = (NSData *)CFBridgingRelease(SecCertificateCopySerialNumber(cert, NULL));
+#else
         serialNumberData = (NSData *)CFBridgingRelease(SecCertificateCopySerialNumber(cert));
+#endif
     }
     if (serialNumberData) {
         serialNumber = [serialNumberData tnl_hexStringValue];

--- a/Source/TNL_Project.h
+++ b/Source/TNL_Project.h
@@ -55,6 +55,12 @@ do { \
 
 FOUNDATION_EXTERN NSString *TNLVersion(void);
 
+#if TARGET_OS_IOS
+#define tnl_available_multipath_service_type @available(iOS 11, *)
+#else
+#define tnl_available_multipath_service_type (NO)
+#endif
+
 #pragma mark - GCD Helpers
 
 #define MIN_TIMER_INTERVAL (0.1)
@@ -84,7 +90,7 @@ FOUNDATION_EXTERN dispatch_queue_t tnl_coding_queue(void);
 
 #pragma mark - Dynamic Linking
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
 
 NS_ASSUME_NONNULL_END
 #import <UIKit/UIApplication.h>
@@ -93,7 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
 FOUNDATION_EXTERN UIApplication * __nullable TNLDynamicUIApplicationSharedApplication(void);
 FOUNDATION_EXTERN Class __nullable TNLDynamicUIApplicationClass(void);
 
-#endif
+#endif // TARGET_OS_IPHONE
 
 #pragma mark - Logging
 

--- a/Source/TNL_Project.h
+++ b/Source/TNL_Project.h
@@ -55,12 +55,6 @@ do { \
 
 FOUNDATION_EXTERN NSString *TNLVersion(void);
 
-#if TARGET_OS_IOS
-#define tnl_available_multipath_service_type @available(iOS 11, *)
-#else
-#define tnl_available_multipath_service_type (NO)
-#endif
-
 #pragma mark - GCD Helpers
 
 #define MIN_TIMER_INTERVAL (0.1)
@@ -90,7 +84,7 @@ FOUNDATION_EXTERN dispatch_queue_t tnl_coding_queue(void);
 
 #pragma mark - Dynamic Linking
 
-#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
+#if TARGET_OS_IOS || TARGET_OS_TV
 
 NS_ASSUME_NONNULL_END
 #import <UIKit/UIApplication.h>
@@ -99,7 +93,7 @@ NS_ASSUME_NONNULL_BEGIN
 FOUNDATION_EXTERN UIApplication * __nullable TNLDynamicUIApplicationSharedApplication(void);
 FOUNDATION_EXTERN Class __nullable TNLDynamicUIApplicationClass(void);
 
-#endif // TARGET_OS_IPHONE
+#endif // TARGET_OS_IOS || TARGET_OS_TV
 
 #pragma mark - Logging
 
@@ -159,12 +153,16 @@ FOUNDATION_EXTERN void TNLDecrementObjectCount(Class class);
 #define TNLDecrementObjectCount(class) ((void)0)
 #endif
 
-#pragma mark - Error Functions
+#pragma mark - Error Helpers
 
 FOUNDATION_EXTERN NSError *TNLErrorCreateWithCode(TNLErrorCode code);
 FOUNDATION_EXTERN NSError *TNLErrorCreateWithCodeAndUnderlyingError(TNLErrorCode code,
                                                                     NSError * __nullable underlyingError);
 FOUNDATION_EXTERN NSError *TNLErrorCreateWithCodeAndUserInfo(TNLErrorCode code,
                                                              NSDictionary * __nullable userInfo);
+
+#if TARGET_OS_WATCH
+#define kCFErrorDomainCFNetwork @"kCFErrorDomainCFNetwork"
+#endif
 
 NS_ASSUME_NONNULL_END

--- a/Source/TNL_Project.m
+++ b/Source/TNL_Project.m
@@ -30,7 +30,7 @@ dispatch_source_t tnl_dispatch_timer_create_and_start(dispatch_queue_t queue,
 
 NSString *TNLVersion()
 {
-    return @"2.0";
+    return @"2.2";
 }
 
 #pragma mark - Threading
@@ -57,7 +57,7 @@ dispatch_queue_t tnl_coding_queue()
 
 #pragma mark - Dynamic Loading
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
 
 Class TNLDynamicUIApplicationClass()
 {
@@ -78,7 +78,7 @@ UIApplication *TNLDynamicUIApplicationSharedApplication()
     return UIApplicationClass ? [UIApplicationClass sharedApplication] : nil;
 }
 
-#endif
+#endif // TARGET_OS_IPHONE
 
 #pragma mark - Introspection
 

--- a/Source/TNL_Project.m
+++ b/Source/TNL_Project.m
@@ -57,7 +57,7 @@ dispatch_queue_t tnl_coding_queue()
 
 #pragma mark - Dynamic Loading
 
-#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
+#if TARGET_OS_IOS || TARGET_OS_TV
 
 Class TNLDynamicUIApplicationClass()
 {
@@ -78,7 +78,7 @@ UIApplication *TNLDynamicUIApplicationSharedApplication()
     return UIApplicationClass ? [UIApplicationClass sharedApplication] : nil;
 }
 
-#endif // TARGET_OS_IPHONE
+#endif // IOS + TV
 
 #pragma mark - Introspection
 

--- a/Source/TNL_ProjectCommon.h
+++ b/Source/TNL_ProjectCommon.h
@@ -20,6 +20,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 FOUNDATION_EXTERN BOOL TNLIsExtension(void);
 
+#pragma mark - Availability
+
+// macros helpers to match against specific iOS versions and their mapped non-iOS platform versions
+
+#define tnl_available_ios_9     @available(iOS 9, tvOS 9, macOS 10.11, watchOS 2, *)
+#define tnl_available_ios_10    @available(iOS 10, tvOS 10, macOS 10.12, watchOS 3, *)
+#define tnl_available_ios_11    @available(iOS 11, tvOS 11, macOS 10.13, watchOS 4, *)
+#define tnl_available_ios_12    @available(iOS 12, tvOS 12, macOS 10.14, watchOS 5, *)
+
 #pragma mark - Bitmask Helpers
 
 /** Does the `mask` have at least 1 of the bits in `flags` set */

--- a/Source/TNL_ProjectCommon.m
+++ b/Source/TNL_ProjectCommon.m
@@ -44,7 +44,7 @@ BOOL TNLAmIBeingUnitTested(void)
     static BOOL sAmIBeingUnitTested = NO;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        sAmIBeingUnitTested = (NSClassFromString(@"SenTest") != NULL || NSClassFromString(@"XCTest") != NULL);
+        sAmIBeingUnitTested = (NSClassFromString(@"SenTest") != Nil || NSClassFromString(@"XCTest") != Nil);
     });
     return sAmIBeingUnitTested;
 }

--- a/TNLExample/TNLXImageSupport.m
+++ b/TNLExample/TNLXImageSupport.m
@@ -359,7 +359,7 @@
 - (void)willMoveToWindow:(UIWindow *)newWindow
 {
     [super willMoveToWindow:newWindow];
-    _imageOp.priority = (newWindow != nil) ? TNLPriorityNormal : TNLPriorityVeryLow;
+    _imageOp.priority = (newWindow != nil) ? TNLPriorityNormal : TNLPriorityLow;
 }
 
 - (void)dealloc

--- a/TNLExample/TNLXLotsOfRequestsViewController.m
+++ b/TNLExample/TNLXLotsOfRequestsViewController.m
@@ -163,7 +163,7 @@ static const BOOL kUseThumbnail = NO;
     TNLRequestOperation *op = [TNLRequestOperation operationWithRequest:urlReq
                                                           configuration:_imageConfig
                                                                delegate:self];
-    op.priority = TNLPriorityVeryLow;
+    op.priority = TNLPriorityLow;
     [[TNLRequestOperationQueue defaultOperationQueue] enqueueRequestOperation:op];
     [_operations addObject:op];
     [self _update];

--- a/TNLExample/TNLXPlaygroundViewController.m
+++ b/TNLExample/TNLXPlaygroundViewController.m
@@ -118,6 +118,9 @@ typedef NS_ENUM(NSInteger, TNLXRedirectTestPolicy)
     NSFileManager *fm = [NSFileManager defaultManager];
     [fm createDirectoryAtPath:[_fileDestination stringByDeletingLastPathComponent] withIntermediateDirectories:YES attributes:nil error:NULL];
     _queue = [[TNLRequestOperationQueue alloc] initWithIdentifier:NSStringFromClass([self class]).lowercaseString];
+    if ([_queue respondsToSelector:@selector(setQualityOfService:)]) {
+        _queue.qualityOfService = NSQualityOfServiceUtility;
+    }
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(backgroundRequestDidDownloadNotification:) name:TNLBackgroundRequestOperationDidCompleteNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];

--- a/TwitterNetworkLayer.xcodeproj/project.pbxproj
+++ b/TwitterNetworkLayer.xcodeproj/project.pbxproj
@@ -361,7 +361,6 @@
 		8BFDF93B2135AB2C002F6A80 /* libxml2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BE3DB9B1CDB009F0081ACCE /* libxml2.tbd */; };
 		8BFDF93C2135AB2C002F6A80 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BE3DB991CDB008C0081ACCE /* libz.tbd */; };
 		8BFDF93D2135AB2C002F6A80 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B6DCB4B1974598300235576 /* CFNetwork.framework */; };
-		8BFDF93E2135AB2C002F6A80 /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B4AA75D1E1F28DF00BF7EA0 /* CoreTelephony.framework */; };
 		8BFDF93F2135AB2C002F6A80 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BE402C91946743D00C7241E /* Foundation.framework */; };
 		8BFDF9402135AB2C002F6A80 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B427D541FB53DBF00C9E5CE /* Security.framework */; };
 		8BFDF9412135AB2C002F6A80 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B4DEFF81986AA64008A31EB /* SystemConfiguration.framework */; };
@@ -986,7 +985,6 @@
 				8BFDF93B2135AB2C002F6A80 /* libxml2.tbd in Frameworks */,
 				8BFDF93C2135AB2C002F6A80 /* libz.tbd in Frameworks */,
 				8BFDF93D2135AB2C002F6A80 /* CFNetwork.framework in Frameworks */,
-				8BFDF93E2135AB2C002F6A80 /* CoreTelephony.framework in Frameworks */,
 				8BFDF93F2135AB2C002F6A80 /* Foundation.framework in Frameworks */,
 				8BFDF9402135AB2C002F6A80 /* Security.framework in Frameworks */,
 				8BFDF9412135AB2C002F6A80 /* SystemConfiguration.framework in Frameworks */,
@@ -1815,7 +1813,6 @@
 						ProvisioningStyle = Manual;
 					};
 					8BE402C51946743D00C7241E = {
-						DevelopmentTeamName = Twitter;
 						ProvisioningStyle = Manual;
 					};
 					8BE402D51946743E00C7241E = {

--- a/TwitterNetworkLayer.xcodeproj/project.pbxproj
+++ b/TwitterNetworkLayer.xcodeproj/project.pbxproj
@@ -24,8 +24,6 @@
 		8B0DDD2519C7456A004BEE4B /* TNLNetwork.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B0DDD2319C7456A004BEE4B /* TNLNetwork.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8B0DDD2619C7456A004BEE4B /* TNLNetwork.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B0DDD2419C7456A004BEE4B /* TNLNetwork.m */; };
 		8B0E0C4D1DE69C5700283B45 /* BingResults.json.base64 in Resources */ = {isa = PBXBuildFile; fileRef = 8B0E0C4C1DE69C5700283B45 /* BingResults.json.base64 */; };
-		8B109D6D20B63F16000D10AA /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 8B109D6B20B63F15000D10AA /* README.md */; };
-		8B109D6E20B63F16000D10AA /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = 8B109D6C20B63F16000D10AA /* CHANGELOG.md */; };
 		8B13EB9F19C9F7580098E349 /* TNLResponse_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B13EB9D19C9F7580098E349 /* TNLResponse_Project.h */; };
 		8B153162207D1DA400A1288F /* TNLAuthenticationChallengeHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B153161207D1DA400A1288F /* TNLAuthenticationChallengeHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8B153163207D1DA400A1288F /* TNLAuthenticationChallengeHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B153161207D1DA400A1288F /* TNLAuthenticationChallengeHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -111,6 +109,125 @@
 		8B959C291BAB6BA3007858C0 /* NSNumber+TNLURLCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B959C261BAB6BA3007858C0 /* NSNumber+TNLURLCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8B959C2B1BAB6BA3007858C0 /* NSNumber+TNLURLCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B959C271BAB6BA3007858C0 /* NSNumber+TNLURLCoding.m */; };
 		8B986C651BE3EF1D0053BB14 /* TNLHTTPTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B986C641BE3EF1D0053BB14 /* TNLHTTPTests.m */; };
+		8B9EBDB72135B4B100E6E466 /* NSURLResponse+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B3586A91A1551DB00E82D51 /* NSURLResponse+TNLAdditions.m */; };
+		8B9EBDB82135B4B100E6E466 /* TNLRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE403021946794300C7241E /* TNLRequestOperation.m */; };
+		8B9EBDB92135B4B100E6E466 /* TNLAttemptMetaData.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B3DB55A1A699C8D00FFF836 /* TNLAttemptMetaData.m */; };
+		8B9EBDBA2135B4B100E6E466 /* NSURLRequest+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE857651DD396B100F79F3D /* NSURLRequest+TNLAdditions.m */; };
+		8B9EBDBB2135B4B100E6E466 /* NSURLSessionTaskMetrics+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B4EC7F71D46DD6500DDEAF3 /* NSURLSessionTaskMetrics+TNLAdditions.m */; };
+		8B9EBDBC2135B4B100E6E466 /* TNLURLCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B4DEFFB1986AE55008A31EB /* TNLURLCoding.m */; };
+		8B9EBDBD2135B4B100E6E466 /* NSURLSessionConfiguration+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BFDF957199ADF4300248C3D /* NSURLSessionConfiguration+TNLAdditions.m */; };
+		8B9EBDBE2135B4B100E6E466 /* TNLHTTPRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE30EED1AA266EC0061FE99 /* TNLHTTPRequest.m */; };
+		8B9EBDBF2135B4B100E6E466 /* TNLTiming.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B5141221CE530E000830987 /* TNLTiming.m */; };
+		8B9EBDC02135B4B100E6E466 /* TNLURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BAFBF0F1BDABAB500F36EFF /* TNLURLSessionManager.m */; };
+		8B9EBDC12135B4B100E6E466 /* TNLNetwork.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B0DDD2419C7456A004BEE4B /* TNLNetwork.m */; };
+		8B9EBDC22135B4B100E6E466 /* TNLRequestConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B79ACD61975E4BD00FA8D1E /* TNLRequestConfiguration.m */; };
+		8B9EBDC32135B4B100E6E466 /* NSData+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BB1190E1D83537C00E75CD9 /* NSData+TNLAdditions.m */; };
+		8B9EBDC42135B4B100E6E466 /* TNLGlobalConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BB0E39A1A1FA861008CF992 /* TNLGlobalConfiguration.m */; };
+		8B9EBDC52135B4B100E6E466 /* TNLRequestRetryPolicyConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE403091946794300C7241E /* TNLRequestRetryPolicyConfiguration.m */; };
+		8B9EBDC62135B4B100E6E466 /* TNLResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE403071946794300C7241E /* TNLResponse.m */; };
+		8B9EBDC72135B4B100E6E466 /* TNLURLStringCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD500E61D8765F200D828C7 /* TNLURLStringCoding.m */; };
+		8B9EBDC82135B4B100E6E466 /* TNLSimpleRequestDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B397AE91A252E4900D2CB54 /* TNLSimpleRequestDelegate.m */; };
+		8B9EBDC92135B4B100E6E466 /* TNLSafeOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B1EE88C1EE0D0E0007B2D76 /* TNLSafeOperation.m */; };
+		8B9EBDCA2135B4B100E6E466 /* TNLURLSessionTaskOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B82A5AA1948D63100A16237 /* TNLURLSessionTaskOperation.m */; };
+		8B9EBDCB2135B4B100E6E466 /* NSDictionary+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B022A8219AAD2F800DB3052 /* NSDictionary+TNLAdditions.m */; };
+		8B9EBDCC2135B4B100E6E466 /* NSCachedURLResponse+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B277E481C022B5C00279EA9 /* NSCachedURLResponse+TNLAdditions.m */; };
+		8B9EBDCD2135B4B100E6E466 /* TNLLRUCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BDC0E3A1BDFE15C0077F8FC /* TNLLRUCache.m */; };
+		8B9EBDCE2135B4B100E6E466 /* TNLParameterCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B4E017019FB0632004D3CED /* TNLParameterCollection.m */; };
+		8B9EBDCF2135B4B100E6E466 /* TNLPseudoURLProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B0AFAA71A018EBE00C8C81F /* TNLPseudoURLProtocol.m */; };
+		8B9EBDD02135B4B100E6E466 /* TNL_ProjectCommon.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD500F41D87762200D828C7 /* TNL_ProjectCommon.m */; };
+		8B9EBDD12135B4B100E6E466 /* TNLPriority.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BDA9D321978822300678D90 /* TNLPriority.m */; };
+		8B9EBDD22135B4B100E6E466 /* TNLRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE403041946794300C7241E /* TNLRequest.m */; };
+		8B9EBDD32135B4B100E6E466 /* NSURL+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B87BA3E1E09DA20005A8926 /* NSURL+TNLAdditions.m */; };
+		8B9EBDD42135B4B100E6E466 /* NSNumber+TNLURLCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B959C271BAB6BA3007858C0 /* NSNumber+TNLURLCoding.m */; };
+		8B9EBDD52135B4B100E6E466 /* NSOperationQueue+TNLSafety.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE68CFE1B7E421100A0F853 /* NSOperationQueue+TNLSafety.m */; };
+		8B9EBDD62135B4B100E6E466 /* TNLAttemptMetrics.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BF953DC1A67DD3F00E9C1AA /* TNLAttemptMetrics.m */; };
+		8B9EBDD72135B4B100E6E466 /* TNLCommunicationAgent.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B00D5AA1CFF512100D1728D /* TNLCommunicationAgent.m */; };
+		8B9EBDD82135B4B100E6E466 /* TNLTemporaryFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B9038DB19799D4A001A3DDD /* TNLTemporaryFile.m */; };
+		8B9EBDD92135B4B100E6E466 /* TNLRequestOperationQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE4030E1946794300C7241E /* TNLRequestOperationQueue.m */; };
+		8B9EBDDA2135B4B100E6E466 /* TNLHTTP.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE4032419467A1400C7241E /* TNLHTTP.m */; };
+		8B9EBDDB2135B4B100E6E466 /* TNLError.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BDA9D2C197881DE00678D90 /* TNLError.m */; };
+		8B9EBDDC2135B4B100E6E466 /* NSURLCache+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B8434841A13B77700D006DA /* NSURLCache+TNLAdditions.m */; };
+		8B9EBDDD2135B4B100E6E466 /* NSURLCredentialStorage+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BA336D91A3271A0005D7B35 /* NSURLCredentialStorage+TNLAdditions.m */; };
+		8B9EBDDE2135B4B100E6E466 /* TNL_Project.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B07EE681987E7DD00F9EF8E /* TNL_Project.m */; };
+		8B9EBDDF2135B4B100E6E466 /* NSHTTPCookieStorage+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B23BA3C1A89B69A0027EB80 /* NSHTTPCookieStorage+TNLAdditions.m */; };
+		8B9EBDE02135B4B100E6E466 /* TNLBackgroundURLSessionTaskOperationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B2924BC1992E42900AC139A /* TNLBackgroundURLSessionTaskOperationManager.m */; };
+		8B9EBDE12135B4B100E6E466 /* TNLTimeoutOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD083C81FD9C2020090B7C3 /* TNLTimeoutOperation.m */; };
+		8B9EBDE22135B4B100E6E466 /* TNLRequestOperationCancelSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BCAF8C419F716370043EB22 /* TNLRequestOperationCancelSource.m */; };
+		8B9EBDE42135B4B100E6E466 /* libxml2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BE3DB9B1CDB009F0081ACCE /* libxml2.tbd */; };
+		8B9EBDE52135B4B100E6E466 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BE3DB991CDB008C0081ACCE /* libz.tbd */; };
+		8B9EBDE62135B4B100E6E466 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B6DCB4B1974598300235576 /* CFNetwork.framework */; };
+		8B9EBDE82135B4B100E6E466 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BE402C91946743D00C7241E /* Foundation.framework */; };
+		8B9EBDE92135B4B100E6E466 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B427D541FB53DBF00C9E5CE /* Security.framework */; };
+		8B9EBDEB2135B4B100E6E466 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B6DCB491974583B00235576 /* UIKit.framework */; };
+		8B9EBDEE2135B4B100E6E466 /* TNLRequestConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B79ACD51975E4BD00FA8D1E /* TNLRequestConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBDEF2135B4B100E6E466 /* TNLInternalKeys.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B5849E320D4454500FA8C84 /* TNLInternalKeys.h */; };
+		8B9EBDF02135B4B100E6E466 /* TNLParameterCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B4E016F19FB0632004D3CED /* TNLParameterCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBDF12135B4B100E6E466 /* TNLRequest+Utilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE30EF21AA270750061FE99 /* TNLRequest+Utilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBDF22135B4B100E6E466 /* TNLResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE403061946794300C7241E /* TNLResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBDF32135B4B100E6E466 /* TNLAttemptMetaData.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B3DB5591A699C8D00FFF836 /* TNLAttemptMetaData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBDF42135B4B100E6E466 /* NSURLCredentialStorage+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BA336D81A3271A0005D7B35 /* NSURLCredentialStorage+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBDF52135B4B100E6E466 /* TNLRequestDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BB8B87B1A1E710E0093AE63 /* TNLRequestDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBDF62135B4B100E6E466 /* TNLTemporaryFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B9038DA19799D4A001A3DDD /* TNLTemporaryFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBDF72135B4B100E6E466 /* TNLSimpleRequestDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B397AE81A252E4900D2CB54 /* TNLSimpleRequestDelegate.h */; };
+		8B9EBDF82135B4B100E6E466 /* TNLRequestRetryPolicyConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE403081946794300C7241E /* TNLRequestRetryPolicyConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBDF92135B4B100E6E466 /* TNLRequestOperation_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE403001946794300C7241E /* TNLRequestOperation_Project.h */; };
+		8B9EBDFA2135B4B100E6E466 /* TNLURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BAFBF0E1BDABAB500F36EFF /* TNLURLSessionManager.h */; };
+		8B9EBDFB2135B4B100E6E466 /* TNLBackgroundURLSessionTaskOperationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B2924BB1992E42900AC139A /* TNLBackgroundURLSessionTaskOperationManager.h */; };
+		8B9EBDFC2135B4B100E6E466 /* TNLHostSanitizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BB0E3A51A1FCFB6008CF992 /* TNLHostSanitizer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBDFD2135B4B100E6E466 /* module.modulemap in Headers */ = {isa = PBXBuildFile; fileRef = B3B9E9FE1C3AEDE700B8A451 /* module.modulemap */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBDFE2135B4B100E6E466 /* NSURLSessionConfiguration+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BFDF956199ADF4300248C3D /* NSURLSessionConfiguration+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBDFF2135B4B100E6E466 /* TNLRequestHydrater.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B2DF7D0199D7F2600A064B3 /* TNLRequestHydrater.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE002135B4B100E6E466 /* TNLHTTP.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE4032319467A1400C7241E /* TNLHTTP.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE012135B4B100E6E466 /* TNLGlobalConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BB0E3991A1FA861008CF992 /* TNLGlobalConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE022135B4B100E6E466 /* TNLRequestOperationQueue_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE4030C1946794300C7241E /* TNLRequestOperationQueue_Project.h */; };
+		8B9EBE032135B4B100E6E466 /* NSURLSessionTaskMetrics+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B4EC7F61D46DD6500DDEAF3 /* NSURLSessionTaskMetrics+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE042135B4B100E6E466 /* TNLSafeOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B1EE88B1EE0D0E0007B2D76 /* TNLSafeOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE052135B4B100E6E466 /* TNLRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE403011946794300C7241E /* TNLRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE062135B4B100E6E466 /* NSHTTPCookieStorage+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B23BA3B1A89B69A0027EB80 /* NSHTTPCookieStorage+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE072135B4B100E6E466 /* TNLContentCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B6E34241DE0B755004A35C7 /* TNLContentCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE082135B4B100E6E466 /* TNLRequestAuthorizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B2DF7D6199D7F9F00A064B3 /* TNLRequestAuthorizer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE092135B4B100E6E466 /* TNLRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE403031946794300C7241E /* TNLRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE0A2135B4B100E6E466 /* TNL_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE402FB1946794300C7241E /* TNL_Project.h */; };
+		8B9EBE0B2135B4B100E6E466 /* TNL_ProjectCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BD500F31D87762200D828C7 /* TNL_ProjectCommon.h */; };
+		8B9EBE0C2135B4B100E6E466 /* TNLNetworkObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B82A5A61948D3E900A16237 /* TNLNetworkObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE0D2135B4B100E6E466 /* TNLTiming.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B5141211CE530E000830987 /* TNLTiming.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE0E2135B4B100E6E466 /* TNLRequestOperationCancelSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BCAF8C319F716370043EB22 /* TNLRequestOperationCancelSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE0F2135B4B100E6E466 /* TNLError.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BDA9D2B197881DE00678D90 /* TNLError.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE102135B4B100E6E466 /* TNLAttemptMetrics_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BF953E11A67E73E00E9C1AA /* TNLAttemptMetrics_Project.h */; };
+		8B9EBE112135B4B100E6E466 /* TNLCommunicationAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B00D5A91CFF512100D1728D /* TNLCommunicationAgent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE122135B4B100E6E466 /* NSDictionary+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B022A8119AAD2F800DB3052 /* NSDictionary+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE132135B4B100E6E466 /* TNLAttemptMetrics.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BF953DB1A67DD3F00E9C1AA /* TNLAttemptMetrics.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE142135B4B100E6E466 /* TNLPriority.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BDA9D311978822300678D90 /* TNLPriority.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE152135B4B100E6E466 /* NSURLRequest+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE857641DD396B100F79F3D /* NSURLRequest+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE162135B4B100E6E466 /* NSOperationQueue+TNLSafety.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE68CFD1B7E421100A0F853 /* NSOperationQueue+TNLSafety.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE172135B4B100E6E466 /* NSCachedURLResponse+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B277E471C022B5C00279EA9 /* NSCachedURLResponse+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE182135B4B100E6E466 /* NSData+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BB1190D1D83537C00E75CD9 /* NSData+TNLAdditions.h */; };
+		8B9EBE192135B4B100E6E466 /* TNLURLSessionTaskOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B82A5A91948D63100A16237 /* TNLURLSessionTaskOperation.h */; };
+		8B9EBE1A2135B4B100E6E466 /* NSURLCache+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B8434831A13B77700D006DA /* NSURLCache+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE1B2135B4B100E6E466 /* TNLHTTPHeaderProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BEE98C11ADC5E3100A58A92 /* TNLHTTPHeaderProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE1C2135B4B100E6E466 /* NSURLResponse+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B3586A81A1551DB00E82D51 /* NSURLResponse+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE1D2135B4B100E6E466 /* TNLURLCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B4DEFFA1986AE55008A31EB /* TNLURLCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE1E2135B4B100E6E466 /* TNLPseudoURLProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B0AFAA61A018EBE00C8C81F /* TNLPseudoURLProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE1F2135B4B100E6E466 /* TNLLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B322FEE1CA321AB00733D7A /* TNLLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE202135B4B100E6E466 /* TNLTimeoutOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BD083C71FD9C2020090B7C3 /* TNLTimeoutOperation.h */; };
+		8B9EBE212135B4B100E6E466 /* TwitterNetworkLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BA2970D1946CF8800BD7E91 /* TwitterNetworkLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE222135B4B100E6E466 /* TNLRequestEventHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B2DF7DA199D7FF700A064B3 /* TNLRequestEventHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE232135B4B100E6E466 /* TNLHTTPRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE30EEC1AA266EC0061FE99 /* TNLHTTPRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE242135B4B100E6E466 /* NSNumber+TNLURLCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B959C261BAB6BA3007858C0 /* NSNumber+TNLURLCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE252135B4B100E6E466 /* TNLGlobalConfiguration_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B86BF381A2D0998005AE96B /* TNLGlobalConfiguration_Project.h */; };
+		8B9EBE262135B4B100E6E466 /* TNLTemporaryFile_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B9038E119799D7C001A3DDD /* TNLTemporaryFile_Project.h */; };
+		8B9EBE272135B4B100E6E466 /* TNLRequestOperationQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE4030D1946794300C7241E /* TNLRequestOperationQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE282135B4B100E6E466 /* TNLRequestOperationState.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BCA626319C356AE00F3F8CA /* TNLRequestOperationState.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE292135B4B100E6E466 /* TNLRequestRedirecter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BED1FBF1A89480C00279141 /* TNLRequestRedirecter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE2A2135B4B100E6E466 /* TNLCommunicationAgent_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B5DBBFD206D8F9C007EF65B /* TNLCommunicationAgent_Project.h */; };
+		8B9EBE2B2135B4B100E6E466 /* TNLNetwork.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B0DDD2319C7456A004BEE4B /* TNLNetwork.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE2C2135B4B100E6E466 /* TNLResponse_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B13EB9D19C9F7580098E349 /* TNLResponse_Project.h */; };
+		8B9EBE2D2135B4B100E6E466 /* TNLLRUCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BDC0E391BDFE15C0077F8FC /* TNLLRUCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE2E2135B4B100E6E466 /* TNLAuthenticationChallengeHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B153161207D1DA400A1288F /* TNLAuthenticationChallengeHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE2F2135B4B100E6E466 /* TNLRequestConfiguration_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B6CB1A5199BE234009A09CE /* TNLRequestConfiguration_Project.h */; };
+		8B9EBE302135B4B100E6E466 /* NSURL+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B87BA3D1E09DA20005A8926 /* NSURL+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B9EBE312135B4B100E6E466 /* TNLAttemptMetaData_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CA2A7AA1B01BC3B00553B16 /* TNLAttemptMetaData_Project.h */; };
+		8B9EBE322135B4B100E6E466 /* TNLRequestRetryPolicyProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE4030A1946794300C7241E /* TNLRequestRetryPolicyProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8BA2970F1946CF8800BD7E91 /* TwitterNetworkLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BA2970D1946CF8800BD7E91 /* TwitterNetworkLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8BA336DB1A3271A0005D7B35 /* NSURLCredentialStorage+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BA336D81A3271A0005D7B35 /* NSURLCredentialStorage+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8BA336DD1A3271A0005D7B35 /* NSURLCredentialStorage+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BA336D91A3271A0005D7B35 /* NSURLCredentialStorage+TNLAdditions.m */; };
@@ -195,8 +312,166 @@
 		8BF953DE1A67DD3F00E9C1AA /* TNLAttemptMetrics.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BF953DB1A67DD3F00E9C1AA /* TNLAttemptMetrics.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8BF953E01A67DD3F00E9C1AA /* TNLAttemptMetrics.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BF953DC1A67DD3F00E9C1AA /* TNLAttemptMetrics.m */; };
 		8BF953E31A67E73E00E9C1AA /* TNLAttemptMetrics_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BF953E11A67E73E00E9C1AA /* TNLAttemptMetrics_Project.h */; };
+		8BFDF8FD2135A1FC002F6A80 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BFDF8FC2135A1FC002F6A80 /* Security.framework */; };
+		8BFDF8FE2135A215002F6A80 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BFDF8FC2135A1FC002F6A80 /* Security.framework */; };
+		8BFDF90E2135AB2C002F6A80 /* NSURLResponse+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B3586A91A1551DB00E82D51 /* NSURLResponse+TNLAdditions.m */; };
+		8BFDF90F2135AB2C002F6A80 /* TNLRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE403021946794300C7241E /* TNLRequestOperation.m */; };
+		8BFDF9102135AB2C002F6A80 /* TNLAttemptMetaData.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B3DB55A1A699C8D00FFF836 /* TNLAttemptMetaData.m */; };
+		8BFDF9112135AB2C002F6A80 /* NSURLRequest+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE857651DD396B100F79F3D /* NSURLRequest+TNLAdditions.m */; };
+		8BFDF9122135AB2C002F6A80 /* NSURLSessionTaskMetrics+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B4EC7F71D46DD6500DDEAF3 /* NSURLSessionTaskMetrics+TNLAdditions.m */; };
+		8BFDF9132135AB2C002F6A80 /* TNLURLCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B4DEFFB1986AE55008A31EB /* TNLURLCoding.m */; };
+		8BFDF9142135AB2C002F6A80 /* NSURLSessionConfiguration+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BFDF957199ADF4300248C3D /* NSURLSessionConfiguration+TNLAdditions.m */; };
+		8BFDF9152135AB2C002F6A80 /* TNLHTTPRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE30EED1AA266EC0061FE99 /* TNLHTTPRequest.m */; };
+		8BFDF9162135AB2C002F6A80 /* TNLTiming.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B5141221CE530E000830987 /* TNLTiming.m */; };
+		8BFDF9172135AB2C002F6A80 /* TNLURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BAFBF0F1BDABAB500F36EFF /* TNLURLSessionManager.m */; };
+		8BFDF9182135AB2C002F6A80 /* TNLNetwork.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B0DDD2419C7456A004BEE4B /* TNLNetwork.m */; };
+		8BFDF9192135AB2C002F6A80 /* TNLRequestConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B79ACD61975E4BD00FA8D1E /* TNLRequestConfiguration.m */; };
+		8BFDF91A2135AB2C002F6A80 /* NSData+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BB1190E1D83537C00E75CD9 /* NSData+TNLAdditions.m */; };
+		8BFDF91B2135AB2C002F6A80 /* TNLGlobalConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BB0E39A1A1FA861008CF992 /* TNLGlobalConfiguration.m */; };
+		8BFDF91C2135AB2C002F6A80 /* TNLRequestRetryPolicyConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE403091946794300C7241E /* TNLRequestRetryPolicyConfiguration.m */; };
+		8BFDF91D2135AB2C002F6A80 /* TNLResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE403071946794300C7241E /* TNLResponse.m */; };
+		8BFDF91E2135AB2C002F6A80 /* TNLURLStringCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD500E61D8765F200D828C7 /* TNLURLStringCoding.m */; };
+		8BFDF91F2135AB2C002F6A80 /* TNLSimpleRequestDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B397AE91A252E4900D2CB54 /* TNLSimpleRequestDelegate.m */; };
+		8BFDF9202135AB2C002F6A80 /* TNLSafeOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B1EE88C1EE0D0E0007B2D76 /* TNLSafeOperation.m */; };
+		8BFDF9212135AB2C002F6A80 /* TNLURLSessionTaskOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B82A5AA1948D63100A16237 /* TNLURLSessionTaskOperation.m */; };
+		8BFDF9222135AB2C002F6A80 /* NSDictionary+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B022A8219AAD2F800DB3052 /* NSDictionary+TNLAdditions.m */; };
+		8BFDF9232135AB2C002F6A80 /* NSCachedURLResponse+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B277E481C022B5C00279EA9 /* NSCachedURLResponse+TNLAdditions.m */; };
+		8BFDF9242135AB2C002F6A80 /* TNLLRUCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BDC0E3A1BDFE15C0077F8FC /* TNLLRUCache.m */; };
+		8BFDF9252135AB2C002F6A80 /* TNLParameterCollection.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B4E017019FB0632004D3CED /* TNLParameterCollection.m */; };
+		8BFDF9262135AB2C002F6A80 /* TNLPseudoURLProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B0AFAA71A018EBE00C8C81F /* TNLPseudoURLProtocol.m */; };
+		8BFDF9272135AB2C002F6A80 /* TNL_ProjectCommon.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD500F41D87762200D828C7 /* TNL_ProjectCommon.m */; };
+		8BFDF9282135AB2C002F6A80 /* TNLPriority.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BDA9D321978822300678D90 /* TNLPriority.m */; };
+		8BFDF9292135AB2C002F6A80 /* TNLRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE403041946794300C7241E /* TNLRequest.m */; };
+		8BFDF92A2135AB2C002F6A80 /* NSURL+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B87BA3E1E09DA20005A8926 /* NSURL+TNLAdditions.m */; };
+		8BFDF92B2135AB2C002F6A80 /* NSNumber+TNLURLCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B959C271BAB6BA3007858C0 /* NSNumber+TNLURLCoding.m */; };
+		8BFDF92C2135AB2C002F6A80 /* NSOperationQueue+TNLSafety.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE68CFE1B7E421100A0F853 /* NSOperationQueue+TNLSafety.m */; };
+		8BFDF92D2135AB2C002F6A80 /* TNLAttemptMetrics.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BF953DC1A67DD3F00E9C1AA /* TNLAttemptMetrics.m */; };
+		8BFDF92E2135AB2C002F6A80 /* TNLCommunicationAgent.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B00D5AA1CFF512100D1728D /* TNLCommunicationAgent.m */; };
+		8BFDF92F2135AB2C002F6A80 /* TNLTemporaryFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B9038DB19799D4A001A3DDD /* TNLTemporaryFile.m */; };
+		8BFDF9302135AB2C002F6A80 /* TNLRequestOperationQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE4030E1946794300C7241E /* TNLRequestOperationQueue.m */; };
+		8BFDF9312135AB2C002F6A80 /* TNLHTTP.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE4032419467A1400C7241E /* TNLHTTP.m */; };
+		8BFDF9322135AB2C002F6A80 /* TNLError.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BDA9D2C197881DE00678D90 /* TNLError.m */; };
+		8BFDF9332135AB2C002F6A80 /* NSURLCache+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B8434841A13B77700D006DA /* NSURLCache+TNLAdditions.m */; };
+		8BFDF9342135AB2C002F6A80 /* NSURLCredentialStorage+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BA336D91A3271A0005D7B35 /* NSURLCredentialStorage+TNLAdditions.m */; };
+		8BFDF9352135AB2C002F6A80 /* TNL_Project.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B07EE681987E7DD00F9EF8E /* TNL_Project.m */; };
+		8BFDF9362135AB2C002F6A80 /* NSHTTPCookieStorage+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B23BA3C1A89B69A0027EB80 /* NSHTTPCookieStorage+TNLAdditions.m */; };
+		8BFDF9372135AB2C002F6A80 /* TNLBackgroundURLSessionTaskOperationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B2924BC1992E42900AC139A /* TNLBackgroundURLSessionTaskOperationManager.m */; };
+		8BFDF9382135AB2C002F6A80 /* TNLTimeoutOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD083C81FD9C2020090B7C3 /* TNLTimeoutOperation.m */; };
+		8BFDF9392135AB2C002F6A80 /* TNLRequestOperationCancelSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BCAF8C419F716370043EB22 /* TNLRequestOperationCancelSource.m */; };
+		8BFDF93B2135AB2C002F6A80 /* libxml2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BE3DB9B1CDB009F0081ACCE /* libxml2.tbd */; };
+		8BFDF93C2135AB2C002F6A80 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BE3DB991CDB008C0081ACCE /* libz.tbd */; };
+		8BFDF93D2135AB2C002F6A80 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B6DCB4B1974598300235576 /* CFNetwork.framework */; };
+		8BFDF93E2135AB2C002F6A80 /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B4AA75D1E1F28DF00BF7EA0 /* CoreTelephony.framework */; };
+		8BFDF93F2135AB2C002F6A80 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BE402C91946743D00C7241E /* Foundation.framework */; };
+		8BFDF9402135AB2C002F6A80 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B427D541FB53DBF00C9E5CE /* Security.framework */; };
+		8BFDF9412135AB2C002F6A80 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B4DEFF81986AA64008A31EB /* SystemConfiguration.framework */; };
+		8BFDF9422135AB2C002F6A80 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B6DCB491974583B00235576 /* UIKit.framework */; };
+		8BFDF9452135AB2C002F6A80 /* TNLRequestConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B79ACD51975E4BD00FA8D1E /* TNLRequestConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9462135AB2C002F6A80 /* TNLInternalKeys.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B5849E320D4454500FA8C84 /* TNLInternalKeys.h */; };
+		8BFDF9472135AB2C002F6A80 /* TNLParameterCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B4E016F19FB0632004D3CED /* TNLParameterCollection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9482135AB2C002F6A80 /* TNLRequest+Utilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE30EF21AA270750061FE99 /* TNLRequest+Utilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9492135AB2C002F6A80 /* TNLResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE403061946794300C7241E /* TNLResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF94A2135AB2C002F6A80 /* TNLAttemptMetaData.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B3DB5591A699C8D00FFF836 /* TNLAttemptMetaData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF94B2135AB2C002F6A80 /* NSURLCredentialStorage+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BA336D81A3271A0005D7B35 /* NSURLCredentialStorage+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF94C2135AB2C002F6A80 /* TNLRequestDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BB8B87B1A1E710E0093AE63 /* TNLRequestDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF94D2135AB2C002F6A80 /* TNLTemporaryFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B9038DA19799D4A001A3DDD /* TNLTemporaryFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF94E2135AB2C002F6A80 /* TNLSimpleRequestDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B397AE81A252E4900D2CB54 /* TNLSimpleRequestDelegate.h */; };
+		8BFDF94F2135AB2C002F6A80 /* TNLRequestRetryPolicyConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE403081946794300C7241E /* TNLRequestRetryPolicyConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9502135AB2C002F6A80 /* TNLRequestOperation_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE403001946794300C7241E /* TNLRequestOperation_Project.h */; };
+		8BFDF9512135AB2C002F6A80 /* TNLURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BAFBF0E1BDABAB500F36EFF /* TNLURLSessionManager.h */; };
+		8BFDF9522135AB2C002F6A80 /* TNLBackgroundURLSessionTaskOperationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B2924BB1992E42900AC139A /* TNLBackgroundURLSessionTaskOperationManager.h */; };
+		8BFDF9532135AB2C002F6A80 /* TNLHostSanitizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BB0E3A51A1FCFB6008CF992 /* TNLHostSanitizer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9542135AB2C002F6A80 /* module.modulemap in Headers */ = {isa = PBXBuildFile; fileRef = B3B9E9FE1C3AEDE700B8A451 /* module.modulemap */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9552135AB2C002F6A80 /* NSURLSessionConfiguration+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BFDF956199ADF4300248C3D /* NSURLSessionConfiguration+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9562135AB2C002F6A80 /* TNLRequestHydrater.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B2DF7D0199D7F2600A064B3 /* TNLRequestHydrater.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9572135AB2C002F6A80 /* TNLHTTP.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE4032319467A1400C7241E /* TNLHTTP.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8BFDF958199ADF4300248C3D /* NSURLSessionConfiguration+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BFDF956199ADF4300248C3D /* NSURLSessionConfiguration+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9582135AB2C002F6A80 /* TNLGlobalConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BB0E3991A1FA861008CF992 /* TNLGlobalConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8BFDF959199ADF4300248C3D /* NSURLSessionConfiguration+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BFDF957199ADF4300248C3D /* NSURLSessionConfiguration+TNLAdditions.m */; };
+		8BFDF9592135AB2C002F6A80 /* TNLRequestOperationQueue_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE4030C1946794300C7241E /* TNLRequestOperationQueue_Project.h */; };
+		8BFDF95A2135AB2C002F6A80 /* NSURLSessionTaskMetrics+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B4EC7F61D46DD6500DDEAF3 /* NSURLSessionTaskMetrics+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF95B2135AB2C002F6A80 /* TNLSafeOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B1EE88B1EE0D0E0007B2D76 /* TNLSafeOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF95C2135AB2C002F6A80 /* TNLRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE403011946794300C7241E /* TNLRequestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF95D2135AB2C002F6A80 /* NSHTTPCookieStorage+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B23BA3B1A89B69A0027EB80 /* NSHTTPCookieStorage+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF95E2135AB2C002F6A80 /* TNLContentCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B6E34241DE0B755004A35C7 /* TNLContentCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF95F2135AB2C002F6A80 /* TNLRequestAuthorizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B2DF7D6199D7F9F00A064B3 /* TNLRequestAuthorizer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9602135AB2C002F6A80 /* TNLRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE403031946794300C7241E /* TNLRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9612135AB2C002F6A80 /* TNL_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE402FB1946794300C7241E /* TNL_Project.h */; };
+		8BFDF9622135AB2C002F6A80 /* TNL_ProjectCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BD500F31D87762200D828C7 /* TNL_ProjectCommon.h */; };
+		8BFDF9632135AB2C002F6A80 /* TNLNetworkObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B82A5A61948D3E900A16237 /* TNLNetworkObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9642135AB2C002F6A80 /* TNLTiming.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B5141211CE530E000830987 /* TNLTiming.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9652135AB2C002F6A80 /* TNLRequestOperationCancelSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BCAF8C319F716370043EB22 /* TNLRequestOperationCancelSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9662135AB2C002F6A80 /* TNLError.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BDA9D2B197881DE00678D90 /* TNLError.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9672135AB2C002F6A80 /* TNLAttemptMetrics_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BF953E11A67E73E00E9C1AA /* TNLAttemptMetrics_Project.h */; };
+		8BFDF9682135AB2C002F6A80 /* TNLCommunicationAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B00D5A91CFF512100D1728D /* TNLCommunicationAgent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9692135AB2C002F6A80 /* NSDictionary+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B022A8119AAD2F800DB3052 /* NSDictionary+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF96A2135AB2C002F6A80 /* TNLAttemptMetrics.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BF953DB1A67DD3F00E9C1AA /* TNLAttemptMetrics.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF96B2135AB2C002F6A80 /* TNLPriority.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BDA9D311978822300678D90 /* TNLPriority.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF96C2135AB2C002F6A80 /* NSURLRequest+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE857641DD396B100F79F3D /* NSURLRequest+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF96D2135AB2C002F6A80 /* NSOperationQueue+TNLSafety.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE68CFD1B7E421100A0F853 /* NSOperationQueue+TNLSafety.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF96E2135AB2C002F6A80 /* NSCachedURLResponse+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B277E471C022B5C00279EA9 /* NSCachedURLResponse+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF96F2135AB2C002F6A80 /* NSData+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BB1190D1D83537C00E75CD9 /* NSData+TNLAdditions.h */; };
+		8BFDF9702135AB2C002F6A80 /* TNLURLSessionTaskOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B82A5A91948D63100A16237 /* TNLURLSessionTaskOperation.h */; };
+		8BFDF9712135AB2C002F6A80 /* NSURLCache+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B8434831A13B77700D006DA /* NSURLCache+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9722135AB2C002F6A80 /* TNLHTTPHeaderProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BEE98C11ADC5E3100A58A92 /* TNLHTTPHeaderProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9732135AB2C002F6A80 /* NSURLResponse+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B3586A81A1551DB00E82D51 /* NSURLResponse+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9742135AB2C002F6A80 /* TNLURLCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B4DEFFA1986AE55008A31EB /* TNLURLCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9752135AB2C002F6A80 /* TNLPseudoURLProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B0AFAA61A018EBE00C8C81F /* TNLPseudoURLProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9762135AB2C002F6A80 /* TNLLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B322FEE1CA321AB00733D7A /* TNLLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9772135AB2C002F6A80 /* TNLTimeoutOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BD083C71FD9C2020090B7C3 /* TNLTimeoutOperation.h */; };
+		8BFDF9782135AB2C002F6A80 /* TwitterNetworkLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BA2970D1946CF8800BD7E91 /* TwitterNetworkLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9792135AB2C002F6A80 /* TNLRequestEventHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B2DF7DA199D7FF700A064B3 /* TNLRequestEventHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF97A2135AB2C002F6A80 /* TNLHTTPRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE30EEC1AA266EC0061FE99 /* TNLHTTPRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF97B2135AB2C002F6A80 /* NSNumber+TNLURLCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B959C261BAB6BA3007858C0 /* NSNumber+TNLURLCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF97C2135AB2C002F6A80 /* TNLGlobalConfiguration_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B86BF381A2D0998005AE96B /* TNLGlobalConfiguration_Project.h */; };
+		8BFDF97D2135AB2C002F6A80 /* TNLTemporaryFile_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B9038E119799D7C001A3DDD /* TNLTemporaryFile_Project.h */; };
+		8BFDF97E2135AB2C002F6A80 /* TNLRequestOperationQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE4030D1946794300C7241E /* TNLRequestOperationQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF97F2135AB2C002F6A80 /* TNLRequestOperationState.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BCA626319C356AE00F3F8CA /* TNLRequestOperationState.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9802135AB2C002F6A80 /* TNLRequestRedirecter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BED1FBF1A89480C00279141 /* TNLRequestRedirecter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9812135AB2C002F6A80 /* TNLCommunicationAgent_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B5DBBFD206D8F9C007EF65B /* TNLCommunicationAgent_Project.h */; };
+		8BFDF9822135AB2C002F6A80 /* TNLNetwork.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B0DDD2319C7456A004BEE4B /* TNLNetwork.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9832135AB2C002F6A80 /* TNLResponse_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B13EB9D19C9F7580098E349 /* TNLResponse_Project.h */; };
+		8BFDF9842135AB2C002F6A80 /* TNLLRUCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BDC0E391BDFE15C0077F8FC /* TNLLRUCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9852135AB2C002F6A80 /* TNLAuthenticationChallengeHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B153161207D1DA400A1288F /* TNLAuthenticationChallengeHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9862135AB2C002F6A80 /* TNLRequestConfiguration_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B6CB1A5199BE234009A09CE /* TNLRequestConfiguration_Project.h */; };
+		8BFDF9872135AB2C002F6A80 /* NSURL+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B87BA3D1E09DA20005A8926 /* NSURL+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9882135AB2C002F6A80 /* TNLAttemptMetaData_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CA2A7AA1B01BC3B00553B16 /* TNLAttemptMetaData_Project.h */; };
+		8BFDF9892135AB2C002F6A80 /* TNLRequestRetryPolicyProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE4030A1946794300C7241E /* TNLRequestRetryPolicyProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BFDF9932135ACDB002F6A80 /* TNLResponseTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B8434891A13B8E500D006DA /* TNLResponseTest.m */; };
+		8BFDF9942135ACDB002F6A80 /* TNLXImageSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BC1AC3C19A27559008687EE /* TNLXImageSupport.m */; };
+		8BFDF9952135ACDB002F6A80 /* TNLHTTPTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B986C641BE3EF1D0053BB14 /* TNLHTTPTests.m */; };
+		8BFDF9962135ACDB002F6A80 /* TNLRequestOperationQueueTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B8FA3331AF426B200BC91DF /* TNLRequestOperationQueueTest.m */; };
+		8BFDF9972135ACDB002F6A80 /* TNLRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B23E00C19FFF799007C1E35 /* TNLRequestTests.m */; };
+		8BFDF9982135ACDB002F6A80 /* TNLTemporaryFileTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B227B831A004F97003B1C7C /* TNLTemporaryFileTest.m */; };
+		8BFDF9992135ACDB002F6A80 /* TNLParameterCollectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B8A683D19FEEB51008623E8 /* TNLParameterCollectionTests.m */; };
+		8BFDF99A2135ACDB002F6A80 /* TNLRequestOperationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B84348B1A13BF3C00D006DA /* TNLRequestOperationTest.m */; };
+		8BFDF99B2135ACDB002F6A80 /* NSURLCache+TNLAdditionsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B84348D1A1509F500D006DA /* NSURLCache+TNLAdditionsTest.m */; };
+		8BFDF99C2135ACDB002F6A80 /* NSURLSessionConfiguration+TNLAdditionsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BFF0A6219FFEFED001F42B7 /* NSURLSessionConfiguration+TNLAdditionsTest.m */; };
+		8BFDF99D2135ACDB002F6A80 /* TNLXMultipartFormData.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BDDDF1C19C0D0BB00D7C0CD /* TNLXMultipartFormData.m */; };
+		8BFDF99E2135ACDB002F6A80 /* TNLRequestRetryPolicyConfigurationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B4CBEA81A169A6800230318 /* TNLRequestRetryPolicyConfigurationTest.m */; };
+		8BFDF99F2135ACDB002F6A80 /* TNLPseudoRequestOperationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B0AFAAD1A01C20000C8C81F /* TNLPseudoRequestOperationTest.m */; };
+		8BFDF9A02135ACDB002F6A80 /* TNLAutoDependencyTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B68AA5C1D95BF2E00AFD0C8 /* TNLAutoDependencyTest.m */; };
+		8BFDF9A12135ACDB002F6A80 /* NSDictionary+TNLAdditionsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BFF0A1C19FF32D1001F42B7 /* NSDictionary+TNLAdditionsTest.m */; };
+		8BFDF9A22135ACDB002F6A80 /* TNLURLCodingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B84347B1A13B70C00D006DA /* TNLURLCodingTest.m */; };
+		8BFDF9A32135ACDB002F6A80 /* TNLRequestConfigurationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B393D0F1A128173002976B4 /* TNLRequestConfigurationTest.m */; };
+		8BFDF9A42135ACDB002F6A80 /* NSOperationQueue+TNLSafetyTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B472C491BC41CB900DEA3BF /* NSOperationQueue+TNLSafetyTest.m */; };
+		8BFDF9A52135ACDB002F6A80 /* TNLAttemptMetaDataTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C7E65741B0298670037AD91 /* TNLAttemptMetaDataTest.m */; };
+		8BFDF9A62135ACDB002F6A80 /* TNLContentEncodingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B6E34261DE35F71004A35C7 /* TNLContentEncodingTests.m */; };
+		8BFDF9A72135ACDB002F6A80 /* TNLXContentEncoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B6E34291DE35FCD004A35C7 /* TNLXContentEncoding.m */; };
+		8BFDF9A82135ACDB002F6A80 /* TNLRequestRetryPolicyTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BFE79D9213076E600E3B2AD /* TNLRequestRetryPolicyTest.m */; };
+		8BFDF9A92135ACDB002F6A80 /* TNLNetworkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B8A684219FF13F0008623E8 /* TNLNetworkTests.m */; };
+		8BFDF9AC2135ACDB002F6A80 /* libsqlite3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BD410EB197446E9005FE24C /* libsqlite3.dylib */; };
+		8BFDF9AD2135ACDB002F6A80 /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BD410EF19744944005FE24C /* libxml2.dylib */; };
+		8BFDF9AE2135ACDB002F6A80 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B6DCB4D197459E400235576 /* libz.dylib */; };
+		8BFDF9AF2135ACDB002F6A80 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B6DCB4B1974598300235576 /* CFNetwork.framework */; };
+		8BFDF9B02135ACDB002F6A80 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BE402C91946743D00C7241E /* Foundation.framework */; };
+		8BFDF9B12135ACDB002F6A80 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B4DEFF81986AA64008A31EB /* SystemConfiguration.framework */; };
+		8BFDF9B22135ACDB002F6A80 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B6DCB491974583B00235576 /* UIKit.framework */; };
+		8BFDF9B32135ACDB002F6A80 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BE402D71946743E00C7241E /* XCTest.framework */; };
+		8BFDF9B52135ACDB002F6A80 /* BingResults.json.base64 in Resources */ = {isa = PBXBuildFile; fileRef = 8B0E0C4C1DE69C5700283B45 /* BingResults.json.base64 */; };
+		8BFDF9B72135ACDB002F6A80 /* BingResults.json in Resources */ = {isa = PBXBuildFile; fileRef = 8B17C22F1A1A83DD007A8DF6 /* BingResults.json */; };
+		8BFDF9B92135ACDB002F6A80 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8BE402E21946743E00C7241E /* InfoPlist.strings */; };
+		8BFDF9BF2135AD6A002F6A80 /* TwitterNetworkLayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BFDF98D2135AB2C002F6A80 /* TwitterNetworkLayer.framework */; };
 		8BFE79DA213076E600E3B2AD /* TNLRequestRetryPolicyTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BFE79D9213076E600E3B2AD /* TNLRequestRetryPolicyTest.m */; };
 		8BFE79DB21308A7B00E3B2AD /* TNLRequestRetryPolicyTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BFE79D9213076E600E3B2AD /* TNLRequestRetryPolicyTest.m */; };
 		8BFF0A1D19FF32D1001F42B7 /* NSDictionary+TNLAdditionsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BFF0A1C19FF32D1001F42B7 /* NSDictionary+TNLAdditionsTest.m */; };
@@ -365,6 +640,13 @@
 			remoteGlobalIDString = 8BE402C51946743D00C7241E;
 			remoteInfo = TwitterNetworkLayer;
 		};
+		8B9EBDB32135B2D700E6E466 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8BE402BE1946743D00C7241E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8BFDF90C2135AB2C002F6A80;
+			remoteInfo = "TwitterNetworkLayer tvOS";
+		};
 		BF4765F81EEEFC5B00A23506 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 8BE402BE1946743D00C7241E /* Project object */;
@@ -375,6 +657,15 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		8B9EBDEC2135B4B100E6E466 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8BDB97E71D24D28800861951 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -387,6 +678,15 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		8BE402C41946743D00C7241E /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8BFDF9432135AB2C002F6A80 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "include/$(PRODUCT_NAME)";
@@ -518,6 +818,7 @@
 		8B959C261BAB6BA3007858C0 /* NSNumber+TNLURLCoding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSNumber+TNLURLCoding.h"; sourceTree = "<group>"; };
 		8B959C271BAB6BA3007858C0 /* NSNumber+TNLURLCoding.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSNumber+TNLURLCoding.m"; sourceTree = "<group>"; };
 		8B986C641BE3EF1D0053BB14 /* TNLHTTPTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TNLHTTPTests.m; sourceTree = "<group>"; };
+		8B9EBE362135B4B100E6E466 /* TwitterNetworkLayer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TwitterNetworkLayer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8BA2970D1946CF8800BD7E91 /* TwitterNetworkLayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TwitterNetworkLayer.h; sourceTree = "<group>"; };
 		8BA336D81A3271A0005D7B35 /* NSURLCredentialStorage+TNLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURLCredentialStorage+TNLAdditions.h"; sourceTree = "<group>"; };
 		8BA336D91A3271A0005D7B35 /* NSURLCredentialStorage+TNLAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURLCredentialStorage+TNLAdditions.m"; sourceTree = "<group>"; };
@@ -603,8 +904,11 @@
 		8BF953DB1A67DD3F00E9C1AA /* TNLAttemptMetrics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TNLAttemptMetrics.h; sourceTree = "<group>"; };
 		8BF953DC1A67DD3F00E9C1AA /* TNLAttemptMetrics.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TNLAttemptMetrics.m; sourceTree = "<group>"; };
 		8BF953E11A67E73E00E9C1AA /* TNLAttemptMetrics_Project.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TNLAttemptMetrics_Project.h; sourceTree = "<group>"; };
+		8BFDF8FC2135A1FC002F6A80 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		8BFDF956199ADF4300248C3D /* NSURLSessionConfiguration+TNLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURLSessionConfiguration+TNLAdditions.h"; sourceTree = "<group>"; };
 		8BFDF957199ADF4300248C3D /* NSURLSessionConfiguration+TNLAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURLSessionConfiguration+TNLAdditions.m"; sourceTree = "<group>"; };
+		8BFDF98D2135AB2C002F6A80 /* TwitterNetworkLayer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TwitterNetworkLayer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8BFDF9BD2135ACDB002F6A80 /* TwitterNetworkLayerTests tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "TwitterNetworkLayerTests tvOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8BFE79D9213076E600E3B2AD /* TNLRequestRetryPolicyTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TNLRequestRetryPolicyTest.m; sourceTree = "<group>"; };
 		8BFF0A1C19FF32D1001F42B7 /* NSDictionary+TNLAdditionsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+TNLAdditionsTest.m"; sourceTree = "<group>"; };
 		8BFF0A6219FFEFED001F42B7 /* NSURLSessionConfiguration+TNLAdditionsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURLSessionConfiguration+TNLAdditionsTest.m"; sourceTree = "<group>"; };
@@ -614,6 +918,19 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		8B9EBDE32135B4B100E6E466 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8B9EBDE42135B4B100E6E466 /* libxml2.tbd in Frameworks */,
+				8B9EBDE52135B4B100E6E466 /* libz.tbd in Frameworks */,
+				8B9EBDE62135B4B100E6E466 /* CFNetwork.framework in Frameworks */,
+				8B9EBDE82135B4B100E6E466 /* Foundation.framework in Frameworks */,
+				8B9EBDE92135B4B100E6E466 /* Security.framework in Frameworks */,
+				8B9EBDEB2135B4B100E6E466 /* UIKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8BDFFC0119814D3100F7F670 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -650,15 +967,46 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3DD6EF981C8394BC008F78B8 /* TwitterNetworkLayer.framework in Frameworks */,
 				8BD410EC197446E9005FE24C /* libsqlite3.dylib in Frameworks */,
 				8BD410F019744944005FE24C /* libxml2.dylib in Frameworks */,
 				8B6DCB4E197459E400235576 /* libz.dylib in Frameworks */,
 				8B6DCB4C1974598300235576 /* CFNetwork.framework in Frameworks */,
 				8BE402D91946743E00C7241E /* Foundation.framework in Frameworks */,
 				8B1782551A1584BD00B48A7F /* SystemConfiguration.framework in Frameworks */,
+				3DD6EF981C8394BC008F78B8 /* TwitterNetworkLayer.framework in Frameworks */,
 				8B6DCB4A1974583B00235576 /* UIKit.framework in Frameworks */,
 				8B956CE019883EE60050D937 /* XCTest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8BFDF93A2135AB2C002F6A80 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8BFDF93B2135AB2C002F6A80 /* libxml2.tbd in Frameworks */,
+				8BFDF93C2135AB2C002F6A80 /* libz.tbd in Frameworks */,
+				8BFDF93D2135AB2C002F6A80 /* CFNetwork.framework in Frameworks */,
+				8BFDF93E2135AB2C002F6A80 /* CoreTelephony.framework in Frameworks */,
+				8BFDF93F2135AB2C002F6A80 /* Foundation.framework in Frameworks */,
+				8BFDF9402135AB2C002F6A80 /* Security.framework in Frameworks */,
+				8BFDF9412135AB2C002F6A80 /* SystemConfiguration.framework in Frameworks */,
+				8BFDF9422135AB2C002F6A80 /* UIKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8BFDF9AA2135ACDB002F6A80 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8BFDF9AC2135ACDB002F6A80 /* libsqlite3.dylib in Frameworks */,
+				8BFDF9AD2135ACDB002F6A80 /* libxml2.dylib in Frameworks */,
+				8BFDF9AE2135ACDB002F6A80 /* libz.dylib in Frameworks */,
+				8BFDF9AF2135ACDB002F6A80 /* CFNetwork.framework in Frameworks */,
+				8BFDF9B02135ACDB002F6A80 /* Foundation.framework in Frameworks */,
+				8BFDF9B12135ACDB002F6A80 /* SystemConfiguration.framework in Frameworks */,
+				8BFDF9BF2135AD6A002F6A80 /* TwitterNetworkLayer.framework in Frameworks */,
+				8BFDF9B22135ACDB002F6A80 /* UIKit.framework in Frameworks */,
+				8BFDF9B32135ACDB002F6A80 /* XCTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -670,6 +1018,7 @@
 				BF4AA0EF1EE61D46001647B5 /* libz.tbd in Frameworks */,
 				BF4AA0F01EE61D46001647B5 /* CFNetwork.framework in Frameworks */,
 				BF4AA0F21EE61D46001647B5 /* Foundation.framework in Frameworks */,
+				8BFDF8FD2135A1FC002F6A80 /* Security.framework in Frameworks */,
 				BF4AA0F31EE61D46001647B5 /* SystemConfiguration.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -678,13 +1027,14 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF4765FA1EEEFC8600A23506 /* TwitterNetworkLayer.framework in Frameworks */,
 				BF4AA15B1EE626ED001647B5 /* libsqlite3.dylib in Frameworks */,
 				BF4AA15C1EE626ED001647B5 /* libxml2.dylib in Frameworks */,
 				BF4AA15D1EE626ED001647B5 /* libz.dylib in Frameworks */,
 				BF4AA15E1EE626ED001647B5 /* CFNetwork.framework in Frameworks */,
 				BF4AA15F1EE626ED001647B5 /* Foundation.framework in Frameworks */,
+				8BFDF8FE2135A215002F6A80 /* Security.framework in Frameworks */,
 				BF4AA1601EE626ED001647B5 /* SystemConfiguration.framework in Frameworks */,
+				BF4765FA1EEEFC8600A23506 /* TwitterNetworkLayer.framework in Frameworks */,
 				BF4AA1621EE626ED001647B5 /* XCTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -812,6 +1162,9 @@
 				8BDFFC0419814D3100F7F670 /* TNLExample.app */,
 				BF4AA13B1EE61D47001647B5 /* TwitterNetworkLayer.framework */,
 				BF4AA16A1EE626ED001647B5 /* TwitterNetworkLayerTests MacOS.xctest */,
+				8BFDF98D2135AB2C002F6A80 /* TwitterNetworkLayer.framework */,
+				8BFDF9BD2135ACDB002F6A80 /* TwitterNetworkLayerTests tvOS.xctest */,
+				8B9EBE362135B4B100E6E466 /* TwitterNetworkLayer.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -819,6 +1172,7 @@
 		8BE402C81946743D00C7241E /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				8BFDF8FC2135A1FC002F6A80 /* Security.framework */,
 				8B022A7B19AA52F800DB3052 /* Accounts.framework */,
 				8B6DCB4B1974598300235576 /* CFNetwork.framework */,
 				8BDFFC0619814D3100F7F670 /* CoreGraphics.framework */,
@@ -993,6 +1347,82 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		8B9EBDED2135B4B100E6E466 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8B9EBDEE2135B4B100E6E466 /* TNLRequestConfiguration.h in Headers */,
+				8B9EBDEF2135B4B100E6E466 /* TNLInternalKeys.h in Headers */,
+				8B9EBDF02135B4B100E6E466 /* TNLParameterCollection.h in Headers */,
+				8B9EBDF12135B4B100E6E466 /* TNLRequest+Utilities.h in Headers */,
+				8B9EBDF22135B4B100E6E466 /* TNLResponse.h in Headers */,
+				8B9EBDF32135B4B100E6E466 /* TNLAttemptMetaData.h in Headers */,
+				8B9EBDF42135B4B100E6E466 /* NSURLCredentialStorage+TNLAdditions.h in Headers */,
+				8B9EBDF52135B4B100E6E466 /* TNLRequestDelegate.h in Headers */,
+				8B9EBDF62135B4B100E6E466 /* TNLTemporaryFile.h in Headers */,
+				8B9EBDF72135B4B100E6E466 /* TNLSimpleRequestDelegate.h in Headers */,
+				8B9EBDF82135B4B100E6E466 /* TNLRequestRetryPolicyConfiguration.h in Headers */,
+				8B9EBDF92135B4B100E6E466 /* TNLRequestOperation_Project.h in Headers */,
+				8B9EBDFA2135B4B100E6E466 /* TNLURLSessionManager.h in Headers */,
+				8B9EBDFB2135B4B100E6E466 /* TNLBackgroundURLSessionTaskOperationManager.h in Headers */,
+				8B9EBDFC2135B4B100E6E466 /* TNLHostSanitizer.h in Headers */,
+				8B9EBDFD2135B4B100E6E466 /* module.modulemap in Headers */,
+				8B9EBDFE2135B4B100E6E466 /* NSURLSessionConfiguration+TNLAdditions.h in Headers */,
+				8B9EBDFF2135B4B100E6E466 /* TNLRequestHydrater.h in Headers */,
+				8B9EBE002135B4B100E6E466 /* TNLHTTP.h in Headers */,
+				8B9EBE012135B4B100E6E466 /* TNLGlobalConfiguration.h in Headers */,
+				8B9EBE022135B4B100E6E466 /* TNLRequestOperationQueue_Project.h in Headers */,
+				8B9EBE032135B4B100E6E466 /* NSURLSessionTaskMetrics+TNLAdditions.h in Headers */,
+				8B9EBE042135B4B100E6E466 /* TNLSafeOperation.h in Headers */,
+				8B9EBE052135B4B100E6E466 /* TNLRequestOperation.h in Headers */,
+				8B9EBE062135B4B100E6E466 /* NSHTTPCookieStorage+TNLAdditions.h in Headers */,
+				8B9EBE072135B4B100E6E466 /* TNLContentCoding.h in Headers */,
+				8B9EBE082135B4B100E6E466 /* TNLRequestAuthorizer.h in Headers */,
+				8B9EBE092135B4B100E6E466 /* TNLRequest.h in Headers */,
+				8B9EBE0A2135B4B100E6E466 /* TNL_Project.h in Headers */,
+				8B9EBE0B2135B4B100E6E466 /* TNL_ProjectCommon.h in Headers */,
+				8B9EBE0C2135B4B100E6E466 /* TNLNetworkObserver.h in Headers */,
+				8B9EBE0D2135B4B100E6E466 /* TNLTiming.h in Headers */,
+				8B9EBE0E2135B4B100E6E466 /* TNLRequestOperationCancelSource.h in Headers */,
+				8B9EBE0F2135B4B100E6E466 /* TNLError.h in Headers */,
+				8B9EBE102135B4B100E6E466 /* TNLAttemptMetrics_Project.h in Headers */,
+				8B9EBE112135B4B100E6E466 /* TNLCommunicationAgent.h in Headers */,
+				8B9EBE122135B4B100E6E466 /* NSDictionary+TNLAdditions.h in Headers */,
+				8B9EBE132135B4B100E6E466 /* TNLAttemptMetrics.h in Headers */,
+				8B9EBE142135B4B100E6E466 /* TNLPriority.h in Headers */,
+				8B9EBE152135B4B100E6E466 /* NSURLRequest+TNLAdditions.h in Headers */,
+				8B9EBE162135B4B100E6E466 /* NSOperationQueue+TNLSafety.h in Headers */,
+				8B9EBE172135B4B100E6E466 /* NSCachedURLResponse+TNLAdditions.h in Headers */,
+				8B9EBE182135B4B100E6E466 /* NSData+TNLAdditions.h in Headers */,
+				8B9EBE192135B4B100E6E466 /* TNLURLSessionTaskOperation.h in Headers */,
+				8B9EBE1A2135B4B100E6E466 /* NSURLCache+TNLAdditions.h in Headers */,
+				8B9EBE1B2135B4B100E6E466 /* TNLHTTPHeaderProvider.h in Headers */,
+				8B9EBE1C2135B4B100E6E466 /* NSURLResponse+TNLAdditions.h in Headers */,
+				8B9EBE1D2135B4B100E6E466 /* TNLURLCoding.h in Headers */,
+				8B9EBE1E2135B4B100E6E466 /* TNLPseudoURLProtocol.h in Headers */,
+				8B9EBE1F2135B4B100E6E466 /* TNLLogger.h in Headers */,
+				8B9EBE202135B4B100E6E466 /* TNLTimeoutOperation.h in Headers */,
+				8B9EBE212135B4B100E6E466 /* TwitterNetworkLayer.h in Headers */,
+				8B9EBE222135B4B100E6E466 /* TNLRequestEventHandler.h in Headers */,
+				8B9EBE232135B4B100E6E466 /* TNLHTTPRequest.h in Headers */,
+				8B9EBE242135B4B100E6E466 /* NSNumber+TNLURLCoding.h in Headers */,
+				8B9EBE252135B4B100E6E466 /* TNLGlobalConfiguration_Project.h in Headers */,
+				8B9EBE262135B4B100E6E466 /* TNLTemporaryFile_Project.h in Headers */,
+				8B9EBE272135B4B100E6E466 /* TNLRequestOperationQueue.h in Headers */,
+				8B9EBE282135B4B100E6E466 /* TNLRequestOperationState.h in Headers */,
+				8B9EBE292135B4B100E6E466 /* TNLRequestRedirecter.h in Headers */,
+				8B9EBE2A2135B4B100E6E466 /* TNLCommunicationAgent_Project.h in Headers */,
+				8B9EBE2B2135B4B100E6E466 /* TNLNetwork.h in Headers */,
+				8B9EBE2C2135B4B100E6E466 /* TNLResponse_Project.h in Headers */,
+				8B9EBE2D2135B4B100E6E466 /* TNLLRUCache.h in Headers */,
+				8B9EBE2E2135B4B100E6E466 /* TNLAuthenticationChallengeHandler.h in Headers */,
+				8B9EBE2F2135B4B100E6E466 /* TNLRequestConfiguration_Project.h in Headers */,
+				8B9EBE302135B4B100E6E466 /* NSURL+TNLAdditions.h in Headers */,
+				8B9EBE312135B4B100E6E466 /* TNLAttemptMetaData_Project.h in Headers */,
+				8B9EBE322135B4B100E6E466 /* TNLRequestRetryPolicyProvider.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8BE402F91946786900C7241E /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -1066,6 +1496,82 @@
 				8B87BA3F1E09DA20005A8926 /* NSURL+TNLAdditions.h in Headers */,
 				5CA2A7AC1B01BC3B00553B16 /* TNLAttemptMetaData_Project.h in Headers */,
 				8BE4031E1946794300C7241E /* TNLRequestRetryPolicyProvider.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8BFDF9442135AB2C002F6A80 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8BFDF9452135AB2C002F6A80 /* TNLRequestConfiguration.h in Headers */,
+				8BFDF9462135AB2C002F6A80 /* TNLInternalKeys.h in Headers */,
+				8BFDF9472135AB2C002F6A80 /* TNLParameterCollection.h in Headers */,
+				8BFDF9482135AB2C002F6A80 /* TNLRequest+Utilities.h in Headers */,
+				8BFDF9492135AB2C002F6A80 /* TNLResponse.h in Headers */,
+				8BFDF94A2135AB2C002F6A80 /* TNLAttemptMetaData.h in Headers */,
+				8BFDF94B2135AB2C002F6A80 /* NSURLCredentialStorage+TNLAdditions.h in Headers */,
+				8BFDF94C2135AB2C002F6A80 /* TNLRequestDelegate.h in Headers */,
+				8BFDF94D2135AB2C002F6A80 /* TNLTemporaryFile.h in Headers */,
+				8BFDF94E2135AB2C002F6A80 /* TNLSimpleRequestDelegate.h in Headers */,
+				8BFDF94F2135AB2C002F6A80 /* TNLRequestRetryPolicyConfiguration.h in Headers */,
+				8BFDF9502135AB2C002F6A80 /* TNLRequestOperation_Project.h in Headers */,
+				8BFDF9512135AB2C002F6A80 /* TNLURLSessionManager.h in Headers */,
+				8BFDF9522135AB2C002F6A80 /* TNLBackgroundURLSessionTaskOperationManager.h in Headers */,
+				8BFDF9532135AB2C002F6A80 /* TNLHostSanitizer.h in Headers */,
+				8BFDF9542135AB2C002F6A80 /* module.modulemap in Headers */,
+				8BFDF9552135AB2C002F6A80 /* NSURLSessionConfiguration+TNLAdditions.h in Headers */,
+				8BFDF9562135AB2C002F6A80 /* TNLRequestHydrater.h in Headers */,
+				8BFDF9572135AB2C002F6A80 /* TNLHTTP.h in Headers */,
+				8BFDF9582135AB2C002F6A80 /* TNLGlobalConfiguration.h in Headers */,
+				8BFDF9592135AB2C002F6A80 /* TNLRequestOperationQueue_Project.h in Headers */,
+				8BFDF95A2135AB2C002F6A80 /* NSURLSessionTaskMetrics+TNLAdditions.h in Headers */,
+				8BFDF95B2135AB2C002F6A80 /* TNLSafeOperation.h in Headers */,
+				8BFDF95C2135AB2C002F6A80 /* TNLRequestOperation.h in Headers */,
+				8BFDF95D2135AB2C002F6A80 /* NSHTTPCookieStorage+TNLAdditions.h in Headers */,
+				8BFDF95E2135AB2C002F6A80 /* TNLContentCoding.h in Headers */,
+				8BFDF95F2135AB2C002F6A80 /* TNLRequestAuthorizer.h in Headers */,
+				8BFDF9602135AB2C002F6A80 /* TNLRequest.h in Headers */,
+				8BFDF9612135AB2C002F6A80 /* TNL_Project.h in Headers */,
+				8BFDF9622135AB2C002F6A80 /* TNL_ProjectCommon.h in Headers */,
+				8BFDF9632135AB2C002F6A80 /* TNLNetworkObserver.h in Headers */,
+				8BFDF9642135AB2C002F6A80 /* TNLTiming.h in Headers */,
+				8BFDF9652135AB2C002F6A80 /* TNLRequestOperationCancelSource.h in Headers */,
+				8BFDF9662135AB2C002F6A80 /* TNLError.h in Headers */,
+				8BFDF9672135AB2C002F6A80 /* TNLAttemptMetrics_Project.h in Headers */,
+				8BFDF9682135AB2C002F6A80 /* TNLCommunicationAgent.h in Headers */,
+				8BFDF9692135AB2C002F6A80 /* NSDictionary+TNLAdditions.h in Headers */,
+				8BFDF96A2135AB2C002F6A80 /* TNLAttemptMetrics.h in Headers */,
+				8BFDF96B2135AB2C002F6A80 /* TNLPriority.h in Headers */,
+				8BFDF96C2135AB2C002F6A80 /* NSURLRequest+TNLAdditions.h in Headers */,
+				8BFDF96D2135AB2C002F6A80 /* NSOperationQueue+TNLSafety.h in Headers */,
+				8BFDF96E2135AB2C002F6A80 /* NSCachedURLResponse+TNLAdditions.h in Headers */,
+				8BFDF96F2135AB2C002F6A80 /* NSData+TNLAdditions.h in Headers */,
+				8BFDF9702135AB2C002F6A80 /* TNLURLSessionTaskOperation.h in Headers */,
+				8BFDF9712135AB2C002F6A80 /* NSURLCache+TNLAdditions.h in Headers */,
+				8BFDF9722135AB2C002F6A80 /* TNLHTTPHeaderProvider.h in Headers */,
+				8BFDF9732135AB2C002F6A80 /* NSURLResponse+TNLAdditions.h in Headers */,
+				8BFDF9742135AB2C002F6A80 /* TNLURLCoding.h in Headers */,
+				8BFDF9752135AB2C002F6A80 /* TNLPseudoURLProtocol.h in Headers */,
+				8BFDF9762135AB2C002F6A80 /* TNLLogger.h in Headers */,
+				8BFDF9772135AB2C002F6A80 /* TNLTimeoutOperation.h in Headers */,
+				8BFDF9782135AB2C002F6A80 /* TwitterNetworkLayer.h in Headers */,
+				8BFDF9792135AB2C002F6A80 /* TNLRequestEventHandler.h in Headers */,
+				8BFDF97A2135AB2C002F6A80 /* TNLHTTPRequest.h in Headers */,
+				8BFDF97B2135AB2C002F6A80 /* NSNumber+TNLURLCoding.h in Headers */,
+				8BFDF97C2135AB2C002F6A80 /* TNLGlobalConfiguration_Project.h in Headers */,
+				8BFDF97D2135AB2C002F6A80 /* TNLTemporaryFile_Project.h in Headers */,
+				8BFDF97E2135AB2C002F6A80 /* TNLRequestOperationQueue.h in Headers */,
+				8BFDF97F2135AB2C002F6A80 /* TNLRequestOperationState.h in Headers */,
+				8BFDF9802135AB2C002F6A80 /* TNLRequestRedirecter.h in Headers */,
+				8BFDF9812135AB2C002F6A80 /* TNLCommunicationAgent_Project.h in Headers */,
+				8BFDF9822135AB2C002F6A80 /* TNLNetwork.h in Headers */,
+				8BFDF9832135AB2C002F6A80 /* TNLResponse_Project.h in Headers */,
+				8BFDF9842135AB2C002F6A80 /* TNLLRUCache.h in Headers */,
+				8BFDF9852135AB2C002F6A80 /* TNLAuthenticationChallengeHandler.h in Headers */,
+				8BFDF9862135AB2C002F6A80 /* TNLRequestConfiguration_Project.h in Headers */,
+				8BFDF9872135AB2C002F6A80 /* NSURL+TNLAdditions.h in Headers */,
+				8BFDF9882135AB2C002F6A80 /* TNLAttemptMetaData_Project.h in Headers */,
+				8BFDF9892135AB2C002F6A80 /* TNLRequestRetryPolicyProvider.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1147,6 +1653,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		8B9EBDB52135B4B100E6E466 /* TwitterNetworkLayer watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8B9EBE332135B4B100E6E466 /* Build configuration list for PBXNativeTarget "TwitterNetworkLayer watchOS" */;
+			buildPhases = (
+				8B9EBDB62135B4B100E6E466 /* Sources */,
+				8B9EBDE32135B4B100E6E466 /* Frameworks */,
+				8B9EBDEC2135B4B100E6E466 /* CopyFiles */,
+				8B9EBDED2135B4B100E6E466 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "TwitterNetworkLayer watchOS";
+			productName = TwitterNetworkLayer;
+			productReference = 8B9EBE362135B4B100E6E466 /* TwitterNetworkLayer.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		8BDFFC0319814D3100F7F670 /* TNLExample */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8BDFFC3719814D3100F7F670 /* Build configuration list for PBXNativeTarget "TNLExample" */;
@@ -1202,6 +1726,42 @@
 			productReference = 8BE402D61946743E00C7241E /* TwitterNetworkLayerTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		8BFDF90C2135AB2C002F6A80 /* TwitterNetworkLayer tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8BFDF98A2135AB2C002F6A80 /* Build configuration list for PBXNativeTarget "TwitterNetworkLayer tvOS" */;
+			buildPhases = (
+				8BFDF90D2135AB2C002F6A80 /* Sources */,
+				8BFDF93A2135AB2C002F6A80 /* Frameworks */,
+				8BFDF9432135AB2C002F6A80 /* CopyFiles */,
+				8BFDF9442135AB2C002F6A80 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "TwitterNetworkLayer tvOS";
+			productName = TwitterNetworkLayer;
+			productReference = 8BFDF98D2135AB2C002F6A80 /* TwitterNetworkLayer.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		8BFDF98F2135ACDB002F6A80 /* TwitterNetworkLayerTests tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8BFDF9BA2135ACDB002F6A80 /* Build configuration list for PBXNativeTarget "TwitterNetworkLayerTests tvOS" */;
+			buildPhases = (
+				8BFDF9922135ACDB002F6A80 /* Sources */,
+				8BFDF9AA2135ACDB002F6A80 /* Frameworks */,
+				8BFDF9B42135ACDB002F6A80 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				8B9EBDB42135B2D700E6E466 /* PBXTargetDependency */,
+			);
+			name = "TwitterNetworkLayerTests tvOS";
+			productName = TwitterNetworkLayerTests;
+			productReference = 8BFDF9BD2135ACDB002F6A80 /* TwitterNetworkLayerTests tvOS.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		BF4AA0C01EE61D46001647B5 /* TwitterNetworkLayer macOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = BF4AA1381EE61D46001647B5 /* Build configuration list for PBXNativeTarget "TwitterNetworkLayer macOS" */;
@@ -1248,12 +1808,31 @@
 				LastUpgradeCheck = 0940;
 				ORGANIZATIONNAME = Twitter;
 				TargetAttributes = {
+					8B9EBDB52135B4B100E6E466 = {
+						ProvisioningStyle = Manual;
+					};
+					8BDFFC0319814D3100F7F670 = {
+						ProvisioningStyle = Manual;
+					};
 					8BE402C51946743D00C7241E = {
 						DevelopmentTeamName = Twitter;
 						ProvisioningStyle = Manual;
 					};
 					8BE402D51946743E00C7241E = {
+						ProvisioningStyle = Manual;
 						TestTargetID = 8BE402C51946743D00C7241E;
+					};
+					8BFDF90C2135AB2C002F6A80 = {
+						ProvisioningStyle = Manual;
+					};
+					8BFDF98F2135ACDB002F6A80 = {
+						ProvisioningStyle = Manual;
+					};
+					BF4AA0C01EE61D46001647B5 = {
+						ProvisioningStyle = Manual;
+					};
+					BF4AA13D1EE626ED001647B5 = {
+						ProvisioningStyle = Manual;
 					};
 				};
 			};
@@ -1275,6 +1854,9 @@
 				8BDFFC0319814D3100F7F670 /* TNLExample */,
 				BF4AA0C01EE61D46001647B5 /* TwitterNetworkLayer macOS */,
 				BF4AA13D1EE626ED001647B5 /* TwitterNetworkLayerTests MacOS */,
+				8BFDF90C2135AB2C002F6A80 /* TwitterNetworkLayer tvOS */,
+				8BFDF98F2135ACDB002F6A80 /* TwitterNetworkLayerTests tvOS */,
+				8B9EBDB52135B4B100E6E466 /* TwitterNetworkLayer watchOS */,
 			);
 		};
 /* End PBXProject section */
@@ -1295,10 +1877,18 @@
 			buildActionMask = 2147483647;
 			files = (
 				8B0E0C4D1DE69C5700283B45 /* BingResults.json.base64 in Resources */,
-				8B109D6E20B63F16000D10AA /* CHANGELOG.md in Resources */,
 				8B17C2301A1A83DD007A8DF6 /* BingResults.json in Resources */,
-				8B109D6D20B63F16000D10AA /* README.md in Resources */,
 				8BE402E41946743E00C7241E /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8BFDF9B42135ACDB002F6A80 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8BFDF9B52135ACDB002F6A80 /* BingResults.json.base64 in Resources */,
+				8BFDF9B72135ACDB002F6A80 /* BingResults.json in Resources */,
+				8BFDF9B92135ACDB002F6A80 /* InfoPlist.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1315,6 +1905,57 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		8B9EBDB62135B4B100E6E466 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8B9EBDB72135B4B100E6E466 /* NSURLResponse+TNLAdditions.m in Sources */,
+				8B9EBDB82135B4B100E6E466 /* TNLRequestOperation.m in Sources */,
+				8B9EBDB92135B4B100E6E466 /* TNLAttemptMetaData.m in Sources */,
+				8B9EBDBA2135B4B100E6E466 /* NSURLRequest+TNLAdditions.m in Sources */,
+				8B9EBDBB2135B4B100E6E466 /* NSURLSessionTaskMetrics+TNLAdditions.m in Sources */,
+				8B9EBDBC2135B4B100E6E466 /* TNLURLCoding.m in Sources */,
+				8B9EBDBD2135B4B100E6E466 /* NSURLSessionConfiguration+TNLAdditions.m in Sources */,
+				8B9EBDBE2135B4B100E6E466 /* TNLHTTPRequest.m in Sources */,
+				8B9EBDBF2135B4B100E6E466 /* TNLTiming.m in Sources */,
+				8B9EBDC02135B4B100E6E466 /* TNLURLSessionManager.m in Sources */,
+				8B9EBDC12135B4B100E6E466 /* TNLNetwork.m in Sources */,
+				8B9EBDC22135B4B100E6E466 /* TNLRequestConfiguration.m in Sources */,
+				8B9EBDC32135B4B100E6E466 /* NSData+TNLAdditions.m in Sources */,
+				8B9EBDC42135B4B100E6E466 /* TNLGlobalConfiguration.m in Sources */,
+				8B9EBDC52135B4B100E6E466 /* TNLRequestRetryPolicyConfiguration.m in Sources */,
+				8B9EBDC62135B4B100E6E466 /* TNLResponse.m in Sources */,
+				8B9EBDC72135B4B100E6E466 /* TNLURLStringCoding.m in Sources */,
+				8B9EBDC82135B4B100E6E466 /* TNLSimpleRequestDelegate.m in Sources */,
+				8B9EBDC92135B4B100E6E466 /* TNLSafeOperation.m in Sources */,
+				8B9EBDCA2135B4B100E6E466 /* TNLURLSessionTaskOperation.m in Sources */,
+				8B9EBDCB2135B4B100E6E466 /* NSDictionary+TNLAdditions.m in Sources */,
+				8B9EBDCC2135B4B100E6E466 /* NSCachedURLResponse+TNLAdditions.m in Sources */,
+				8B9EBDCD2135B4B100E6E466 /* TNLLRUCache.m in Sources */,
+				8B9EBDCE2135B4B100E6E466 /* TNLParameterCollection.m in Sources */,
+				8B9EBDCF2135B4B100E6E466 /* TNLPseudoURLProtocol.m in Sources */,
+				8B9EBDD02135B4B100E6E466 /* TNL_ProjectCommon.m in Sources */,
+				8B9EBDD12135B4B100E6E466 /* TNLPriority.m in Sources */,
+				8B9EBDD22135B4B100E6E466 /* TNLRequest.m in Sources */,
+				8B9EBDD32135B4B100E6E466 /* NSURL+TNLAdditions.m in Sources */,
+				8B9EBDD42135B4B100E6E466 /* NSNumber+TNLURLCoding.m in Sources */,
+				8B9EBDD52135B4B100E6E466 /* NSOperationQueue+TNLSafety.m in Sources */,
+				8B9EBDD62135B4B100E6E466 /* TNLAttemptMetrics.m in Sources */,
+				8B9EBDD72135B4B100E6E466 /* TNLCommunicationAgent.m in Sources */,
+				8B9EBDD82135B4B100E6E466 /* TNLTemporaryFile.m in Sources */,
+				8B9EBDD92135B4B100E6E466 /* TNLRequestOperationQueue.m in Sources */,
+				8B9EBDDA2135B4B100E6E466 /* TNLHTTP.m in Sources */,
+				8B9EBDDB2135B4B100E6E466 /* TNLError.m in Sources */,
+				8B9EBDDC2135B4B100E6E466 /* NSURLCache+TNLAdditions.m in Sources */,
+				8B9EBDDD2135B4B100E6E466 /* NSURLCredentialStorage+TNLAdditions.m in Sources */,
+				8B9EBDDE2135B4B100E6E466 /* TNL_Project.m in Sources */,
+				8B9EBDDF2135B4B100E6E466 /* NSHTTPCookieStorage+TNLAdditions.m in Sources */,
+				8B9EBDE02135B4B100E6E466 /* TNLBackgroundURLSessionTaskOperationManager.m in Sources */,
+				8B9EBDE12135B4B100E6E466 /* TNLTimeoutOperation.m in Sources */,
+				8B9EBDE22135B4B100E6E466 /* TNLRequestOperationCancelSource.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8BDFFC0019814D3100F7F670 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1421,6 +2062,87 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		8BFDF90D2135AB2C002F6A80 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8BFDF90E2135AB2C002F6A80 /* NSURLResponse+TNLAdditions.m in Sources */,
+				8BFDF90F2135AB2C002F6A80 /* TNLRequestOperation.m in Sources */,
+				8BFDF9102135AB2C002F6A80 /* TNLAttemptMetaData.m in Sources */,
+				8BFDF9112135AB2C002F6A80 /* NSURLRequest+TNLAdditions.m in Sources */,
+				8BFDF9122135AB2C002F6A80 /* NSURLSessionTaskMetrics+TNLAdditions.m in Sources */,
+				8BFDF9132135AB2C002F6A80 /* TNLURLCoding.m in Sources */,
+				8BFDF9142135AB2C002F6A80 /* NSURLSessionConfiguration+TNLAdditions.m in Sources */,
+				8BFDF9152135AB2C002F6A80 /* TNLHTTPRequest.m in Sources */,
+				8BFDF9162135AB2C002F6A80 /* TNLTiming.m in Sources */,
+				8BFDF9172135AB2C002F6A80 /* TNLURLSessionManager.m in Sources */,
+				8BFDF9182135AB2C002F6A80 /* TNLNetwork.m in Sources */,
+				8BFDF9192135AB2C002F6A80 /* TNLRequestConfiguration.m in Sources */,
+				8BFDF91A2135AB2C002F6A80 /* NSData+TNLAdditions.m in Sources */,
+				8BFDF91B2135AB2C002F6A80 /* TNLGlobalConfiguration.m in Sources */,
+				8BFDF91C2135AB2C002F6A80 /* TNLRequestRetryPolicyConfiguration.m in Sources */,
+				8BFDF91D2135AB2C002F6A80 /* TNLResponse.m in Sources */,
+				8BFDF91E2135AB2C002F6A80 /* TNLURLStringCoding.m in Sources */,
+				8BFDF91F2135AB2C002F6A80 /* TNLSimpleRequestDelegate.m in Sources */,
+				8BFDF9202135AB2C002F6A80 /* TNLSafeOperation.m in Sources */,
+				8BFDF9212135AB2C002F6A80 /* TNLURLSessionTaskOperation.m in Sources */,
+				8BFDF9222135AB2C002F6A80 /* NSDictionary+TNLAdditions.m in Sources */,
+				8BFDF9232135AB2C002F6A80 /* NSCachedURLResponse+TNLAdditions.m in Sources */,
+				8BFDF9242135AB2C002F6A80 /* TNLLRUCache.m in Sources */,
+				8BFDF9252135AB2C002F6A80 /* TNLParameterCollection.m in Sources */,
+				8BFDF9262135AB2C002F6A80 /* TNLPseudoURLProtocol.m in Sources */,
+				8BFDF9272135AB2C002F6A80 /* TNL_ProjectCommon.m in Sources */,
+				8BFDF9282135AB2C002F6A80 /* TNLPriority.m in Sources */,
+				8BFDF9292135AB2C002F6A80 /* TNLRequest.m in Sources */,
+				8BFDF92A2135AB2C002F6A80 /* NSURL+TNLAdditions.m in Sources */,
+				8BFDF92B2135AB2C002F6A80 /* NSNumber+TNLURLCoding.m in Sources */,
+				8BFDF92C2135AB2C002F6A80 /* NSOperationQueue+TNLSafety.m in Sources */,
+				8BFDF92D2135AB2C002F6A80 /* TNLAttemptMetrics.m in Sources */,
+				8BFDF92E2135AB2C002F6A80 /* TNLCommunicationAgent.m in Sources */,
+				8BFDF92F2135AB2C002F6A80 /* TNLTemporaryFile.m in Sources */,
+				8BFDF9302135AB2C002F6A80 /* TNLRequestOperationQueue.m in Sources */,
+				8BFDF9312135AB2C002F6A80 /* TNLHTTP.m in Sources */,
+				8BFDF9322135AB2C002F6A80 /* TNLError.m in Sources */,
+				8BFDF9332135AB2C002F6A80 /* NSURLCache+TNLAdditions.m in Sources */,
+				8BFDF9342135AB2C002F6A80 /* NSURLCredentialStorage+TNLAdditions.m in Sources */,
+				8BFDF9352135AB2C002F6A80 /* TNL_Project.m in Sources */,
+				8BFDF9362135AB2C002F6A80 /* NSHTTPCookieStorage+TNLAdditions.m in Sources */,
+				8BFDF9372135AB2C002F6A80 /* TNLBackgroundURLSessionTaskOperationManager.m in Sources */,
+				8BFDF9382135AB2C002F6A80 /* TNLTimeoutOperation.m in Sources */,
+				8BFDF9392135AB2C002F6A80 /* TNLRequestOperationCancelSource.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8BFDF9922135ACDB002F6A80 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8BFDF9932135ACDB002F6A80 /* TNLResponseTest.m in Sources */,
+				8BFDF9942135ACDB002F6A80 /* TNLXImageSupport.m in Sources */,
+				8BFDF9952135ACDB002F6A80 /* TNLHTTPTests.m in Sources */,
+				8BFDF9962135ACDB002F6A80 /* TNLRequestOperationQueueTest.m in Sources */,
+				8BFDF9972135ACDB002F6A80 /* TNLRequestTests.m in Sources */,
+				8BFDF9982135ACDB002F6A80 /* TNLTemporaryFileTest.m in Sources */,
+				8BFDF9992135ACDB002F6A80 /* TNLParameterCollectionTests.m in Sources */,
+				8BFDF99A2135ACDB002F6A80 /* TNLRequestOperationTest.m in Sources */,
+				8BFDF99B2135ACDB002F6A80 /* NSURLCache+TNLAdditionsTest.m in Sources */,
+				8BFDF99C2135ACDB002F6A80 /* NSURLSessionConfiguration+TNLAdditionsTest.m in Sources */,
+				8BFDF99D2135ACDB002F6A80 /* TNLXMultipartFormData.m in Sources */,
+				8BFDF99E2135ACDB002F6A80 /* TNLRequestRetryPolicyConfigurationTest.m in Sources */,
+				8BFDF99F2135ACDB002F6A80 /* TNLPseudoRequestOperationTest.m in Sources */,
+				8BFDF9A02135ACDB002F6A80 /* TNLAutoDependencyTest.m in Sources */,
+				8BFDF9A12135ACDB002F6A80 /* NSDictionary+TNLAdditionsTest.m in Sources */,
+				8BFDF9A22135ACDB002F6A80 /* TNLURLCodingTest.m in Sources */,
+				8BFDF9A32135ACDB002F6A80 /* TNLRequestConfigurationTest.m in Sources */,
+				8BFDF9A42135ACDB002F6A80 /* NSOperationQueue+TNLSafetyTest.m in Sources */,
+				8BFDF9A52135ACDB002F6A80 /* TNLAttemptMetaDataTest.m in Sources */,
+				8BFDF9A62135ACDB002F6A80 /* TNLContentEncodingTests.m in Sources */,
+				8BFDF9A72135ACDB002F6A80 /* TNLXContentEncoding.m in Sources */,
+				8BFDF9A82135ACDB002F6A80 /* TNLRequestRetryPolicyTest.m in Sources */,
+				8BFDF9A92135ACDB002F6A80 /* TNLNetworkTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BF4AA0C11EE61D46001647B5 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1515,6 +2237,11 @@
 			target = 8BE402C51946743D00C7241E /* TwitterNetworkLayer */;
 			targetProxy = 8B600B9A1CB46D290079C116 /* PBXContainerItemProxy */;
 		};
+		8B9EBDB42135B2D700E6E466 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8BFDF90C2135AB2C002F6A80 /* TwitterNetworkLayer tvOS */;
+			targetProxy = 8B9EBDB32135B2D700E6E466 /* PBXContainerItemProxy */;
+		};
 		BF4765F91EEEFC5B00A23506 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = BF4AA0C01EE61D46001647B5 /* TwitterNetworkLayer macOS */;
@@ -1550,6 +2277,32 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		8B9EBE342135B4B100E6E466 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_MODULES_AUTOLINK = NO;
+				DEFINES_MODULE = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = com.twitter.TwitterNetworkLayer;
+				PRODUCT_NAME = TwitterNetworkLayer;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		8B9EBE352135B4B100E6E466 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_MODULES_AUTOLINK = NO;
+				DEFINES_MODULE = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = com.twitter.TwitterNetworkLayer;
+				PRODUCT_NAME = TwitterNetworkLayer;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
 		8BDFFC3219814D3100F7F670 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1558,9 +2311,6 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -1576,7 +2326,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.twitter.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "";
+				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -1589,10 +2339,7 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
-				DEVELOPMENT_TEAM = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = "TNLExample/TNLExample-Info.plist";
@@ -1604,7 +2351,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.twitter.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "";
+				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
@@ -1639,11 +2386,11 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 2.2;
 				DEAD_CODE_STRIPPING = NO;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = $CURRENT_PROJECT_VERSION;
+				DYLIB_CURRENT_VERSION = "$(CURRENT_PROJECT_VERSION)";
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -1664,11 +2411,13 @@
 				GCC_WARN_UNUSED_LABEL = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
 				STRIP_INSTALLED_PRODUCT = NO;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Debug;
 		};
@@ -1702,10 +2451,10 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 2.2;
 				DEAD_CODE_STRIPPING = NO;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = $CURRENT_PROJECT_VERSION;
+				DYLIB_CURRENT_VERSION = "$(CURRENT_PROJECT_VERSION)";
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -1723,11 +2472,13 @@
 				GCC_WARN_UNUSED_LABEL = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
 				STRIP_INSTALLED_PRODUCT = NO;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;
 		};
@@ -1736,11 +2487,11 @@
 			buildSettings = {
 				CLANG_MODULES_AUTOLINK = NO;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twitter.TwitterNetworkLayer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -1749,18 +2500,17 @@
 			buildSettings = {
 				CLANG_MODULES_AUTOLINK = NO;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twitter.TwitterNetworkLayer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
 		8BE402ED1946743E00C7241E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				INFOPLIST_FILE = "TwitterNetworkLayerTests/TwitterNetworkLayerTests-Info.plist";
 				OTHER_LDFLAGS = (
@@ -1769,6 +2519,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.twitter.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = xctest;
 			};
 			name = Debug;
@@ -1776,7 +2527,6 @@
 		8BE402EE1946743E00C7241E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				INFOPLIST_FILE = "TwitterNetworkLayerTests/TwitterNetworkLayerTests-Info.plist";
 				ONLY_ACTIVE_ARCH = YES;
@@ -1786,6 +2536,66 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.twitter.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Release;
+		};
+		8BFDF98B2135AB2C002F6A80 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_MODULES_AUTOLINK = NO;
+				DEFINES_MODULE = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = com.twitter.TwitterNetworkLayer;
+				PRODUCT_NAME = TwitterNetworkLayer;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		8BFDF98C2135AB2C002F6A80 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_MODULES_AUTOLINK = NO;
+				DEFINES_MODULE = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = com.twitter.TwitterNetworkLayer;
+				PRODUCT_NAME = TwitterNetworkLayer;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		8BFDF9BB2135ACDB002F6A80 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				INFOPLIST_FILE = "TwitterNetworkLayerTests/TwitterNetworkLayerTests-Info.plist";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-Wl,-U,_CLSLog",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.twitter.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Debug;
+		};
+		8BFDF9BC2135ACDB002F6A80 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				INFOPLIST_FILE = "TwitterNetworkLayerTests/TwitterNetworkLayerTests-Info.plist";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-Wl,-U,_CLSLog",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.twitter.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
 				WRAPPER_EXTENSION = xctest;
 			};
 			name = Release;
@@ -1795,12 +2605,10 @@
 			buildSettings = {
 				CLANG_MODULES_AUTOLINK = NO;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twitter.TwitterNetworkLayer;
 				PRODUCT_NAME = TwitterNetworkLayer;
-				RESOURCES_TARGETED_DEVICE_FAMILY = "";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 			};
@@ -1811,12 +2619,10 @@
 			buildSettings = {
 				CLANG_MODULES_AUTOLINK = NO;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twitter.TwitterNetworkLayer;
 				PRODUCT_NAME = TwitterNetworkLayer;
-				RESOURCES_TARGETED_DEVICE_FAMILY = "";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 			};
@@ -1825,7 +2631,6 @@
 		BF4AA1681EE626ED001647B5 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				INFOPLIST_FILE = "TwitterNetworkLayerTests/TwitterNetworkLayerTests-Info.plist";
 				OTHER_LDFLAGS = (
@@ -1842,7 +2647,6 @@
 		BF4AA1691EE626ED001647B5 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				INFOPLIST_FILE = "TwitterNetworkLayerTests/TwitterNetworkLayerTests-Info.plist";
 				ONLY_ACTIVE_ARCH = YES;
@@ -1860,6 +2664,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		8B9EBE332135B4B100E6E466 /* Build configuration list for PBXNativeTarget "TwitterNetworkLayer watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8B9EBE342135B4B100E6E466 /* Debug */,
+				8B9EBE352135B4B100E6E466 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		8BDFFC3719814D3100F7F670 /* Build configuration list for PBXNativeTarget "TNLExample" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -1892,6 +2705,24 @@
 			buildConfigurations = (
 				8BE402ED1946743E00C7241E /* Debug */,
 				8BE402EE1946743E00C7241E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8BFDF98A2135AB2C002F6A80 /* Build configuration list for PBXNativeTarget "TwitterNetworkLayer tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8BFDF98B2135AB2C002F6A80 /* Debug */,
+				8BFDF98C2135AB2C002F6A80 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8BFDF9BA2135ACDB002F6A80 /* Build configuration list for PBXNativeTarget "TwitterNetworkLayerTests tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8BFDF9BB2135ACDB002F6A80 /* Debug */,
+				8BFDF9BC2135ACDB002F6A80 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/TwitterNetworkLayer.xcodeproj/project.pbxproj
+++ b/TwitterNetworkLayer.xcodeproj/project.pbxproj
@@ -197,6 +197,8 @@
 		8BF953E31A67E73E00E9C1AA /* TNLAttemptMetrics_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BF953E11A67E73E00E9C1AA /* TNLAttemptMetrics_Project.h */; };
 		8BFDF958199ADF4300248C3D /* NSURLSessionConfiguration+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BFDF956199ADF4300248C3D /* NSURLSessionConfiguration+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8BFDF959199ADF4300248C3D /* NSURLSessionConfiguration+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BFDF957199ADF4300248C3D /* NSURLSessionConfiguration+TNLAdditions.m */; };
+		8BFE79DA213076E600E3B2AD /* TNLRequestRetryPolicyTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BFE79D9213076E600E3B2AD /* TNLRequestRetryPolicyTest.m */; };
+		8BFE79DB21308A7B00E3B2AD /* TNLRequestRetryPolicyTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BFE79D9213076E600E3B2AD /* TNLRequestRetryPolicyTest.m */; };
 		8BFF0A1D19FF32D1001F42B7 /* NSDictionary+TNLAdditionsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BFF0A1C19FF32D1001F42B7 /* NSDictionary+TNLAdditionsTest.m */; };
 		8BFF0A6319FFEFED001F42B7 /* NSURLSessionConfiguration+TNLAdditionsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BFF0A6219FFEFED001F42B7 /* NSURLSessionConfiguration+TNLAdditionsTest.m */; };
 		B3B9EA031C3AF02100B8A451 /* module.modulemap in Headers */ = {isa = PBXBuildFile; fileRef = B3B9E9FE1C3AEDE700B8A451 /* module.modulemap */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -603,6 +605,7 @@
 		8BF953E11A67E73E00E9C1AA /* TNLAttemptMetrics_Project.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TNLAttemptMetrics_Project.h; sourceTree = "<group>"; };
 		8BFDF956199ADF4300248C3D /* NSURLSessionConfiguration+TNLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURLSessionConfiguration+TNLAdditions.h"; sourceTree = "<group>"; };
 		8BFDF957199ADF4300248C3D /* NSURLSessionConfiguration+TNLAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURLSessionConfiguration+TNLAdditions.m"; sourceTree = "<group>"; };
+		8BFE79D9213076E600E3B2AD /* TNLRequestRetryPolicyTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TNLRequestRetryPolicyTest.m; sourceTree = "<group>"; };
 		8BFF0A1C19FF32D1001F42B7 /* NSDictionary+TNLAdditionsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+TNLAdditionsTest.m"; sourceTree = "<group>"; };
 		8BFF0A6219FFEFED001F42B7 /* NSURLSessionConfiguration+TNLAdditionsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURLSessionConfiguration+TNLAdditionsTest.m"; sourceTree = "<group>"; };
 		B3B9E9FE1C3AEDE700B8A451 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
@@ -957,6 +960,7 @@
 				8B8FA3331AF426B200BC91DF /* TNLRequestOperationQueueTest.m */,
 				8B84348B1A13BF3C00D006DA /* TNLRequestOperationTest.m */,
 				8B4CBEA81A169A6800230318 /* TNLRequestRetryPolicyConfigurationTest.m */,
+				8BFE79D9213076E600E3B2AD /* TNLRequestRetryPolicyTest.m */,
 				8B23E00C19FFF799007C1E35 /* TNLRequestTests.m */,
 				8B8434891A13B8E500D006DA /* TNLResponseTest.m */,
 				8B227B831A004F97003B1C7C /* TNLTemporaryFileTest.m */,
@@ -1412,6 +1416,7 @@
 				5C7E65751B0298670037AD91 /* TNLAttemptMetaDataTest.m in Sources */,
 				8B6E34271DE35F71004A35C7 /* TNLContentEncodingTests.m in Sources */,
 				8B6E342A1DE35FCD004A35C7 /* TNLXContentEncoding.m in Sources */,
+				8BFE79DA213076E600E3B2AD /* TNLRequestRetryPolicyTest.m in Sources */,
 				8B8A684319FF13F0008623E8 /* TNLNetworkTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1492,6 +1497,7 @@
 				BF4AA1541EE626ED001647B5 /* TNLAttemptMetaDataTest.m in Sources */,
 				BF4AA1551EE626ED001647B5 /* TNLContentEncodingTests.m in Sources */,
 				BF4AA1561EE626ED001647B5 /* TNLXContentEncoding.m in Sources */,
+				8BFE79DB21308A7B00E3B2AD /* TNLRequestRetryPolicyTest.m in Sources */,
 				BF4AA1571EE626ED001647B5 /* TNLNetworkTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1563,7 +1569,6 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = "TNLExample/TNLExample-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -1591,7 +1596,6 @@
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = "TNLExample/TNLExample-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
@@ -1636,7 +1640,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 2.0;
+				CURRENT_PROJECT_VERSION = 2.2;
 				DEAD_CODE_STRIPPING = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = $CURRENT_PROJECT_VERSION;
@@ -1659,7 +1663,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_LABEL = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -1698,7 +1702,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CURRENT_PROJECT_VERSION = 2.0;
+				CURRENT_PROJECT_VERSION = 2.2;
 				DEAD_CODE_STRIPPING = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = $CURRENT_PROJECT_VERSION;
@@ -1718,7 +1722,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_LABEL = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
@@ -1734,7 +1738,6 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.twitter.TwitterNetworkLayer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1748,7 +1751,6 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.twitter.TwitterNetworkLayer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1761,7 +1763,6 @@
 				APPLICATION_EXTENSION_API_ONLY = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				INFOPLIST_FILE = "TwitterNetworkLayerTests/TwitterNetworkLayerTests-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-Wl,-U,_CLSLog",
@@ -1778,7 +1779,6 @@
 				APPLICATION_EXTENSION_API_ONLY = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				INFOPLIST_FILE = "TwitterNetworkLayerTests/TwitterNetworkLayerTests-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -1797,7 +1797,6 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twitter.TwitterNetworkLayer;
 				PRODUCT_NAME = TwitterNetworkLayer;
@@ -1814,7 +1813,6 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twitter.TwitterNetworkLayer;
 				PRODUCT_NAME = TwitterNetworkLayer;
@@ -1830,7 +1828,6 @@
 				APPLICATION_EXTENSION_API_ONLY = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				INFOPLIST_FILE = "TwitterNetworkLayerTests/TwitterNetworkLayerTests-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-Wl,-U,_CLSLog",
@@ -1848,7 +1845,6 @@
 				APPLICATION_EXTENSION_API_ONLY = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				INFOPLIST_FILE = "TwitterNetworkLayerTests/TwitterNetworkLayerTests-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
 					"$(inherited)",

--- a/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer tvOS.xcscheme
+++ b/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer tvOS.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0940"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8BFDF90C2135AB2C002F6A80"
+               BuildableName = "TwitterNetworkLayer.framework"
+               BlueprintName = "TwitterNetworkLayer tvOS"
+               ReferencedContainer = "container:TwitterNetworkLayer.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8BFDF98F2135ACDB002F6A80"
+               BuildableName = "TwitterNetworkLayerTests tvOS.xctest"
+               BlueprintName = "TwitterNetworkLayerTests tvOS"
+               ReferencedContainer = "container:TwitterNetworkLayer.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8BFDF90C2135AB2C002F6A80"
+            BuildableName = "TwitterNetworkLayer.framework"
+            BlueprintName = "TwitterNetworkLayer tvOS"
+            ReferencedContainer = "container:TwitterNetworkLayer.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8BFDF90C2135AB2C002F6A80"
+            BuildableName = "TwitterNetworkLayer.framework"
+            BlueprintName = "TwitterNetworkLayer tvOS"
+            ReferencedContainer = "container:TwitterNetworkLayer.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8BFDF90C2135AB2C002F6A80"
+            BuildableName = "TwitterNetworkLayer.framework"
+            BlueprintName = "TwitterNetworkLayer tvOS"
+            ReferencedContainer = "container:TwitterNetworkLayer.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer watchOS.xcscheme
+++ b/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer watchOS.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0940"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8B9EBDB52135B4B100E6E466"
+               BuildableName = "TwitterNetworkLayer.framework"
+               BlueprintName = "TwitterNetworkLayer watchOS"
+               ReferencedContainer = "container:TwitterNetworkLayer.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8B9EBDB52135B4B100E6E466"
+            BuildableName = "TwitterNetworkLayer.framework"
+            BlueprintName = "TwitterNetworkLayer watchOS"
+            ReferencedContainer = "container:TwitterNetworkLayer.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8B9EBDB52135B4B100E6E466"
+            BuildableName = "TwitterNetworkLayer.framework"
+            BlueprintName = "TwitterNetworkLayer watchOS"
+            ReferencedContainer = "container:TwitterNetworkLayer.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8B9EBDB52135B4B100E6E466"
+            BuildableName = "TwitterNetworkLayer.framework"
+            BlueprintName = "TwitterNetworkLayer watchOS"
+            ReferencedContainer = "container:TwitterNetworkLayer.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/TwitterNetworkLayerTests/NSOperationQueue+TNLSafetyTest.m
+++ b/TwitterNetworkLayerTests/NSOperationQueue+TNLSafetyTest.m
@@ -9,6 +9,7 @@
 #include <stdatomic.h>
 
 #import "NSOperationQueue+TNLSafety.h"
+#import "TNLSafeOperation.h"
 
 @import XCTest;
 
@@ -17,7 +18,7 @@
 + (nullable instancetype)operationSafetyGuard;
 @end
 
-@interface TestAsyncOperation : NSOperation
+@interface TestAsyncOperation : TNLSafeOperation
 @property (nonatomic, copy) dispatch_block_t block;
 @property (atomic, getter=isExecuting) BOOL executing;
 @property (atomic, getter=isFinished) BOOL finished;

--- a/TwitterNetworkLayerTests/NSURLCache+TNLAdditionsTest.m
+++ b/TwitterNetworkLayerTests/NSURLCache+TNLAdditionsTest.m
@@ -72,6 +72,7 @@
     });
 
     NSString *path = [NSTemporaryDirectory() stringByAppendingPathComponent:NSStringFromSelector(_cmd)];
+    [[NSFileManager defaultManager] removeItemAtPath:path error:NULL];
     NSURLCache *cache = [[NSURLCache alloc] initWithMemoryCapacity:1024*1024*10 diskCapacity:1024*1024*10 diskPath:path];
     [cache removeAllCachedResponses];
     [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:2.5]]; // give cache time to purge
@@ -82,10 +83,10 @@
 
     TNLResponse *response = nil;
     TNLMutableRequestConfiguration *config = [TNLMutableRequestConfiguration defaultConfiguration];
-    config.cachePolicy = NSURLRequestReturnCacheDataElseLoad;
     config.URLCache = cache;
     config.protocolOptions = TNLRequestProtocolOptionPseudo;
 
+    config.cachePolicy = NSURLRequestReturnCacheDataElseLoad;
     response = [[self class] GETResponseWithURL:URL config:config];
     XCTAssertEqualObjects(response.info.data, body);
     XCTAssertEqual(response.info.source, TNLResponseSourceNetworkRequest);
@@ -98,6 +99,21 @@
     response = [[self class] GETResponseWithURL:URL config:config];
     XCTAssertEqualObjects(response.info.data, body);
     XCTAssertEqual(response.info.source, TNLResponseSourceNetworkRequest);
+
+#if TARGET_OS_OSX
+    // macOS has no way to clear the NSURLCache disk cache via API
+    // clearing the cache from disk can be done, but corrupts the sqlite db
+    // radar://43799833
+    return;
+#endif
+
+    if (tnl_available_ios_10) {
+        // ok
+    } else {
+        // just like macOS, iOS and tvOS on iOS 9 and lower cannot clear their disk cache
+        return;
+    }
+
     [cache removeAllCachedResponses];
     [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:2.5]]; // give cache time to purge
 

--- a/TwitterNetworkLayerTests/NSURLCache+TNLAdditionsTest.m
+++ b/TwitterNetworkLayerTests/NSURLCache+TNLAdditionsTest.m
@@ -175,13 +175,8 @@
     });
     response = [[self class] GETResponseWithURL:URL config:config];
 
-    if (@available(macOS 10.10, iOS 8, tvOS 9, watchOS 2, *)) {
-        // modern OSes with TNL will use demuxing to avoid spinning up multiple sessions
-        XCTAssertEqual(originalSpinUpCount, self.spinUps);
-    } else {
-        // legacy OSes with TNL cannot demuxing and will have a session per cache instance
-        XCTAssertLessThan(originalSpinUpCount, self.spinUps);
-    }
+    // TNL will use demuxing to avoid spinning up multiple sessions
+    XCTAssertEqual(originalSpinUpCount, self.spinUps);
 }
 
 - (void)_didSpinUpSession:(NSNotification *)note

--- a/TwitterNetworkLayerTests/NSURLSessionConfiguration+TNLAdditionsTest.m
+++ b/TwitterNetworkLayerTests/NSURLSessionConfiguration+TNLAdditionsTest.m
@@ -20,25 +20,9 @@
 {
     NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
 
-    XCTAssertEqual([config respondsToSelector:@selector(setSharedContainerIdentifier:)], [NSURLSessionConfiguration tnl_supportsSharedContainerIdentifier]);
-
-    if (![config respondsToSelector:@selector(setSharedContainerIdentifier:)]) {
-
-        // iOS 7
-
-        XCTAssertNotEqualObjects(config.URLCache, config.URLCache);
-        XCTAssertNotEqualObjects(config.URLCredentialStorage, config.URLCredentialStorage);
-        XCTAssertNotEqualObjects(config.HTTPCookieStorage, config.HTTPCookieStorage);
-    } else {
-
-        // iOS 8+
-
-        XCTAssertEqualObjects(config.URLCache, config.URLCache);
-        XCTAssertEqualObjects(config.URLCredentialStorage, config.URLCredentialStorage);
-        XCTAssertEqualObjects(config.HTTPCookieStorage, config.HTTPCookieStorage);
-    }
-
-    [NSURLSessionConfiguration tnl_cementConfiguration:config];
+    XCTAssertEqualObjects(config.URLCache, config.URLCache);
+    XCTAssertEqualObjects(config.URLCredentialStorage, config.URLCredentialStorage);
+    XCTAssertEqualObjects(config.HTTPCookieStorage, config.HTTPCookieStorage);
 
     XCTAssertEqualObjects(config.URLCache, config.URLCache);
     XCTAssertEqualObjects(config.URLCredentialStorage, config.URLCredentialStorage);

--- a/TwitterNetworkLayerTests/TNLNetworkTests.m
+++ b/TwitterNetworkLayerTests/TNLNetworkTests.m
@@ -36,31 +36,31 @@
 
     incrementExpectation = [self _incrementExpectation];
     [TNLNetwork incrementExecutingNetworkConnections];
-    [self waitForExpectationsWithTimeout:5.0 handler:NULL];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
     decrementExpectation = [self _decrementExpectation];
     [TNLNetwork decrementExecutingNetworkConnections];
-    [self waitForExpectationsWithTimeout:5.0 handler:NULL];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
     incrementExpectation = [self _incrementExpectation];
     for (NSUInteger i = 0; i < 5; i++) {
         [TNLNetwork incrementExecutingNetworkConnections];
     }
-    [self waitForExpectationsWithTimeout:5.0 handler:NULL];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
     decrementExpectation = [self _decrementExpectation];
     for (NSUInteger i = 0; i < 5; i++) {
         [TNLNetwork decrementExecutingNetworkConnections];
     }
-    [self waitForExpectationsWithTimeout:5.0 handler:NULL];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
     incrementExpectation = [self _incrementExpectation];
     [TNLNetwork incrementExecutingNetworkConnections];
-    [self waitForExpectationsWithTimeout:5.0 handler:NULL];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
     decrementExpectation = [self _decrementExpectation];
     [TNLNetwork decrementExecutingNetworkConnections];
-    [self waitForExpectationsWithTimeout:5.0 handler:NULL];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
     (void)incrementExpectation;
     (void)decrementExpectation;

--- a/TwitterNetworkLayerTests/TNLParameterCollectionTests.m
+++ b/TwitterNetworkLayerTests/TNLParameterCollectionTests.m
@@ -561,7 +561,7 @@ static void TestSwizzle(Class cls, SEL originalSelector, SEL swizzledSelector)
     [params addParametersFromDictionary:dict withFormattingMode:TNLParameterCollectionAddParametersFromDictionaryModeJSONEncoded combineRepeatingKeys:NO forKey:@"dict"];
     encodedString = [params stableURLEncodedStringValue];
 
-    if (@available(iOS 11.0, macos 10.13, watchos 4.0, tvos 11.0, *)) {
+    if (tnl_available_ios_11) {
         // will be sorted
         XCTAssertEqualObjects(encodedString, @"dict=%7B%22key1%22%3A%22value1%22%2C%22key2%22%3A%22value2%22%2C%22key3%22%3A%22value3%22%7D");
     } else {

--- a/TwitterNetworkLayerTests/TNLPseudoRequestOperationTest.m
+++ b/TwitterNetworkLayerTests/TNLPseudoRequestOperationTest.m
@@ -105,7 +105,7 @@ static NSData *sData;
     XCTAssertEqual(op.state, TNLRequestOperationStateIdle);
 
     [sQueue enqueueRequestOperation:op];
-    [self waitForExpectationsWithTimeout:5.0 handler:NULL];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
     XCTAssertFalse(op.isCancelled);
     XCTAssertFalse(op.isExecuting);
@@ -155,7 +155,7 @@ static NSData *sData;
     [sQueue enqueueRequestOperation:op];
     [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.1]];
     [sQueue resume];
-    [self waitForExpectationsWithTimeout:5.0 handler:NULL];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
     XCTAssertFalse(op.isCancelled);
     XCTAssertFalse(op.isExecuting);
@@ -204,7 +204,7 @@ static NSData *sData;
     XCTAssertEqual(op.state, TNLRequestOperationStateIdle);
 
     [sQueue enqueueRequestOperation:op];
-    [self waitForExpectationsWithTimeout:5.0 handler:NULL];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
     XCTAssertFalse(op.isCancelled);
     XCTAssertFalse(op.isExecuting);
@@ -254,7 +254,7 @@ static NSData *sData;
     XCTAssertEqual(op.state, TNLRequestOperationStateIdle);
 
     [sQueue enqueueRequestOperation:op];
-    [self waitForExpectationsWithTimeout:5.0 handler:NULL];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
     XCTAssertFalse(op.isCancelled);
     XCTAssertFalse(op.isExecuting);
@@ -303,7 +303,7 @@ static NSData *sData;
     XCTAssertEqual(op.state, TNLRequestOperationStateIdle);
 
     [sQueue enqueueRequestOperation:op];
-    [self waitForExpectationsWithTimeout:5.0 handler:NULL];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
     XCTAssertFalse(op.isCancelled);
     XCTAssertFalse(op.isExecuting);
@@ -354,7 +354,7 @@ static NSData *sData;
     XCTAssertEqual(op.state, TNLRequestOperationStateIdle);
 
     [sQueue enqueueRequestOperation:op];
-    [self waitForExpectationsWithTimeout:5.0 handler:NULL];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
     XCTAssertFalse(op.isCancelled);
     XCTAssertFalse(op.isExecuting);
@@ -404,7 +404,7 @@ static NSData *sData;
     XCTAssertEqual(op.state, TNLRequestOperationStateIdle);
 
     [sQueue enqueueRequestOperation:op];
-    [self waitForExpectationsWithTimeout:5.0 handler:NULL];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
     XCTAssertFalse(op.isCancelled);
     XCTAssertFalse(op.isExecuting);
@@ -453,7 +453,7 @@ static NSData *sData;
     XCTAssertEqual(op.state, TNLRequestOperationStateIdle);
 
     [sQueue enqueueRequestOperation:op];
-    [self waitForExpectationsWithTimeout:5.0 handler:NULL];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
     XCTAssertFalse(op.isCancelled);
     XCTAssertFalse(op.isExecuting);
@@ -503,7 +503,7 @@ static NSData *sData;
     XCTAssertEqual(op.state, TNLRequestOperationStateIdle);
 
     [sQueue enqueueRequestOperation:op];
-    [self waitForExpectationsWithTimeout:5.0 handler:NULL];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
     XCTAssertFalse(op.isCancelled);
     XCTAssertFalse(op.isExecuting);
@@ -552,7 +552,7 @@ static NSData *sData;
     XCTAssertEqual(op.state, TNLRequestOperationStateIdle);
 
     [sQueue enqueueRequestOperation:op];
-    [self waitForExpectationsWithTimeout:5.0 handler:NULL];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
     XCTAssertFalse(op.isCancelled);
     XCTAssertFalse(op.isExecuting);
@@ -592,7 +592,7 @@ static NSData *sData;
     XCTAssertEqual(op.state, TNLRequestOperationStateIdle);
 
     [sQueue enqueueRequestOperation:op];
-    [self waitForExpectationsWithTimeout:5.0 handler:NULL];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
     XCTAssertFalse(op.isCancelled);
     XCTAssertFalse(op.isExecuting);
@@ -647,7 +647,7 @@ static NSData *sData;
     [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.5]];
     [op cancelWithSource:@"FORCE_CANCEL_SOURCE"];
 
-    [self waitForExpectationsWithTimeout:5.0 handler:NULL];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
     XCTAssertTrue(op.isCancelled);
     XCTAssertFalse(op.isExecuting);
@@ -688,7 +688,7 @@ static NSData *sData;
     [op cancelWithSource:@"FORCE_CANCEL_SOURCE"];
     [sQueue enqueueRequestOperation:op];
 
-    [self waitForExpectationsWithTimeout:5.0 handler:NULL];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
     XCTAssertTrue(op.isCancelled);
     XCTAssertFalse(op.isExecuting);
@@ -729,7 +729,7 @@ static NSData *sData;
     [sQueue enqueueRequestOperation:op];
     [op cancelWithSource:@"FORCE_CANCEL_SOURCE"];
 
-    [self waitForExpectationsWithTimeout:5.0 handler:NULL];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
     XCTAssertTrue(op.isCancelled);
     XCTAssertFalse(op.isExecuting);

--- a/TwitterNetworkLayerTests/TNLRequestConfigurationTest.m
+++ b/TwitterNetworkLayerTests/TNLRequestConfigurationTest.m
@@ -10,6 +10,7 @@
 #import "NSURLCache+TNLAdditions.h"
 #import "NSURLCredentialStorage+TNLAdditions.h"
 #import "NSURLSessionConfiguration+TNLAdditions.h"
+#import "TNL_Project.h"
 #import "TNLGlobalConfiguration.h"
 #import "TNLRequestConfiguration_Project.h"
 
@@ -61,7 +62,7 @@
     [self runTestParamsEqualBetweenOriginal:params roundTrip:roundTripParams];
     XCTAssertEqualObjects(roundTripConfig, config);
 
-    if (@available(iOS 11, *)) {
+    if (tnl_available_multipath_service_type) {
         config.multipathServiceType = NSURLSessionMultipathServiceTypeInteractive;
 #if TARGET_OS_IOS
         testParamString = @"aca=1&atmpTO=60&ckiplcy=1&cnvty=0&dfrI=0&dis=0&idlTO=30&mptcp=2&nst=0&opTO=180&ptcls=0&rcp=0&rdcm=1&rdp=1&setcki=0&ssle=1";
@@ -99,12 +100,7 @@
     config.shouldSetCookies = NO;
     config.cookieAcceptPolicy = NSHTTPCookieAcceptPolicyNever;
 
-    if ([NSURLSessionConfiguration tnl_supportsSharedContainerIdentifier]) {
-        XCTAssertNotNil(config.sharedContainerIdentifier);
-    } else {
-        XCTAssertNil(config.sharedContainerIdentifier);
-    }
-
+    XCTAssertNotNil(config.sharedContainerIdentifier);
     XCTAssertEqualObjects(config, [config copy]);
 
     params = TNLMutableParametersFromRequestConfiguration(config, nil, nil, nil);

--- a/TwitterNetworkLayerTests/TNLRequestConfigurationTest.m
+++ b/TwitterNetworkLayerTests/TNLRequestConfigurationTest.m
@@ -51,7 +51,7 @@
     roundTripParams = [[TNLParameterCollection alloc] initWithURLEncodedString:paramString options:0];
     roundTripConfig = (id)[TNLRequestConfiguration configurationFromParameters:params executionMode:config.executionMode version:[TNLGlobalConfiguration version]];
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IPHONE // == IOS + WATCH + TV
     testParamString = @"aca=1&atmpTO=60&ckiplcy=1&cnvty=0&dfrI=0&dis=0&double=3.14159265359&idlTO=30&nst=0&opTO=180&ptcls=0&rcp=0&rdcm=1&rdp=1&setcki=0&ssle=1";
 #else
     testParamString = @"aca=1&atmpTO=60&ckiplcy=1&cnvty=0&dfrI=0&dis=0&double=3.14159265359&idlTO=30&nst=0&opTO=180&ptcls=0&rcp=0&rdcm=1&rdp=1&setcki=0&ssle=0";
@@ -62,13 +62,10 @@
     [self runTestParamsEqualBetweenOriginal:params roundTrip:roundTripParams];
     XCTAssertEqualObjects(roundTripConfig, config);
 
-    if (tnl_available_multipath_service_type) {
-        config.multipathServiceType = NSURLSessionMultipathServiceTypeInteractive;
 #if TARGET_OS_IOS
+    if (tnl_available_ios_11) {
+        config.multipathServiceType = NSURLSessionMultipathServiceTypeInteractive;
         testParamString = @"aca=1&atmpTO=60&ckiplcy=1&cnvty=0&dfrI=0&dis=0&idlTO=30&mptcp=2&nst=0&opTO=180&ptcls=0&rcp=0&rdcm=1&rdp=1&setcki=0&ssle=1";
-#else
-        testParamString = @"aca=1&atmpTO=60&ckiplcy=1&cnvty=0&dfrI=0&dis=0&idlTO=30&mptcp=2&nst=0&opTO=180&ptcls=0&rcp=0&rdcm=1&rdp=1&setcki=0&ssle=0";
-#endif
         params = TNLMutableParametersFromRequestConfiguration(config, nil, nil, nil);
         paramString = params.stableURLEncodedStringValue;
         roundTripParams = [[TNLParameterCollection alloc] initWithURLEncodedString:paramString options:0];
@@ -80,6 +77,7 @@
         XCTAssertEqualObjects(roundTripConfig, config);
         config.multipathServiceType = 0;
     }
+#endif // TARGET_OS_IOS
 
     config.contributeToExecutingNetworkConnectionsCount = NO;
     config.executionMode = TNLRequestExecutionModeBackground;

--- a/TwitterNetworkLayerTests/TNLRequestOperationTest.m
+++ b/TwitterNetworkLayerTests/TNLRequestOperationTest.m
@@ -20,7 +20,7 @@
 #import "TNLTemporaryFile_Project.h"
 
 @import ObjectiveC.runtime;
-#if TARGET_OS_IOS
+#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
 @import UIKit.UIApplication; // for notification names
 #endif
 @import XCTest;
@@ -42,7 +42,7 @@ static NSError *CoersedOperationError(NSError *error)
     return error;
 }
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
 @interface FakeApplication : NSObject
 @property (nonatomic) UIApplicationState applicationState;
 - (instancetype)init;
@@ -93,7 +93,7 @@ static void FireFakeApplicationNotification(NSString *notificationName, NSTimeIn
     return self;
 }
 @end
-#endif // TARGET_OS_IOS
+#endif // TARGET_OS_IPHONE
 
 @interface TestJSONResponse : TNLResponse
 @property (nonatomic, readonly) NSDictionary *result;
@@ -135,7 +135,7 @@ typedef void(^TestCallbackBlock)(TestJSONResponse *response);
 + (void)setUp
 {
     [super setUp];
-#if TARGET_OS_IOS
+#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
     (void)[TNLGlobalConfiguration sharedInstance];
     sFakeApplication = [[FakeApplication alloc] init];
     sFakeApplication.applicationState = UIApplicationStateActive;
@@ -145,7 +145,7 @@ typedef void(^TestCallbackBlock)(TestJSONResponse *response);
 
 + (void)tearDown
 {
-#if TARGET_OS_IOS
+#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
     sFakeApplication.applicationState = UIApplicationStateActive;
     FireFakeApplicationNotification(UIApplicationDidFinishLaunchingNotification, 0);
     sFakeApplication = nil;
@@ -1036,7 +1036,7 @@ typedef void(^TestCallbackBlock)(TestJSONResponse *response);
     XCTAssertTrue([[response.operationError.userInfo[@"timeoutTags"] firstObject] hasPrefix:NSStringFromClass([self class])]);
 }
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
 
 - (void)testCallbackClog2_ClogBackgroundForegroundUnclogSuccess
 {
@@ -1057,7 +1057,7 @@ typedef void(^TestCallbackBlock)(TestJSONResponse *response);
     XCTAssertTrue([[response.operationError.userInfo[@"timeoutTags"] firstObject] hasPrefix:NSStringFromClass([self class])]);
 }
 
-#endif
+#endif // TARGET_OS_IPHONE
 
 - (void)testIdleTimeoutModes
 {

--- a/TwitterNetworkLayerTests/TNLRequestOperationTest.m
+++ b/TwitterNetworkLayerTests/TNLRequestOperationTest.m
@@ -20,7 +20,7 @@
 #import "TNLTemporaryFile_Project.h"
 
 @import ObjectiveC.runtime;
-#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
+#if TARGET_OS_IPHONE // == IOS + WATCH + TV
 @import UIKit.UIApplication; // for notification names
 #endif
 @import XCTest;
@@ -42,7 +42,7 @@ static NSError *CoersedOperationError(NSError *error)
     return error;
 }
 
-#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
+#if TARGET_OS_IPHONE // == IOS + WATCH + TV
 @interface FakeApplication : NSObject
 @property (nonatomic) UIApplicationState applicationState;
 - (instancetype)init;
@@ -135,7 +135,7 @@ typedef void(^TestCallbackBlock)(TestJSONResponse *response);
 + (void)setUp
 {
     [super setUp];
-#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
+#if TARGET_OS_IPHONE // == IOS + WATCH + TV
     (void)[TNLGlobalConfiguration sharedInstance];
     sFakeApplication = [[FakeApplication alloc] init];
     sFakeApplication.applicationState = UIApplicationStateActive;
@@ -145,7 +145,7 @@ typedef void(^TestCallbackBlock)(TestJSONResponse *response);
 
 + (void)tearDown
 {
-#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
+#if TARGET_OS_IPHONE // == IOS + WATCH + TV
     sFakeApplication.applicationState = UIApplicationStateActive;
     FireFakeApplicationNotification(UIApplicationDidFinishLaunchingNotification, 0);
     sFakeApplication = nil;
@@ -1036,7 +1036,7 @@ typedef void(^TestCallbackBlock)(TestJSONResponse *response);
     XCTAssertTrue([[response.operationError.userInfo[@"timeoutTags"] firstObject] hasPrefix:NSStringFromClass([self class])]);
 }
 
-#if TARGET_OS_IPHONE // == IOS + WATCHOS + TVOS
+#if TARGET_OS_IPHONE // == IOS + WATCH + TV
 
 - (void)testCallbackClog2_ClogBackgroundForegroundUnclogSuccess
 {

--- a/TwitterNetworkLayerTests/TNLRequestRetryPolicyTest.m
+++ b/TwitterNetworkLayerTests/TNLRequestRetryPolicyTest.m
@@ -1,0 +1,182 @@
+//
+//  TNLRequestRetryPolicyTest.m
+//  TwitterNetworkLayerTests
+//
+//  Created on 8/24/18.
+//  Copyright © 2018 Twitter. All rights reserved.
+//
+
+#import "TNL_Project.h"
+#import "TNLXContentEncoding.h"
+
+@import TwitterNetworkLayer;
+@import XCTest;
+
+@interface BrokenContentEncoder : NSObject <TNLContentEncoder>
+@end
+
+@interface TestRetryPolicy : NSObject <TNLConfiguringRetryPolicyProvider>
+@end
+
+@interface TNLRequestRetryPolicyTest : XCTestCase
+@end
+
+@implementation TNLRequestRetryPolicyTest
+
+- (void)testRetryPolicy
+{
+    NSURL *URL = [NSURL URLWithString:@"https://fake.domain.com/post/results"];
+    TNLMutableRequestConfiguration *config = [TNLMutableRequestConfiguration defaultConfiguration];
+    config.contentEncoder = [[BrokenContentEncoder alloc] init];
+    config.retryPolicyProvider = [[TestRetryPolicy alloc] initWithConfiguration:[TNLRequestRetryPolicyConfiguration standardConfiguration]];
+    config.protocolOptions = TNLRequestProtocolOptionPseudo;
+
+    NSHTTPURLResponse *URLResponse = [[NSHTTPURLResponse alloc] initWithURL:URL
+                                                                 statusCode:200
+                                                                HTTPVersion:@"1.1"
+                                                               headerFields:nil];
+    NSData *URLResponseBody = [@"{\"success\":true}" dataUsingEncoding:NSUTF8StringEncoding];
+    [TNLPseudoURLProtocol registerURLResponse:URLResponse
+                                         body:URLResponseBody
+                                 withEndpoint:URL];
+    tnl_defer(^{
+        [TNLPseudoURLProtocol unregisterEndpoint:URL];
+    });
+
+    __block TNLResponse *response = nil;
+    NSDictionary *results = @{
+                              @"player1" : @{
+                                      @"name" : @"Montoya",
+                                      @"score" : @5,
+                                      },
+                              @"player2" : @{
+                                      @"name" : @"Roberts",
+                                      @"score" : @6,
+                                      }
+                              };
+    NSData *requestBody = [NSJSONSerialization dataWithJSONObject:results
+                                                          options:NSJSONWritingPrettyPrinted
+                                                            error:NULL];
+    TNLMutableHTTPRequest *request = [TNLMutableHTTPRequest POSTRequestWithURL:URL
+                                                              HTTPHeaderFields:nil
+                                                                      HTTPBody:requestBody];
+    TNLRequestOperation *op = [TNLRequestOperation operationWithRequest:request
+                                                          configuration:config
+                                                             completion:^(TNLRequestOperation * _Nonnull operation, TNLResponse * _Nonnull opResponse) {
+                                                                 response = opResponse;
+                                                             }];
+    [[TNLRequestOperationQueue defaultOperationQueue] enqueueRequestOperation:op];
+    [op waitUntilFinishedWithoutBlockingRunLoop];
+
+    XCTAssertNotNil(response);
+    XCTAssertEqual((int)response.info.statusCode, 200);
+    XCTAssertNil(response.operationError);
+    XCTAssertEqual((int)response.metrics.attemptCount, 2);
+
+    do {
+        TNLAttemptMetrics *firstAttemptMetrics = response.metrics.attemptMetrics.firstObject;
+        XCTAssertNotNil(firstAttemptMetrics);
+        XCTAssertNotNil(firstAttemptMetrics.operationError);
+        XCTAssertEqualObjects(firstAttemptMetrics.operationError.domain, TNLErrorDomain);
+        XCTAssertEqual(firstAttemptMetrics.operationError.code, TNLErrorCodeRequestOperationRequestContentEncodingFailed);
+    } while (0);
+
+    do {
+        NSData *requestBodyBase64 = [requestBody base64EncodedDataWithOptions:(NSDataBase64Encoding64CharacterLineLength |
+                                                                               NSDataBase64EncodingEndLineWithCarriageReturn |
+                                                                               NSDataBase64EncodingEndLineWithLineFeed)];
+        TNLAttemptMetrics *lastAttemptMetrics = response.metrics.attemptMetrics.lastObject;
+        XCTAssertNotNil(lastAttemptMetrics);
+        XCTAssertNil(lastAttemptMetrics.operationError);
+        XCTAssertEqualObjects([lastAttemptMetrics.URLRequest valueForHTTPHeaderField:@"Content-Encoding"], @"base64");
+        XCTAssertEqualObjects(lastAttemptMetrics.URLRequest.HTTPBody, requestBodyBase64);
+    } while (0);
+}
+
+@end
+
+@implementation BrokenContentEncoder
+
+- (NSString *)tnl_contentEncodingType
+{
+    return @"gzip";
+}
+
+- (nullable NSData *)tnl_encodeHTTPBody:(NSData *)bodyData
+                                  error:(out NSError * __nullable * __nullable)error
+{
+    if (error) {
+        *error = [NSError errorWithDomain:@"broken.encoder"
+                                     code:-2
+                                 userInfo:nil];
+    }
+    return nil;
+}
+
+@end
+
+@implementation TestRetryPolicy
+{
+    TNLRequestRetryPolicyConfiguration *_config;
+}
+
+- (instancetype)initWithConfiguration:(nullable TNLRequestRetryPolicyConfiguration *)config
+{
+    if (self = [super init]) {
+        _config = [config copy];
+    }
+    return self;
+}
+
+- (nullable TNLRequestRetryPolicyConfiguration *)configuration
+{
+    return _config;
+}
+
+- (BOOL)tnl_shouldRetryRequestOperation:(TNLRequestOperation *)op
+                           withResponse:(TNLResponse *)response
+{
+    if ([response.operationError.domain isEqualToString:TNLErrorDomain] && response.operationError.code == TNLErrorCodeRequestOperationRequestContentEncodingFailed) {
+        if (response.metrics.attemptCount > 3) {
+            return NO;
+        }
+        return YES;
+    }
+
+    return [_config requestCanBeRetriedForResponse:response];
+}
+
+- (NSTimeInterval)tnl_delayBeforeRetryForRequestOperation:(TNLRequestOperation *)op
+                                             withResponse:(TNLResponse *)response
+{
+    return 0.5;
+}
+
+- (nullable TNLRequestConfiguration *)tnl_configurationOfRetryForRequestOperation:(TNLRequestOperation *)op
+                                                                     withResponse:(TNLResponse *)response
+                                                               priorConfiguration:(TNLRequestConfiguration *)priorConfig
+{
+    if (![response.operationError.domain isEqualToString:TNLErrorDomain]) {
+        return nil;
+    }
+
+    if (response.operationError.code != TNLErrorCodeRequestOperationRequestContentEncodingFailed) {
+        return nil;
+    }
+
+    TNLMutableRequestConfiguration *config = [priorConfig mutableCopy];
+    if ([priorConfig.contentEncoder.tnl_contentEncodingType isEqualToString:@"base64"]) {
+        config.contentEncoder = nil;
+    } else {
+        config.contentEncoder = [TNLXContentEncoding Base64ContentEncoder];
+    }
+
+    return config;
+}
+
+- (nullable NSString *)tnl_retryPolicyIdentifier
+{
+    return @"test.tnl.retry.policy.1";
+}
+
+@end


### PR DESCRIPTION
- Fix buggy GZIP/DEFLATE content encoder
- Revise TNLRetryPolicyProvider to support updating the
request's config on retry
- drop iOS 7 support
- fix race condition with UIApplication background tasks for TNL
- clean up misc code
- improve misc logging