### PR TITLE
Update to v2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,57 @@
 
 ## Info
 
-**Document version:** 2.3.0
+**Document version:** 2.6.1
 
-**Last updated:** 09/24/2018
+**Last updated:** 05/30/2019
 
 **Author:** Nolan O'Brien
 
 ## History
+
+### 2.6.1
+
+- Fix terrible bug where cancelling all request operations for *any* `TNLRequestOperationQueue` will cancel *all* request operations for *all* queues! 
+
+### 2.6.0
+
+- Move away from mach time for metrics to `NSDate` instances
+  - This better mirrors what Apple does
+  - Avoids the pitfall of using mach times as more than just measurements of durations and using them as reference timestamps (which is frought)
+  - Using `NSDate` now does have the problem of clock changes impacting timings, but this is so infrequent it practically won't ever affect metrics from **TNL**
+- Add `sessionId` to `TNLAttemptMetaData`
+  - Helps keep track of what `NSURLSession` was used
+- Add `taskResumePriority` to `TNLAttemptMetaData`
+  - Helps keep track of what QOS was used when `resume` was called for the underlying `NSURLSessionTask`
+- Add `taskResumeLatency` to `TNLAttemptMetaData`
+  - Helps diagnose if there is some unforseen stall between calling `resume` for the task and the fetching actuallying starting
+- Add `taskMetricsAfterCompletionLatency` and `taskWithoutMetricsCompletionLatency` to `TNLAttemptMetaData`
+  - Helps track when radar `#27098270` occurs 
+
+### 2.5.0
+
+- Add `[TNLGlobalConfiguration URLSessionPruneOptions]`
+  - These options offer ways for __TNL__ to prune inactive internal `NSURLSession` instances more aggressively than the 12 session limit does
+  - Options can be a combination of: on memory warning, on app background and/or after every network task
+  - Callers can also provide a special option to prune _now_
+- Add `[TNLGlobalConfiguration URLSessionInactivityThreshold]`
+  - Works with `URLSessionPruneOptions` by limiting what `NSURLSession` intances are _inactive_ by requiring a duration to elapse since the last network task ran
+- Add `[TNLGlobalConfiguration pruneURLSessionMatchingRequestConfiguration:operationQueueId:]`
+  - Offers a way to explicitely purge a specific underlying `NSURLSession` based on a given `TNLRequestConfiguration` and a `TNLRequestOperationQueue` instance's `identifier`
+
+### 2.4.1
+
+Author: Laurentiu Dascalu
+- Expose method on `TNLLogger` to redact desired header fields from being logged
+ - Good for redacting things you don't want to log like `Authorization` header field
+
+### 2.4.0
+- Add captive portal detection to `TNLCommunicationAgent`
+  - detects when a known HTTP (non-HTTPS) endpoint is intercepted via a captive portal
+  - this mechanism is a solid tradeoff in coverage vs complexity
+    - there are many ways captive portals can manifest beyond what _TNL_ detects
+    - a 100% coverage is extremely complicated and 100% accuracy is not feasible
+    - supporting the simplest mechanism for detection is sufficient for most detection use cases
 
 ### 2.3.0
 - Add background upload support using `HTTPBody`

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ The high level concept of how to use __TNL__ is rather straightforward:
 
  __TNLHTTPRequest:__
 
-```objc
+```
 NSString *URLString = [NSString stringWithFormat:@"http://api.myapp.com/blob/%tu", blobIdentifier];
 NSURL *URL = [NSURL URLWithString:URLString];
 TNLHTTPRequest *request = [TNLHTTPRequest GETRequestWithURL:URL
@@ -233,7 +233,7 @@ TNLHTTPRequest *request = [TNLHTTPRequest GETRequestWithURL:URL
 
  __TNLMutableHTTPRequest:__
 
-```objc
+```
 NSString *URLString = [NSString stringWithFormat:@"http://api.myapp.com/blob/%tu", blobIdentifier];
 NSURL *URL = [NSURL URLWithString:URLString];
 TNLMutableHTTPRequest *mRequest = [[TNLMutableHTTPRequest alloc] init];
@@ -244,7 +244,7 @@ mRequest.URL = URL;
 
 ### NSURLRequest
 
-```objc
+```
 NSString *URLString = [NSString stringWithFormat:@"http://api.myapp.com/blob/%tu", blobIdentifier];
 NSURL *URL = [NSURL URLWithString:URLString];
 NSMutableURLRequest *mRequest = [[NSMutableURLRequest alloc] init];
@@ -257,7 +257,7 @@ mRequest.URL = URL;
 
  __1) Request Hydration__
 
-```objc
+```
 APPRetrieveBlobRequest *request = [[APPRetrieveBlobRequest alloc] initWithBlobIdentifier:blobIdentifier];
 
 // ... elsewhere ...
@@ -276,7 +276,7 @@ APPRetrieveBlobRequest *request = [[APPRetrieveBlobRequest alloc] initWithBlobId
 
  __2) Request with HTTP support__
 
-```objc
+```
 APPRetrieveBlobRequest *request = [[APPRetrieveBlobRequest alloc] initWithBlobIdentifier:blobIdentifier];
 
 // ... elsewhere ...
@@ -362,7 +362,7 @@ APPRetrieveBlobRequest *request = [[APPRetrieveBlobRequest alloc] initWithBlobId
  execute an _operation_ and need things to be as simple as possible.  __Twitter Network Layer__
  provides all the convenience necessary for getting what needs to be done as simply as possible.
 
-```objc
+```
  NSString *URLString = [NSURL URLWithString:@"http://api.myapp.com/settings"];
  NSURLRequest *request = [NSURLRequest requestWithURL:URLString];
  [[TNLRequestOperationQueue defaultOperationQueue] enqueueRequest:request
@@ -386,7 +386,7 @@ APPRetrieveBlobRequest *request = [[APPRetrieveBlobRequest alloc] initWithBlobId
  _network operation_ when a specific metric is hit.  In this case, we don't care about storing the
  _response_ body and we also want to avoid having a cache that could get in the way.
 
-```objc
+```
  NSURL *URL = [NSURL URLWithString:@"http://api.myapp.com/recordMetric?hit=true"];
  TNLHTTPRequest *request = [TNLHTTPRequest GETRequestWithURL:URL HTTPHeaderFields:nil];
  TNLMutableRequestConfiguration *config = [TNLMutableRequestConfiguration defaultConfiguration];
@@ -405,7 +405,7 @@ APPRetrieveBlobRequest *request = [[APPRetrieveBlobRequest alloc] initWithBlobId
  Now, sometimes, you may want to have the same defaults for certain kinds of _operations_.  That can
  easily be accomplished with a category or some other shared accessor.
 
-```objc
+```
  @interface TNLRequestConfiguration (APPAdditions)
  + (instancetype)configurationForMetricsFiring;
  @end
@@ -472,7 +472,7 @@ APPRetrieveBlobRequest *request = [[APPRetrieveBlobRequest alloc] initWithBlobId
  with things just the objects they care about.  No converting or validating.  No configuring.  The
  power of __TNL__ is completely utilized by _API client_ freeing the caller of any burden.
 
-```objc
+```
  APISendMessageRequest *request = [[APISendMessageRequest alloc] init];
  request.sender = self.user;
  request.receiver = otherUser;

--- a/Resources/module.modulemap
+++ b/Resources/module.modulemap
@@ -1,8 +1,0 @@
-framework module TwitterNetworkLayer {
-    umbrella header "TwitterNetworkLayer.h"
-
-    export *
-    module * {
-        export *
-    }
-}

--- a/Source/NSDictionary+TNLAdditions.m
+++ b/Source/NSDictionary+TNLAdditions.m
@@ -88,7 +88,9 @@ NS_ASSUME_NONNULL_BEGIN
 {
     TNLAssert(key);
     [self tnl_removeObjectsForCaseInsensitiveKey:key];
+#ifndef __clang_analyzer__ // reports key can be nil nil; we prefer to crash if it is
     self[key] = object;
+#endif
 }
 
 - (void)tnl_makeAllKeysLowercase

--- a/Source/NSURLSessionConfiguration+TNLAdditions.h
+++ b/Source/NSURLSessionConfiguration+TNLAdditions.h
@@ -45,6 +45,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (BOOL)tnl_URLSessionSupportsDecodingBrotliContentEncoding;
 
+/**
+ Convenience method for appropriately mutating the session configuration's `protocolClasses`
+ */
+- (void)tnl_insertProtocolClasses:(nullable NSArray<Class> *)additionalClasses;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/NSURLSessionTaskMetrics+TNLAdditions.h
+++ b/Source/NSURLSessionTaskMetrics+TNLAdditions.h
@@ -37,6 +37,28 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (NSDictionary<NSString *, id> *)tnl_dictionaryValue;
 
+/**
+ returns the earliest date of all the timing dates
+ */
+- (nullable NSDate *)tnl_earliestDate;
+
+/**
+ return the latest date of all the timing dates
+ */
+- (nullable NSDate *)tnl_latestDate;
+
+/**
+ The known duration of the task.
+ If a task is cancelled/fails midway through a phase, the timing metrics can be cut off.
+ If a task completes, the duration will be accurate.
+ */
+- (NSTimeInterval)tnl_knownDuration;
+
+/**
+ returns a string describing the timings
+ */
+- (NSString *)tnl_timingDescription;
+
 /** convenience method for TCP start if connect includes TCP connect */
 @property (nonatomic, readonly, nullable) NSDate *tnl_transportConnectionStartDate;
 /** convenience method for TCP end if connect includes TCP connect */

--- a/Source/TNLAttemptMetaData.h
+++ b/Source/TNLAttemptMetaData.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Twitter. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <TwitterNetworkLayer/TNLPriority.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -28,6 +28,50 @@ NS_ASSUME_NONNULL_BEGIN
 /** The HTTP version.  Usually `@"1.1"`. TODO: replace this with "protocol version" */
 @property (nonatomic, copy, readonly, nullable) NSString *HTTPVersion;
 - (BOOL)hasHTTPVersion;
+
+/** The session identifier used for the network transaction (translates to an `NSURLSession` instance) */
+@property (nonatomic, copy, readonly, nullable) NSString *sessionId;
+- (BOOL)hasSessionId;
+
+/** The latency between when the `resume` was called on the underlying task and when the task actually began fetching */
+@property (nonatomic, readonly) NSTimeInterval taskResumeLatency;
+- (BOOL)hasTaskResumeLatency;
+
+/** The priority that `resume` was called with, indicative of the priority the task will execute with */
+@property (nonatomic, readonly) TNLPriority taskResumePriority;
+- (BOOL)hasTaskResumePriority;
+
+/**
+ The latency between task completion and task metrics being delivered.
+ Task metrics, per docs, are to be delivered BEFORE the completion callback.
+ However, due to radar #27098270, this order can end up being mixed up.
+ The presence of this meta data indicates the issue was encountered.
+
+ Apple documentation in `NSURLSession.h`:
+
+     // Sent as the last message related to a specific task.  Error may be
+     // nil, which implies that no error occurred and this task is complete.
+     - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(nullable NSError *)error;
+*/
+@property (nonatomic, readonly) NSTimeInterval taskMetricsAfterCompletionLatency;
+- (BOOL)hasTaskMetricsAfterCompletionLatency;
+
+/**
+ The latency between the task completion and meta data being constructed (actual completion)
+ when there are no task metrics delivered.
+ Task metrics, per docs, are to be delivered BEFORE the completion callback.
+ However, due to radar #27098270, this order can end up being mixed up.
+ The presence of this meta data indicates the issue was encountered AND the metrics did not come sufficiently soon enough.
+
+ Apple documentation in `NSURLSession.h`:
+
+     // Sent as the last message related to a specific task.  Error may be
+     // nil, which implies that no error occurred and this task is complete.
+     - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(nullable NSError *)error;
+ */
+@property (nonatomic, readonly) NSTimeInterval taskWithoutMetricsCompletionLatency;
+- (BOOL)hasTaskWithoutMetricsCompletionLatency;
+
 
 /**
  The number of bytes received in the response body at OSI layer 8.

--- a/Source/TNLAttemptMetaData_Project.h
+++ b/Source/TNLAttemptMetaData_Project.h
@@ -44,6 +44,12 @@ PRIMITIVE_FIELD(serverResponseTime, ServerResponseTime, SInt64, longLongValue) \
 PRIMITIVE_FIELD(localCacheHit, LocalCacheHit, BOOL, boolValue) \
 OBJECT_FIELD(expectedMD5Hash, ExpectedMD5Hash, NSData) \
 OBJECT_FIELD(MD5Hash, MD5Hash, NSData) \
+OBJECT_FIELD(sessionId, SessionId, NSString) \
+\
+PRIMITIVE_FIELD(taskResumeLatency, TaskResumeLatency, NSTimeInterval, doubleValue) \
+PRIMITIVE_FIELD(taskResumePriority, TaskResumePriority, TNLPriority, integerValue) \
+PRIMITIVE_FIELD(taskMetricsAfterCompletionLatency, TaskMetricsAfterCompletionLatency, NSTimeInterval, doubleValue) \
+PRIMITIVE_FIELD(taskWithoutMetricsCompletionLatency, TaskWithoutMetricsCompletionLatency, NSTimeInterval, doubleValue) \
 \
 PRIMITIVE_FIELD(requestContentLength, RequestContentLength, SInt64, longLongValue) \
 PRIMITIVE_FIELD(requestEncodingLatency, RequestEncodingLatency, NSTimeInterval, doubleValue) \

--- a/Source/TNLAttemptMetrics.h
+++ b/Source/TNLAttemptMetrics.h
@@ -61,10 +61,16 @@ static const NSInteger TNLAttemptCompleteDispositionCount = 3;
 @property (nonatomic, readonly) int64_t attemptId;
 /** The type of the attempt */
 @property (nonatomic, readonly) TNLAttemptType attemptType;
+
+/** attempt start date */
+@property (nonatomic, readonly) NSDate *startDate;
 /** attempt start machine time */
 @property (nonatomic, readonly) uint64_t startMachTime;
+/** attempt end date */
+@property (nonatomic, readonly, nullable) NSDate *endDate;
 /** attempt end machine time */
 @property (nonatomic, readonly) uint64_t endMachTime;
+
 /** The associated `TNLAttemptMetaData` (if any) */
 @property (nonatomic, readonly, nullable) TNLAttemptMetaData *metaData;
 
@@ -77,6 +83,8 @@ static const NSInteger TNLAttemptCompleteDispositionCount = 3;
 @property (nonatomic, copy, readonly, nullable) NSString *WWANRadioAccessTechnology;
 /** attempt carrier info. Note: `nil` for macOS since there is no cellular carrier information */
 @property (nonatomic, readonly, nullable) id<TNLCarrierInfo> carrierInfo;
+/** attempt captive portal status */
+@property (nonatomic, readonly) TNLCaptivePortalStatus captivePortalStatus;
 #endif // !TARGET_OS_WATCH
 
 /** The related request for this attempt */
@@ -105,7 +113,9 @@ static const NSInteger TNLAttemptCompleteDispositionCount = 3;
 /** Designated Initializer */
 - (instancetype)initWithAttemptId:(int64_t)attemptId
                              type:(TNLAttemptType)type
+                        startDate:(NSDate *)startDate
                     startMachTime:(uint64_t)startMachTime
+                          endDate:(nullable NSDate *)endDate
                       endMachTime:(uint64_t)endMachTime
                          metaData:(nullable TNLAttemptMetaData *)metaData
                        URLRequest:(NSURLRequest *)request
@@ -114,7 +124,9 @@ static const NSInteger TNLAttemptCompleteDispositionCount = 3;
 
 /** Initializer */
 - (instancetype)initWithType:(TNLAttemptType)type
+                   startDate:(NSDate *)startDate
                startMachTime:(uint64_t)startMachTime
+                     endDate:(nullable NSDate *)endDate
                  endMachTime:(uint64_t)endMachTime
                     metaData:(nullable TNLAttemptMetaData *)metaData
                   URLRequest:(NSURLRequest *)request

--- a/Source/TNLAttemptMetrics_Project.h
+++ b/Source/TNLAttemptMetrics_Project.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface TNLAttemptMetrics (Project)
 
 - (void)setMetaData:(nullable TNLAttemptMetaData *)metaData;
-- (void)setEndMachTime:(uint64_t)time;
+- (void)setEndDate:(nonnull NSDate *)endDate machTime:(uint64_t)time;
 - (void)setURLResponse:(nullable NSHTTPURLResponse *)response;
 - (void)setOperationError:(nullable NSError *)error;
 - (void)setTaskTransactionMetrics:(nullable NSURLSessionTaskTransactionMetrics *)taskMetrics NS_AVAILABLE(10_12, 10_0);

--- a/Source/TNLBackgroundURLSessionTaskOperationManager.m
+++ b/Source/TNLBackgroundURLSessionTaskOperationManager.m
@@ -109,7 +109,9 @@ static TNLBackgroundRequestContext * __nullable _getBackgroundRequestContext(SEL
                                                                       source:TNLResponseSourceNetworkRequest
                                                                         data:nil
                                                           temporarySavedFile:context.tempFile];
-    TNLResponseMetrics *metrics = [[TNLResponseMetrics alloc] initWithEnqueueTime:mach_absolute_time()
+    TNLResponseMetrics *metrics = [[TNLResponseMetrics alloc] initWithEnqueueDate:[NSDate date]
+                                                                      enqueueTime:mach_absolute_time()
+                                                                     completeDate:[NSDate date]
                                                                      completeTime:mach_absolute_time()
                                                                    attemptMetrics:nil];
     TNLResponse *response = [TNLResponse responseWithRequest:task.currentRequest

--- a/Source/TNLError.h
+++ b/Source/TNLError.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+@protocol TNLRequestOperationCancelSource;
+
 NS_ASSUME_NONNULL_BEGIN
 
 FOUNDATION_EXTERN NSString * const TNLErrorDomain;
@@ -215,6 +217,9 @@ FOUNDATION_EXTERN NSString * __nullable TNLErrorCodeToString(TNLErrorCode code);
 FOUNDATION_EXTERN BOOL TNLErrorCodeIsTerminal(TNLErrorCode code);
 //! Return `YES` if the `NSError` is a network security error, possibly due to Apple's _App Transport Security_
 FOUNDATION_EXTERN BOOL TNLErrorIsNetworkSecurityError(NSError * __nullable error);
+//! Create an `NSError` from a `TNLRequestOperationCancelSource`
+FOUNDATION_EXTERN NSError * __nonnull TNLErrorFromCancelSource(id<TNLRequestOperationCancelSource> __nullable cancelSource,
+                                                               NSError * __nullable underlyingError);
 
 #if APPLEDOC
 /**

--- a/Source/TNLGlobalConfiguration_Project.h
+++ b/Source/TNLGlobalConfiguration_Project.h
@@ -26,6 +26,8 @@ FOUNDATION_EXTERN const TNLBackgroundTaskIdentifier TNLBackgroundTaskInvalid;
 @property (nonatomic, readonly) dispatch_queue_t configurationQueue;
 @property (atomic, nullable) id<TNLLogger> internalLogger;
 @property (atomic, copy, nullable, readonly) NSArray<id<TNLAuthenticationChallengeHandler>> * internalAuthenticationChallengeHandlers;
+@property (atomic) TNLGlobalConfigurationURLSessionPruneOptions internalURLSessionPruneOptions;
+@property (atomic) NSTimeInterval internalURLSessionInactivityThreshold;
 
 #if TARGET_OS_IOS || TARGET_OS_TV
 @property (atomic) UIApplicationState lastApplicationState;

--- a/Source/TNLHTTP.h
+++ b/Source/TNLHTTP.h
@@ -228,7 +228,7 @@ FOUNDATION_EXTERN NSString * const TNLHTTPContentTypeMultipartFormData;
 FOUNDATION_EXTERN NSString * const TNLHTTPContentTypeOctetStream;
 FOUNDATION_EXTERN NSString * const TNLHTTPContentTypeURLEncodedString;
 
-//! Is the content type a textual format, helpful for determining if something is printable or compressable
+//! Is the content type a textual format (limited to UTF8 [default] and ASCII currently), helpful for determining if something is printable or compressable
 FOUNDATION_EXTERN BOOL TNLHTTPContentTypeIsTextual(NSString * __nullable contentType);
 
 /**

--- a/Source/TNLHTTPRequest.m
+++ b/Source/TNLHTTPRequest.m
@@ -275,7 +275,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     NSUInteger hash = self.HTTPBody.hash +
                         self.URL.hash +
-                        self.HTTPMethodValue +
+                        (NSUInteger)self.HTTPMethodValue +
                         self.HTTPBodyFilePath.hash +
                         self.HTTPBodyStream.hash +
                         self.allHTTPHeaderFields.count; // use the count of headers, not the hash since the dictionary will be case incensitive in comparison

--- a/Source/TNLLRUCache.m
+++ b/Source/TNLLRUCache.m
@@ -109,6 +109,17 @@ NS_INLINE void TNLLRUCacheAssertHeadAndTail(TNLLRUCache *cache)
 
     NSString *identifier = entry.LRUEntryIdentifier;
     TNLAssert(identifier != nil);
+#ifndef __clang_analyzer__
+    // clang analyzer reports identifier can be nil for the check   if (... && _cache[identifier]) {
+    // just below.  (and then, if we ignore only that with #ifndef __clang_analyzer__, then it reports
+    // _cache[identifier] within the TNLAssert() protected by the if stmt.)
+    // however, in real life, the TNLAssert(identifier != nil) just above will prevent control from getting to
+    // the if stmt at all when the global AssertEnabled variable is true, and when it is false, then the 2nd
+    // part of the condition (and the stmts protected by the condition) will never be executed and won't crash.
+    if (gTwitterNetworkLayerAssertEnabled && _cache[identifier]) {
+        TNLAssert((id)_cache[identifier] == (id)entry);
+    }
+#endif
 
     _tailEntry.nextLRUEntry = entry;
     entry.previousLRUEntry = _tailEntry;

--- a/Source/TNLLogger.h
+++ b/Source/TNLLogger.h
@@ -51,6 +51,15 @@ typedef NS_ENUM(NSInteger, TNLLogLevel)
                     line:(int)line
                  message:(NSString *)message;
 
+
+/*
+ Return YES when you want to redact the value of a header field from being logged.
+
+ This method is called when logging all header fields of a request / response,
+ abstracted by a `TNLRequestOperation`.
+ */
+- (BOOL)tnl_shouldRedactHTTPHeaderField:(NSString *)headerField;
+
 @optional
 
 /**

--- a/Source/TNLParameterCollection.h
+++ b/Source/TNLParameterCollection.h
@@ -19,7 +19,10 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NS_OPTIONS(NSInteger, TNLParameterTypes) {
     /** No type */
     TNLParameterTypeNone = 0,
-    /** The URL Parameter String.  Delimited with a ';'. */
+    /**
+     The URL Parameter String.  Delimited with a ';'.
+     @warning parameter string pattern in a URL is now considered deprecated behavior and `NSURL` will treat ';' delimited parameter string as part of the URL's path.  __TNL__ will continue to parse `TNLParameterTypesURLParameterString` for compatibility, but it is recommend that passing arguments via URL be done using query or fragment delimiters.
+     */
     TNLParameterTypeURLParameterString = (1 << 0),
     /** The URL Query.  Delimited with a '?'. */
     TNLParameterTypeURLQuery = (1 << 1),

--- a/Source/TNLParameterCollection.m
+++ b/Source/TNLParameterCollection.m
@@ -363,7 +363,21 @@ typedef NSString *(^TNLParameterCollectionUpdateKeysAndValuesIterativeKeyBlock)(
                      options:(TNLURLDecodingOptions)options
 {
     if (TNL_BITMASK_HAS_SUBSET_FLAGS(types, TNLParameterTypeURLParameterString)) {
-        [self addParametersWithURLEncodedString:URL.parameterString options:options];
+        NSString *parameterString;
+        if (tnl_available_ios_13) {
+            // parameter string is no longer considered valid according to Apple, which is wise
+            // ... but we'll still support parsing it
+            NSString *path = URL.path;
+            if (path) {
+                NSRange range = [path rangeOfString:@";"];
+                if (range.location != NSNotFound) {
+                    parameterString = [path substringFromIndex:range.location + 1];
+                }
+            }
+        } else {
+            parameterString = URL.parameterString;
+        }
+        [self addParametersWithURLEncodedString:parameterString options:options];
     }
     if (TNL_BITMASK_HAS_SUBSET_FLAGS(types, TNLParameterTypeURLQuery)) {
         [self addParametersWithURLEncodedString:URL.query options:options];

--- a/Source/TNLPseudoURLProtocol.h
+++ b/Source/TNLPseudoURLProtocol.h
@@ -63,6 +63,16 @@ FOUNDATION_EXTERN NSString * const TNLPseudoURLProtocolErrorDomain;
 
 @end
 
+//! Behavior for how the pseudo protocol should handle an observed redirect
+typedef NS_ENUM(NSUInteger, TNLPseudoURLProtocolRedirectBehavior) {
+    /** Follow redirect when `Location` header field is provided */
+    TNLPseudoURLProtocolRedirectBehaviorFollowLocation = 0,
+    /** Return the 3xx HTTP response, don't follow the redirect */
+    TNLPseudoURLProtocolRedirectBehaviorDontFollowLocation = 1,
+    /** Follow redirect when `Location` header field's value is registered with a response too, otherwise return the 3xx response */
+    TNLPseudoURLProtocolRedirectBehaviorFollowLocationIfRedirectResponseIsRegistered = 2,
+};
+
 /**
  The configuration for how the response should behave when registering a pseudo-URLResponse with
  `TNLPseudoURLProtocol`
@@ -107,6 +117,11 @@ FOUNDATION_EXTERN NSString * const TNLPseudoURLProtocolErrorDomain;
  otherwise == the given string will be matched with `isEqualToString:`
  */
 @property (nonatomic, copy, nullable) NSString *stringForIfRange;
+/**
+ Redirect behavior.
+ `TNLPseudoURLProtocolRedirectBehaviorFollowLocation` == default
+ */
+@property (nonatomic) TNLPseudoURLProtocolRedirectBehavior redirectBehavior;
 
 /**
  Any additional headers that the `TNLPseudoURLProtocol` should coerse the request to have

--- a/Source/TNLPseudoURLProtocol.m
+++ b/Source/TNLPseudoURLProtocol.m
@@ -199,6 +199,8 @@ static void _executeClientBlock(SELF_ARG,
                     NSHTTPURLResponse *httpResponse = (id)response.response;
                     NSData *data = response.data;
                     NSInteger statusCode = (config.statusCode > 0) ? config.statusCode : httpResponse.statusCode;
+
+                    // See if we need to change to a 206
                     if (200 == statusCode && config.canProvideRange) {
 
                         const NSRange range = _RangeForRequest(request, data.length, config.stringForIfRange);
@@ -208,6 +210,15 @@ static void _executeClientBlock(SELF_ARG,
                             data = [data subdataWithRange:range];
                         }
 
+                    }
+
+                    // On 3xx (when `Location` is provided), execute redirection based on config behavior.
+                    if (statusCode >= 300 && statusCode < 400) {
+                        const TNLPseudoURLProtocolRedirectBehavior behavior = (config) ? config.redirectBehavior : TNLPseudoURLProtocolRedirectBehaviorFollowLocation;
+                        if (_handleRedirect(self, request, httpResponse, behavior)) {
+                            // was handled, return
+                            return;
+                        }
                     }
 
                     httpResponse = _UpdateResponse(httpResponse, data.length, statusCode);
@@ -250,6 +261,74 @@ static void _executeClientBlock(SELF_ARG,
             });
         }
     });
+}
+
+static BOOL _handleRedirect(SELF_ARG,
+                            NSURLRequest *request,
+                            NSHTTPURLResponse *httpResponse,
+                            const TNLPseudoURLProtocolRedirectBehavior behavior)
+{
+    if (!self) {
+        return NO;
+    }
+
+    TNLAssert(httpResponse.statusCode >= 300);
+    TNLAssert(httpResponse.statusCode < 400);
+
+    if (TNLPseudoURLProtocolRedirectBehaviorDontFollowLocation == behavior) {
+        return NO;
+    }
+
+    NSString *location = httpResponse.allHeaderFields[@"Location"];
+    if (!location) {
+        return NO;
+    }
+
+    NSURL *locationURL = nil;
+    @try {
+        locationURL = [NSURL URLWithString:location];
+    } @catch (NSException *e) {
+        locationURL = nil;
+    }
+    if (!locationURL) {
+        return NO;
+    }
+
+    // create the redirect request
+    NSMutableURLRequest *mRedirectRequest = [request mutableCopy];
+    mRedirectRequest.URL = locationURL;
+    if (303 == httpResponse.statusCode) {
+        mRedirectRequest.HTTPMethod = @"GET";
+    }
+
+    // get the cached redirect response (if requested)
+    __block NSCachedURLResponse *redirectCachedResponse;
+    if (TNLPseudoURLProtocolRedirectBehaviorFollowLocationIfRedirectResponseIsRegistered == behavior) {
+        dispatch_sync(sOriginQueue, ^{
+            redirectCachedResponse = sOriginToResponseDictionary[_UnderlyingURLString(locationURL)];
+        });
+    }
+
+    // if we have a cached response or we follow the redirect anyway, tell the client we redirected
+    if (redirectCachedResponse || TNLPseudoURLProtocolRedirectBehaviorFollowLocation == behavior) {
+        /*
+         radar://45880389
+         The NSURLProtocolClient has always supported taking a `nil` redirectResponse.
+         In recent years, `NS_ASSUME_NONNULL_BEGIN` was added to the interface's header and it mistakenly updates
+            the redirectResponse argument to be a nonnull parameter.
+         We can safely work around this by forcibly casting our potentially `nil` redirectResponse as __nonnull.
+         Radar has been filed against Apple.
+         */
+        NSHTTPURLResponse * __nonnull redirectResponse = (NSHTTPURLResponse * __nonnull)redirectCachedResponse.response;
+        _executeClientBlock(self, ^(id<NSURLProtocolClient> client) {
+            [client URLProtocol:self
+         wasRedirectedToRequest:[mRedirectRequest copy]
+               redirectResponse:redirectResponse];
+        });
+        return YES;
+    }
+
+    return NO;
 }
 
 static void _chunkData(SELF_ARG,
@@ -331,6 +410,7 @@ static void _executeClientBlock(SELF_ARG,
 {
     if (self = [super init]) {
         _canProvideRange = YES;
+        _redirectBehavior = TNLPseudoURLProtocolRedirectBehaviorFollowLocation;
     }
     return self;
 }
@@ -346,6 +426,7 @@ static void _executeClientBlock(SELF_ARG,
     config.statusCode = self.statusCode;
     config.canProvideRange = self.canProvideRange;
     config.stringForIfRange = self.stringForIfRange;
+    config.redirectBehavior = self.redirectBehavior;
     config.extraRequestHeaders = self.extraRequestHeaders;
 
     return config;

--- a/Source/TNLRequestConfiguration.h
+++ b/Source/TNLRequestConfiguration.h
@@ -366,7 +366,7 @@ FOUNDATION_EXTERN NSTimeInterval TNLDeferrableIntervalForPriority(TNLPriority pr
  (a.k.a. an attempt) can take before we time out.  If an attempt is executing and not idle, the
  _idleTimeout_ won't be triggered, so this will cap the attempt if it takes too long.
 
- @note The minimum interval is `1.0` seconds, anything smaller (including negative) will be treated as _never_.
+ @note The minimum interval is `0.1` seconds, anything smaller (including negative) will be treated as _never_.
  */
 @property (nonatomic, readonly) NSTimeInterval attemptTimeout;
 
@@ -380,7 +380,7 @@ FOUNDATION_EXTERN NSTimeInterval TNLDeferrableIntervalForPriority(TNLPriority pr
  to exectue.  This includes time in the queue without starting, redirects, retries, time waiting to
  retry and delegate callbacks.
 
- @note The minimum interval is `1.0` seconds, anything smaller (including negative) will be treated as _never_.
+ @note The minimum interval is `0.1` seconds, anything smaller (including negative) will be treated as _never_.
  */
 @property (nonatomic, readonly) NSTimeInterval operationTimeout;
 

--- a/Source/TNLRequestConfiguration.m
+++ b/Source/TNLRequestConfiguration.m
@@ -32,7 +32,7 @@ static const TNLRequestAnatomyTimeouts kAnatomyTimeouts[] = {
     // TNLRequestAnatomySmallRequestSmallResponse
     { .idleTimeout = 30, .attemptTimeout = 30, .operationTimeout = 90 },
 
-    // TNLRequestAnatomySmallRequestLargeResponse
+    // TNLRequestAnatomySmallRequestLargeResponse (default)
     { .idleTimeout = 30, .attemptTimeout = 60, .operationTimeout = 180 },
 
     // TNLRequestAnatomyLargeRequestSmallResponse
@@ -51,7 +51,7 @@ static const TNLRequestAnatomyTimeouts kAnatomyTimeouts[] = {
     { .idleTimeout = 30, .attemptTimeout = NSTimeIntervalSince1970, .operationTimeout = NSTimeIntervalSince1970 },
 };
 
-static const NSUInteger kMaxAnatomyTimeouts = TNLRequestAnatomySmallRequestStreamingResponse + 1;
+static const NSInteger kMaxAnatomyTimeouts = TNLRequestAnatomySmallRequestStreamingResponse + 1;
 
 TNLStaticAssert((sizeof(kAnatomyTimeouts) / sizeof(kAnatomyTimeouts[0])) == kMaxAnatomyTimeouts, ANATOMY_TIMEOUT_COUNT_MISSMATCH);
 
@@ -222,12 +222,6 @@ static const NSTimeInterval kConfigurationDeferrableIntervalDefault = 0.0;
         _URLCache = config->_URLCache;
         _cookieStorage = config->_cookieStorage;
         _sharedContainerIdentifier = [config->_sharedContainerIdentifier copy];
-#if TARGET_OS_IOS
-        if (tnl_available_ios_11) {
-            _ivars.multipathServiceType = NSURLSessionMultipathServiceTypeNone;
-        }
-#endif
-        _ivars.connectivityOptions = TNLRequestConnectivityOptionsDefault;
 
         memcpy(&_ivars, &(config->_ivars), sizeof(_ivars));
     }

--- a/Source/TNLRequestEventHandler.h
+++ b/Source/TNLRequestEventHandler.h
@@ -102,7 +102,7 @@ typedef void(^TNLRequestOperationEnqueueNetworkingOperationBlock)(NSArray<NSOper
 /**
  The operation is ready to enqueue the networking work.
  This can be for the initial request or a retry.
- Call the `enqueue` to trigger the enqueue with optionally providing dependencies.
+ Call the `enqueueBlock` to trigger the enqueue with optionally providing dependencies.
  Default when not implemented is to just enqueue right away.
  */
 - (void)tnl_requestOperation:(TNLRequestOperation *)op

--- a/Source/TNLRequestOperation.h
+++ b/Source/TNLRequestOperation.h
@@ -147,10 +147,10 @@ typedef void(^TNLRequestDidCompleteBlock)(TNLRequestOperation *op, TNLResponse *
  @param delegate    The *weakly held delegate* for the operation, can be `nil`.
  @return A new operation
  */
-+ (TNLRequestOperation *)operationWithRequest:(nullable id<TNLRequest>)request
-                                responseClass:(nullable Class)responseClass
-                                configuration:(nullable TNLRequestConfiguration *)config
-                                     delegate:(nullable id<TNLRequestDelegate>)delegate;
++ (instancetype)operationWithRequest:(nullable id<TNLRequest>)request
+                       responseClass:(nullable Class)responseClass
+                       configuration:(nullable TNLRequestConfiguration *)config
+                            delegate:(nullable id<TNLRequestDelegate>)delegate;
 
 
 /**
@@ -256,16 +256,16 @@ typedef void(^TNLRequestDidCompleteBlock)(TNLRequestOperation *op, TNLResponse *
  @param delegate The *weakly held delegate* for the operation, can be `nil`.
  @return A new operation
  */
-+ (TNLRequestOperation *)operationWithRequest:(nullable id<TNLRequest>)request
-                                configuration:(nullable TNLRequestConfiguration *)config
-                                     delegate:(nullable id<TNLRequestDelegate>)delegate;
++ (instancetype)operationWithRequest:(nullable id<TNLRequest>)request
+                       configuration:(nullable TNLRequestConfiguration *)config
+                            delegate:(nullable id<TNLRequestDelegate>)delegate;
 
 /**
  Same as calling `operationWithRequest:configuration:delegate:` with `[NRURLRequest requestWithURL:url]` as the _request_
  */
-+ (TNLRequestOperation *)operationWithURL:(nullable NSURL *)url
-                            configuration:(nullable TNLRequestConfiguration *)config
-                                 delegate:(nullable id<TNLRequestDelegate>)delegate;
++ (instancetype)operationWithURL:(nullable NSURL *)url
+                   configuration:(nullable TNLRequestConfiguration *)config
+                        delegate:(nullable id<TNLRequestDelegate>)delegate;
 
 /**
  Convenience constructor that doesn't need a `TNLRequestConfiguration` nor a `TNLRequestDelegate`
@@ -279,8 +279,8 @@ typedef void(^TNLRequestDidCompleteBlock)(TNLRequestOperation *op, TNLResponse *
 
  @return the `TNLRequestOperation` to schedule.  See `[TNLRequestOperationQueue enqueueRequestOperation:]`.
  */
-+ (TNLRequestOperation *)operationWithRequest:(nullable id<TNLRequest>)request
-                                   completion:(nullable TNLRequestDidCompleteBlock)completion;
++ (instancetype)operationWithRequest:(nullable id<TNLRequest>)request
+                          completion:(nullable TNLRequestDidCompleteBlock)completion;
 
 /**
  Convenience constructor that doesn't need a `TNLRequestDelegate`
@@ -295,9 +295,9 @@ typedef void(^TNLRequestDidCompleteBlock)(TNLRequestOperation *op, TNLResponse *
 
  @return the `TNLRequestOperation` to schedule.  See `[TNLRequestOperationQueue enqueueRequestOperation:]`.
  */
-+ (TNLRequestOperation *)operationWithRequest:(nullable id<TNLRequest>)request
-                                configuration:(nullable TNLRequestConfiguration *)config
-                                   completion:(nullable TNLRequestDidCompleteBlock)completion;
++ (instancetype)operationWithRequest:(nullable id<TNLRequest>)request
+                       configuration:(nullable TNLRequestConfiguration *)config
+                          completion:(nullable TNLRequestDidCompleteBlock)completion;
 
 /**
  Convenience constructor that doesn't need a `TNLRequestDelegate`
@@ -313,17 +313,17 @@ typedef void(^TNLRequestDidCompleteBlock)(TNLRequestOperation *op, TNLResponse *
 
  @return the `TNLRequestOperation` to schedule.  See `[TNLRequestOperationQueue enqueueRequestOperation:]`.
  */
-+ (TNLRequestOperation *)operationWithRequest:(nullable id<TNLRequest>)request
-                                responseClass:(nullable Class)responseClass
-                                configuration:(nullable TNLRequestConfiguration *)config
-                                   completion:(nullable TNLRequestDidCompleteBlock)completion;
++ (instancetype)operationWithRequest:(nullable id<TNLRequest>)request
+                       responseClass:(nullable Class)responseClass
+                       configuration:(nullable TNLRequestConfiguration *)config
+                          completion:(nullable TNLRequestDidCompleteBlock)completion;
 
 /**
  Same as `[TNLRequestOperation operationWithRequest:completion:]` with _request_ being
  `[NSURLRequest requestWithURL:`_url_`]`
  */
-+ (TNLRequestOperation *)operationWithURL:(nullable NSURL *)url
-                               completion:(nullable TNLRequestDidCompleteBlock)completion;
++ (instancetype)operationWithURL:(nullable NSURL *)url
+                      completion:(nullable TNLRequestDidCompleteBlock)completion;
 
 @end
 

--- a/Source/TNLRequestOperationCancelSource.h
+++ b/Source/TNLRequestOperationCancelSource.h
@@ -50,13 +50,30 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable NSString *)tnl_localizedCancelSourceDescription;
 
+/**
+ An overriding error in the case that the "cancel" should not be treated with a `TNLErrorCodeRequestOperationCancelled` error.
+ @return an `NSError`, `nil` value will continue to treat the cancel source as a `TNLErrorCodeRequestOperationCancelled` error source.
+ */
+- (nullable NSError *)tnl_cancelSourceOverrideError;
+
 @end
 
 /**
  Category on NSString to adopt `TNLRequestOperationCancelSource` as a convenience.
  */
 @interface NSString (TNLRequestOperationCancelSource) <TNLRequestOperationCancelSource>
+/** returns `self` */
 - (NSString *)tnl_cancelSourceDescription;
+@end
+
+/**
+ Category on NSError to adopt `TNLRequestOperationCancelSource` as a convenience.
+ */
+@interface NSError (TNLRequestOperationCancelSource) <TNLRequestOperationCancelSource>
+/** returns `[self description]` */
+- (NSString *)tnl_cancelSourceDescription;
+/** returns `self` */
+- (NSString *)tnl_cancelSourceOverrideError;
 @end
 
 /**

--- a/Source/TNLRequestOperationCancelSource.m
+++ b/Source/TNLRequestOperationCancelSource.m
@@ -19,6 +19,20 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@implementation NSError (TNLRequestOperationCancelSource)
+
+- (NSString *)tnl_cancelSourceDescription
+{
+    return [self description];
+}
+
+- (NSError *)tnl_cancelSourceOverrideError
+{
+    return self;
+}
+
+@end
+
 @implementation TNLOperationCancelMethodCancelSource
 
 - (NSString *)tnl_cancelSourceDescription

--- a/Source/TNLRequestRetryPolicyConfiguration.m
+++ b/Source/TNLRequestRetryPolicyConfiguration.m
@@ -47,6 +47,11 @@ NS_INLINE NSUInteger _URLErrorCodeToIndex(NSInteger code)
 //    return codeInt * -1;
 //}
 
+NS_INLINE NSUInteger _HTTPStatusCodeToIndex(TNLHTTPStatusCode code)
+{
+    return (NSUInteger)code;
+}
+
 @interface TNLRequestRetryPolicyConfiguration ()
 
 @property (nonatomic, readonly, nullable) NSIndexSet *POSIXErrorCodes;
@@ -147,7 +152,7 @@ NS_INLINE NSUInteger _URLErrorCodeToIndex(NSInteger code)
 
 - (BOOL)statusCodeCanBeRetried:(TNLHTTPStatusCode)code
 {
-    return [self.statusCodes containsIndex:code];
+    return [self.statusCodes containsIndex:_HTTPStatusCodeToIndex(code)];
 }
 
 - (BOOL)URLErrorCodeCanBeRetried:(NSInteger)code
@@ -264,9 +269,9 @@ NS_INLINE NSUInteger _URLErrorCodeToIndex(NSInteger code)
     }
     TNLAssert([_statusCodes isKindOfClass:[NSMutableIndexSet class]]);
     if (canRetry) {
-        [(NSMutableIndexSet *)_statusCodes addIndex:code];
+        [(NSMutableIndexSet *)_statusCodes addIndex:_HTTPStatusCodeToIndex(code)];
     } else {
-        [(NSMutableIndexSet *)_statusCodes removeIndex:code];
+        [(NSMutableIndexSet *)_statusCodes removeIndex:_HTTPStatusCodeToIndex(code)];
     }
 }
 

--- a/Source/TNLResponse.h
+++ b/Source/TNLResponse.h
@@ -263,10 +263,14 @@ NS_SWIFT_NAME(response(request:operationError:info:metrics:));
  */
 @interface TNLResponseMetrics : NSObject <NSSecureCoding>
 
+/** When the `TNLRequestOperation` was enqueued to its `TNLRequestOperationQueue` as `NSDate` */
+@property (nonatomic, readonly) NSDate *enqueueDate;
 /** When the `TNLRequestOperation` was enqueued to its `TNLRequestOperationQueue` */
-@property (nonatomic, readonly) uint64_t enqueueMachTime;
+@property (nonatomic, readonly) uint64_t enqueueMachTime __attribute__((deprecated("use enqueueDate instead")));
+/** When the `TNLRequestOperation` completed as `NSDate` */
+@property (nonatomic, readonly, nullable) NSDate *completeDate;
 /** When the `TNLRequestOperation` completed */
-@property (nonatomic, readonly) uint64_t completeMachTime;
+@property (nonatomic, readonly) uint64_t completeMachTime __attribute__((deprecated("use completeDate instead")));
 
 /** The number of attempts that occurred (initial attempt + retries + redirects) */
 @property (nonatomic, readonly) NSUInteger attemptCount;
@@ -281,7 +285,9 @@ NS_SWIFT_NAME(response(request:operationError:info:metrics:));
 /**
  Helper init for custom `TNLResponseMetrics`
  */
-- (instancetype)initWithEnqueueTime:(uint64_t)enqueueTime
+- (instancetype)initWithEnqueueDate:(NSDate *)enqueueDate
+                        enqueueTime:(uint64_t)enqueueTime
+                       completeDate:(nullable NSDate *)completeDate
                        completeTime:(uint64_t)completeTime
                      attemptMetrics:(nullable NSArray<TNLAttemptMetrics *> *)attemptMetrics;
 
@@ -292,12 +298,18 @@ NS_SWIFT_NAME(response(request:operationError:info:metrics:));
  */
 @interface TNLResponseMetrics (Convenience)
 
+/** When the first attempt started (after the time spent waiting in the queue) as `NSDate` */
+@property (nonatomic, readonly, nullable) NSDate *firstAttemptStartDate;
 /** When the first attempt started (after the time spent waiting in the queue) */
-@property (nonatomic, readonly) uint64_t firstAttemptStartMachTime;
+@property (nonatomic, readonly) uint64_t firstAttemptStartMachTime __attribute__((deprecated("use firstAttemptStartDate instead")));
+/** When the current attempt started as `NSDate` */
+@property (nonatomic, readonly, nullable) NSDate *currentAttemptStartDate;
 /** When the current attempt started */
-@property (nonatomic, readonly) uint64_t currentAttemptStartMachTime;
+@property (nonatomic, readonly) uint64_t currentAttemptStartMachTime __attribute__((deprecated("use currentAttemptStartDate instead")));
+/** When the current attempt ended as `NSDate` */
+@property (nonatomic, readonly, nullable) NSDate *currentAttemptEndDate;
 /** When the current attempt ended */
-@property (nonatomic, readonly) uint64_t currentAttemptEndMachTime;
+@property (nonatomic, readonly) uint64_t currentAttemptEndMachTime __attribute__((deprecated("use currentAttemptEndDate instead")));
 
 /** calculate the total duration of the operation */
 - (NSTimeInterval)totalDuration;

--- a/Source/TNLResponse_Project.h
+++ b/Source/TNLResponse_Project.h
@@ -25,23 +25,26 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface TNLResponseMetrics ()
 
-- (void)setEnqueueMachTime:(uint64_t)time;
+- (void)didEnqueue;
 
-- (void)addInitialStartWithMachTime:(uint64_t)machTime
-                            request:(NSURLRequest *)request;
-- (void)addRetryStartWithMachTime:(uint64_t)machTime
-                          request:(NSURLRequest *)request;
-- (void)addRedirectStartWithMachTime:(uint64_t)machTime
-                             request:(NSURLRequest *)request;
-- (void)addEnd:(uint64_t)time
-      response:(nullable NSHTTPURLResponse *)response
-operationError:(nullable NSError *)error;
-- (void)addMetaData:(nullable TNLAttemptMetaData *)metaData;
-- (void)addTaskMetrics:(nullable NSURLSessionTaskMetrics *)metrics;
+- (void)addInitialStartWithDate:(NSDate *)date
+                       machTime:(uint64_t)machTime
+                        request:(NSURLRequest *)request;
+- (void)addRetryStartWithDate:(NSDate *)date
+                     machTime:(uint64_t)machTime
+                      request:(NSURLRequest *)request;
+- (void)addRedirectStartWithDate:(NSDate *)date
+                        machTime:(uint64_t)machTime
+                         request:(NSURLRequest *)request;
+- (void)addEndDate:(NSDate *)date
+          machTime:(uint64_t)time
+          response:(nullable NSHTTPURLResponse *)response
+    operationError:(nullable NSError *)error;
+- (void)addMetaData:(nullable TNLAttemptMetaData *)metaData taskMetrics:(nullable NSURLSessionTaskMetrics *)metrics;
 
 - (void)updateCurrentRequest:(NSURLRequest *)request;
 
-- (void)setCompleteMachTime:(uint64_t)time;
+- (void)setCompleteDate:(NSDate *)date machTime:(uint64_t)time;
 
 - (TNLResponseMetrics *)deepCopyAndTrimIncompleteAttemptMetrics:(BOOL)trimIncompleteAttemptMetrics;
 

--- a/Source/TNLSafeOperation.h
+++ b/Source/TNLSafeOperation.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
  `TNLSafeOperation` works to encapsulate fixes for `NSOperation`.
 
  Specifically:
-    - `NSOperation` is supposed to clear the `completionBlock` after it has been called.  It does do this on macOS, but not on iOS.  `TNLSafeOperation` fixes this.
+    - `NSOperation` is supposed to clear the `completionBlock` after it has been called.  It does do this on macOS, but not on all versions of iOS.  `TNLSafeOperation` fixes this.
  */
 @interface TNLSafeOperation : NSOperation
 @end

--- a/Source/TNLURLSessionManager.h
+++ b/Source/TNLURLSessionManager.h
@@ -7,6 +7,7 @@
 //
 
 #import <TwitterNetworkLayer/TNLGlobalConfiguration.h>
+#import <TwitterNetworkLayer/TNLRequestConfiguration.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -14,7 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
  * NOTE: this header is private to TNL
  */
 
+@class TNLMutableParameterCollection;
 @class TNLRequestOperationQueue;
+@class TNLResponse;
 @class TNLURLSessionTaskOperation;
 @protocol TNLRequestOperationCancelSource;
 
@@ -34,17 +37,20 @@ FOUNDATION_EXTERN NSTimeInterval TNLGlobalServiceUnavailableRetryAfterMaximumBac
 #pragma mark Declarations
 
 typedef void(^TNLRequestOperationQueueFindTaskOperationCompleteBlock)(TNLURLSessionTaskOperation * taskOp);
+typedef void(^TNLURLSessionManagerGetAllSessionsCallback)(NSArray<NSURLSession *> *foregroundSessions, NSArray<NSURLSession *> *backgroundSessions);
 
 #pragma mark TNLURLSessionManager
 
 @protocol TNLURLSessionManager <NSObject>
 
-- (void)cancelAllWithSource:(id<TNLRequestOperationCancelSource>)source
-            underlyingError:(nullable NSError *)optionalUnderlyingError;
+- (void)cancelAllForQueue:(TNLRequestOperationQueue *)queue
+                   source:(id<TNLRequestOperationCancelSource>)source
+          underlyingError:(nullable NSError *)optionalUnderlyingError;
 
 - (void)findURLSessionTaskOperationForRequestOperationQueue:(TNLRequestOperationQueue *)queue
                                            requestOperation:(TNLRequestOperation *)op
                                                    complete:(TNLRequestOperationQueueFindTaskOperationCompleteBlock)complete;
+- (void)getAllURLSessions:(TNLURLSessionManagerGetAllSessionsCallback)callback;
 - (BOOL)handleBackgroundURLSessionEvents:(NSString *)identifier
                        completionHandler:(dispatch_block_t)completionHandler;
 - (void)URLSessionDidCompleteBackgroundEvents:(NSURLSession *)session;
@@ -61,6 +67,10 @@ typedef void(^TNLRequestOperationQueueFindTaskOperationCompleteBlock)(TNLURLSess
 - (void)serviceUnavailableEncounteredForURL:(NSURL *)URL
                             retryAfterDelay:(NSTimeInterval)delay;
 @property (atomic) TNLGlobalConfigurationServiceUnavailableBackoffMode serviceUnavailableBackoffMode;
+
+- (void)pruneUnusedURLSessions;
+- (void)pruneURLSessionMatchingRequestConfiguration:(TNLRequestConfiguration *)config
+                                   operationQueueId:(nullable NSString *)operationQueueId;
 
 @end
 

--- a/Source/TNL_ProjectCommon.h
+++ b/Source/TNL_ProjectCommon.h
@@ -28,6 +28,7 @@ FOUNDATION_EXTERN BOOL TNLIsExtension(void);
 #define tnl_available_ios_10    @available(iOS 10, tvOS 10, macOS 10.12, watchOS 3, *)
 #define tnl_available_ios_11    @available(iOS 11, tvOS 11, macOS 10.13, watchOS 4, *)
 #define tnl_available_ios_12    @available(iOS 12, tvOS 12, macOS 10.14, watchOS 5, *)
+#define tnl_available_ios_13    @available(iOS 13, tvOS 13, macOS 10.15, watchOS 6, *)
 
 #pragma mark - Bitmask Helpers
 

--- a/TNLExample/TNLXAppDelegate.m
+++ b/TNLExample/TNLXAppDelegate.m
@@ -59,6 +59,14 @@ NSString *TNLXCommunicationStatusUpdatedNotification = @"TNLXCommunicationStatus
     NSLog(@"[%@]: %@", levelString, message);
 }
 
+- (BOOL)tnl_shouldRedactHTTPHeaderField:(nonnull NSString *)headerField
+{
+    if ([headerField isEqualToString:@"Authorization"]) {
+        return YES;
+    }
+    return NO;
+}
+
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     [[NSURLCache sharedURLCache] removeAllCachedResponses];
@@ -210,6 +218,7 @@ NSString *TNLXCommunicationStatusUpdatedNotification = @"TNLXCommunicationStatus
         status:(TNLNetworkReachabilityStatus)status
         carrierInfo:(nullable id<TNLCarrierInfo>)info
         WWANRadioAccessTechnology:(nullable NSString *)radioTech
+        captivePortalStatus:(TNLCaptivePortalStatus)captivePortalStatus
 {
     _SCFlagsString = TNLDebugStringFromNetworkReachabilityFlags(flags);
     _statusString = TNLNetworkReachabilityStatusToString(status) ?: @"<null>";

--- a/TNLExample/TNLXPlaygroundViewController.m
+++ b/TNLExample/TNLXPlaygroundViewController.m
@@ -118,9 +118,6 @@ typedef NS_ENUM(NSInteger, TNLXRedirectTestPolicy)
     NSFileManager *fm = [NSFileManager defaultManager];
     [fm createDirectoryAtPath:[_fileDestination stringByDeletingLastPathComponent] withIntermediateDirectories:YES attributes:nil error:NULL];
     _queue = [[TNLRequestOperationQueue alloc] initWithIdentifier:NSStringFromClass([self class]).lowercaseString];
-    if ([_queue respondsToSelector:@selector(setQualityOfService:)]) {
-        _queue.qualityOfService = NSQualityOfServiceUtility;
-    }
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(backgroundRequestDidDownloadNotification:) name:TNLBackgroundRequestOperationDidCompleteNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];

--- a/TwitterNetworkLayer.xcodeproj/project.pbxproj
+++ b/TwitterNetworkLayer.xcodeproj/project.pbxproj
@@ -24,6 +24,9 @@
 		8B0DDD2519C7456A004BEE4B /* TNLNetwork.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B0DDD2319C7456A004BEE4B /* TNLNetwork.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8B0DDD2619C7456A004BEE4B /* TNLNetwork.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B0DDD2419C7456A004BEE4B /* TNLNetwork.m */; };
 		8B0E0C4D1DE69C5700283B45 /* BingResults.json.base64 in Resources */ = {isa = PBXBuildFile; fileRef = 8B0E0C4C1DE69C5700283B45 /* BingResults.json.base64 */; };
+		8B10826E2252BC9B009C8ECB /* TNLURLSessionManagerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B10826D2252BC9B009C8ECB /* TNLURLSessionManagerTest.m */; };
+		8B10826F2252BC9B009C8ECB /* TNLURLSessionManagerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B10826D2252BC9B009C8ECB /* TNLURLSessionManagerTest.m */; };
+		8B1082702252BC9B009C8ECB /* TNLURLSessionManagerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B10826D2252BC9B009C8ECB /* TNLURLSessionManagerTest.m */; };
 		8B13EB9F19C9F7580098E349 /* TNLResponse_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B13EB9D19C9F7580098E349 /* TNLResponse_Project.h */; };
 		8B153162207D1DA400A1288F /* TNLAuthenticationChallengeHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B153161207D1DA400A1288F /* TNLAuthenticationChallengeHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8B153163207D1DA400A1288F /* TNLAuthenticationChallengeHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B153161207D1DA400A1288F /* TNLAuthenticationChallengeHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -174,7 +177,6 @@
 		8B9EBDFA2135B4B100E6E466 /* TNLURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BAFBF0E1BDABAB500F36EFF /* TNLURLSessionManager.h */; };
 		8B9EBDFB2135B4B100E6E466 /* TNLBackgroundURLSessionTaskOperationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B2924BB1992E42900AC139A /* TNLBackgroundURLSessionTaskOperationManager.h */; };
 		8B9EBDFC2135B4B100E6E466 /* TNLHostSanitizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BB0E3A51A1FCFB6008CF992 /* TNLHostSanitizer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8B9EBDFD2135B4B100E6E466 /* module.modulemap in Headers */ = {isa = PBXBuildFile; fileRef = B3B9E9FE1C3AEDE700B8A451 /* module.modulemap */; settings = {ATTRIBUTES = (Public, ); }; };
 		8B9EBDFE2135B4B100E6E466 /* NSURLSessionConfiguration+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BFDF956199ADF4300248C3D /* NSURLSessionConfiguration+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8B9EBDFF2135B4B100E6E466 /* TNLRequestHydrater.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B2DF7D0199D7F2600A064B3 /* TNLRequestHydrater.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8B9EBE002135B4B100E6E466 /* TNLHTTP.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE4032319467A1400C7241E /* TNLHTTP.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -380,7 +382,6 @@
 		8BFDF9512135AB2C002F6A80 /* TNLURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BAFBF0E1BDABAB500F36EFF /* TNLURLSessionManager.h */; };
 		8BFDF9522135AB2C002F6A80 /* TNLBackgroundURLSessionTaskOperationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B2924BB1992E42900AC139A /* TNLBackgroundURLSessionTaskOperationManager.h */; };
 		8BFDF9532135AB2C002F6A80 /* TNLHostSanitizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BB0E3A51A1FCFB6008CF992 /* TNLHostSanitizer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8BFDF9542135AB2C002F6A80 /* module.modulemap in Headers */ = {isa = PBXBuildFile; fileRef = B3B9E9FE1C3AEDE700B8A451 /* module.modulemap */; settings = {ATTRIBUTES = (Public, ); }; };
 		8BFDF9552135AB2C002F6A80 /* NSURLSessionConfiguration+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BFDF956199ADF4300248C3D /* NSURLSessionConfiguration+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8BFDF9562135AB2C002F6A80 /* TNLRequestHydrater.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B2DF7D0199D7F2600A064B3 /* TNLRequestHydrater.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8BFDF9572135AB2C002F6A80 /* TNLHTTP.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE4032319467A1400C7241E /* TNLHTTP.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -475,7 +476,6 @@
 		8BFE79DB21308A7B00E3B2AD /* TNLRequestRetryPolicyTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BFE79D9213076E600E3B2AD /* TNLRequestRetryPolicyTest.m */; };
 		8BFF0A1D19FF32D1001F42B7 /* NSDictionary+TNLAdditionsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BFF0A1C19FF32D1001F42B7 /* NSDictionary+TNLAdditionsTest.m */; };
 		8BFF0A6319FFEFED001F42B7 /* NSURLSessionConfiguration+TNLAdditionsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BFF0A6219FFEFED001F42B7 /* NSURLSessionConfiguration+TNLAdditionsTest.m */; };
-		B3B9EA031C3AF02100B8A451 /* module.modulemap in Headers */ = {isa = PBXBuildFile; fileRef = B3B9E9FE1C3AEDE700B8A451 /* module.modulemap */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF4765FA1EEEFC8600A23506 /* TwitterNetworkLayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF4AA13B1EE61D47001647B5 /* TwitterNetworkLayer.framework */; };
 		BF4AA0C21EE61D46001647B5 /* NSURLResponse+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B3586A91A1551DB00E82D51 /* NSURLResponse+TNLAdditions.m */; };
 		BF4AA0C31EE61D46001647B5 /* TNLRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE403021946794300C7241E /* TNLRequestOperation.m */; };
@@ -539,7 +539,6 @@
 		BF4AA1021EE61D46001647B5 /* TNLURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BAFBF0E1BDABAB500F36EFF /* TNLURLSessionManager.h */; };
 		BF4AA1031EE61D46001647B5 /* TNLBackgroundURLSessionTaskOperationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B2924BB1992E42900AC139A /* TNLBackgroundURLSessionTaskOperationManager.h */; };
 		BF4AA1041EE61D46001647B5 /* TNLHostSanitizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BB0E3A51A1FCFB6008CF992 /* TNLHostSanitizer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF4AA1051EE61D46001647B5 /* module.modulemap in Headers */ = {isa = PBXBuildFile; fileRef = B3B9E9FE1C3AEDE700B8A451 /* module.modulemap */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF4AA1061EE61D46001647B5 /* NSURLSessionConfiguration+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BFDF956199ADF4300248C3D /* NSURLSessionConfiguration+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF4AA1071EE61D46001647B5 /* TNLRequestHydrater.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B2DF7D0199D7F2600A064B3 /* TNLRequestHydrater.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF4AA1081EE61D46001647B5 /* TNLHTTP.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE4032319467A1400C7241E /* TNLHTTP.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -656,15 +655,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		8B9EBDEC2135B4B100E6E466 /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "include/$(PRODUCT_NAME)";
-			dstSubfolderSpec = 16;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		8BDB97E71D24D28800861951 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -674,33 +664,6 @@
 				8BDB97E31D24D28700861951 /* TwitterNetworkLayer.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		8BE402C41946743D00C7241E /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "include/$(PRODUCT_NAME)";
-			dstSubfolderSpec = 16;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		8BFDF9432135AB2C002F6A80 /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "include/$(PRODUCT_NAME)";
-			dstSubfolderSpec = 16;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		BF4AA0F51EE61D46001647B5 /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "include/$(PRODUCT_NAME)";
-			dstSubfolderSpec = 16;
-			files = (
-			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -725,6 +688,7 @@
 		8B0DDD2319C7456A004BEE4B /* TNLNetwork.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TNLNetwork.h; sourceTree = "<group>"; };
 		8B0DDD2419C7456A004BEE4B /* TNLNetwork.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TNLNetwork.m; sourceTree = "<group>"; };
 		8B0E0C4C1DE69C5700283B45 /* BingResults.json.base64 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = BingResults.json.base64; sourceTree = "<group>"; };
+		8B10826D2252BC9B009C8ECB /* TNLURLSessionManagerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TNLURLSessionManagerTest.m; sourceTree = "<group>"; };
 		8B109D6B20B63F15000D10AA /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		8B109D6C20B63F16000D10AA /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		8B13EB9D19C9F7580098E349 /* TNLResponse_Project.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TNLResponse_Project.h; sourceTree = "<group>"; };
@@ -911,7 +875,6 @@
 		8BFE79D9213076E600E3B2AD /* TNLRequestRetryPolicyTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TNLRequestRetryPolicyTest.m; sourceTree = "<group>"; };
 		8BFF0A1C19FF32D1001F42B7 /* NSDictionary+TNLAdditionsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+TNLAdditionsTest.m"; sourceTree = "<group>"; };
 		8BFF0A6219FFEFED001F42B7 /* NSURLSessionConfiguration+TNLAdditionsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURLSessionConfiguration+TNLAdditionsTest.m"; sourceTree = "<group>"; };
-		B3B9E9FE1C3AEDE700B8A451 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		BF4AA13B1EE61D47001647B5 /* TwitterNetworkLayer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TwitterNetworkLayer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF4AA16A1EE626ED001647B5 /* TwitterNetworkLayerTests MacOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "TwitterNetworkLayerTests MacOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -1145,7 +1108,6 @@
 				8B7106E920B99DF300A78535 /* LICENSE */,
 				8BE402C71946743D00C7241E /* Products */,
 				8B109D6B20B63F15000D10AA /* README.md */,
-				B3B9E9FD1C3AEDD700B8A451 /* Resources */,
 				8BE402CB1946743E00C7241E /* Source */,
 				8BDFFC0919814D3100F7F670 /* TNLExample */,
 				8BE402DF1946743E00C7241E /* TwitterNetworkLayerTests */,
@@ -1317,6 +1279,7 @@
 				8B8434891A13B8E500D006DA /* TNLResponseTest.m */,
 				8B227B831A004F97003B1C7C /* TNLTemporaryFileTest.m */,
 				8B84347B1A13B70C00D006DA /* TNLURLCodingTest.m */,
+				8B10826D2252BC9B009C8ECB /* TNLURLSessionManagerTest.m */,
 				8B6E34281DE35FCD004A35C7 /* TNLXContentEncoding.h */,
 				8B6E34291DE35FCD004A35C7 /* TNLXContentEncoding.m */,
 			);
@@ -1332,14 +1295,6 @@
 				8BE402E11946743E00C7241E /* TwitterNetworkLayerTests-Info.plist */,
 			);
 			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		B3B9E9FD1C3AEDD700B8A451 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				B3B9E9FE1C3AEDE700B8A451 /* module.modulemap */,
-			);
-			path = Resources;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1364,7 +1319,6 @@
 				8B9EBDFA2135B4B100E6E466 /* TNLURLSessionManager.h in Headers */,
 				8B9EBDFB2135B4B100E6E466 /* TNLBackgroundURLSessionTaskOperationManager.h in Headers */,
 				8B9EBDFC2135B4B100E6E466 /* TNLHostSanitizer.h in Headers */,
-				8B9EBDFD2135B4B100E6E466 /* module.modulemap in Headers */,
 				8B9EBDFE2135B4B100E6E466 /* NSURLSessionConfiguration+TNLAdditions.h in Headers */,
 				8B9EBDFF2135B4B100E6E466 /* TNLRequestHydrater.h in Headers */,
 				8B9EBE002135B4B100E6E466 /* TNLHTTP.h in Headers */,
@@ -1440,7 +1394,6 @@
 				8BAFBF111BDABAB500F36EFF /* TNLURLSessionManager.h in Headers */,
 				8B2924BD1992E42900AC139A /* TNLBackgroundURLSessionTaskOperationManager.h in Headers */,
 				8BB0E3A71A1FCFB6008CF992 /* TNLHostSanitizer.h in Headers */,
-				B3B9EA031C3AF02100B8A451 /* module.modulemap in Headers */,
 				8BFDF958199ADF4300248C3D /* NSURLSessionConfiguration+TNLAdditions.h in Headers */,
 				8B2DF7D1199D7F2600A064B3 /* TNLRequestHydrater.h in Headers */,
 				8BE4032519467A1400C7241E /* TNLHTTP.h in Headers */,
@@ -1516,7 +1469,6 @@
 				8BFDF9512135AB2C002F6A80 /* TNLURLSessionManager.h in Headers */,
 				8BFDF9522135AB2C002F6A80 /* TNLBackgroundURLSessionTaskOperationManager.h in Headers */,
 				8BFDF9532135AB2C002F6A80 /* TNLHostSanitizer.h in Headers */,
-				8BFDF9542135AB2C002F6A80 /* module.modulemap in Headers */,
 				8BFDF9552135AB2C002F6A80 /* NSURLSessionConfiguration+TNLAdditions.h in Headers */,
 				8BFDF9562135AB2C002F6A80 /* TNLRequestHydrater.h in Headers */,
 				8BFDF9572135AB2C002F6A80 /* TNLHTTP.h in Headers */,
@@ -1591,7 +1543,6 @@
 				BF4AA1021EE61D46001647B5 /* TNLURLSessionManager.h in Headers */,
 				BF4AA1031EE61D46001647B5 /* TNLBackgroundURLSessionTaskOperationManager.h in Headers */,
 				BF4AA1041EE61D46001647B5 /* TNLHostSanitizer.h in Headers */,
-				BF4AA1051EE61D46001647B5 /* module.modulemap in Headers */,
 				BF4AA1061EE61D46001647B5 /* NSURLSessionConfiguration+TNLAdditions.h in Headers */,
 				BF4AA1071EE61D46001647B5 /* TNLRequestHydrater.h in Headers */,
 				BF4AA1081EE61D46001647B5 /* TNLHTTP.h in Headers */,
@@ -1655,10 +1606,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8B9EBE332135B4B100E6E466 /* Build configuration list for PBXNativeTarget "TwitterNetworkLayer watchOS" */;
 			buildPhases = (
+				8B9EBDED2135B4B100E6E466 /* Headers */,
 				8B9EBDB62135B4B100E6E466 /* Sources */,
 				8B9EBDE32135B4B100E6E466 /* Frameworks */,
-				8B9EBDEC2135B4B100E6E466 /* CopyFiles */,
-				8B9EBDED2135B4B100E6E466 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1692,10 +1642,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8BE402E91946743E00C7241E /* Build configuration list for PBXNativeTarget "TwitterNetworkLayer" */;
 			buildPhases = (
+				8BE402F91946786900C7241E /* Headers */,
 				8BE402C21946743D00C7241E /* Sources */,
 				8BE402C31946743D00C7241E /* Frameworks */,
-				8BE402C41946743D00C7241E /* CopyFiles */,
-				8BE402F91946786900C7241E /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1728,10 +1677,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8BFDF98A2135AB2C002F6A80 /* Build configuration list for PBXNativeTarget "TwitterNetworkLayer tvOS" */;
 			buildPhases = (
+				8BFDF9442135AB2C002F6A80 /* Headers */,
 				8BFDF90D2135AB2C002F6A80 /* Sources */,
 				8BFDF93A2135AB2C002F6A80 /* Frameworks */,
-				8BFDF9432135AB2C002F6A80 /* CopyFiles */,
-				8BFDF9442135AB2C002F6A80 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1764,10 +1712,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = BF4AA1381EE61D46001647B5 /* Build configuration list for PBXNativeTarget "TwitterNetworkLayer macOS" */;
 			buildPhases = (
+				BF4AA0F61EE61D46001647B5 /* Headers */,
 				BF4AA0C11EE61D46001647B5 /* Sources */,
 				BF4AA0ED1EE61D46001647B5 /* Frameworks */,
-				BF4AA0F51EE61D46001647B5 /* CopyFiles */,
-				BF4AA0F61EE61D46001647B5 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1803,7 +1750,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = TNL;
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = Twitter;
 				TargetAttributes = {
 					8B9EBDB52135B4B100E6E466 = {
@@ -1835,9 +1782,10 @@
 			};
 			buildConfigurationList = 8BE402C11946743D00C7241E /* Build configuration list for PBXProject "TwitterNetworkLayer" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -2038,6 +1986,7 @@
 				8B986C651BE3EF1D0053BB14 /* TNLHTTPTests.m in Sources */,
 				8B8FA3341AF426B200BC91DF /* TNLRequestOperationQueueTest.m in Sources */,
 				8B23E00D19FFF799007C1E35 /* TNLRequestTests.m in Sources */,
+				8B10826E2252BC9B009C8ECB /* TNLURLSessionManagerTest.m in Sources */,
 				8B227B841A004F97003B1C7C /* TNLTemporaryFileTest.m in Sources */,
 				8B8A683E19FEEB51008623E8 /* TNLParameterCollectionTests.m in Sources */,
 				8B84348C1A13BF3C00D006DA /* TNLRequestOperationTest.m in Sources */,
@@ -2119,6 +2068,7 @@
 				8BFDF9952135ACDB002F6A80 /* TNLHTTPTests.m in Sources */,
 				8BFDF9962135ACDB002F6A80 /* TNLRequestOperationQueueTest.m in Sources */,
 				8BFDF9972135ACDB002F6A80 /* TNLRequestTests.m in Sources */,
+				8B1082702252BC9B009C8ECB /* TNLURLSessionManagerTest.m in Sources */,
 				8BFDF9982135ACDB002F6A80 /* TNLTemporaryFileTest.m in Sources */,
 				8BFDF9992135ACDB002F6A80 /* TNLParameterCollectionTests.m in Sources */,
 				8BFDF99A2135ACDB002F6A80 /* TNLRequestOperationTest.m in Sources */,
@@ -2200,6 +2150,7 @@
 				BF4AA1431EE626ED001647B5 /* TNLHTTPTests.m in Sources */,
 				BF4AA1441EE626ED001647B5 /* TNLRequestOperationQueueTest.m in Sources */,
 				BF4AA1451EE626ED001647B5 /* TNLRequestTests.m in Sources */,
+				8B10826F2252BC9B009C8ECB /* TNLURLSessionManagerTest.m in Sources */,
 				BF4AA1461EE626ED001647B5 /* TNLTemporaryFileTest.m in Sources */,
 				BF4AA1481EE626ED001647B5 /* TNLParameterCollectionTests.m in Sources */,
 				BF4AA1491EE626ED001647B5 /* TNLRequestOperationTest.m in Sources */,
@@ -2385,7 +2336,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 2.3;
+				CURRENT_PROJECT_VERSION = 2.6;
 				DEAD_CODE_STRIPPING = NO;
 				DYLIB_CURRENT_VERSION = "$(CURRENT_PROJECT_VERSION)";
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -2452,7 +2403,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2.3;
+				CURRENT_PROJECT_VERSION = 2.6;
 				DEAD_CODE_STRIPPING = NO;
 				DYLIB_CURRENT_VERSION = "$(CURRENT_PROJECT_VERSION)";
 				DYLIB_INSTALL_NAME_BASE = "@rpath";

--- a/TwitterNetworkLayer.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/TwitterNetworkLayer.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>

--- a/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TNLExample.xcscheme
+++ b/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TNLExample.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer macOS.xcscheme
+++ b/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer tvOS.xcscheme
+++ b/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer watchOS.xcscheme
+++ b/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer.xcscheme
+++ b/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TwitterNetworkLayerTests/TNLURLSessionManagerTest.m
+++ b/TwitterNetworkLayerTests/TNLURLSessionManagerTest.m
@@ -1,0 +1,340 @@
+//
+//  TNLURLSessionManagerTest.m
+//  TwitterNetworkLayer
+//
+//  Created by Nolan on 4/1/19.
+//  Copyright © 2019 Twitter. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "TNLPseudoURLProtocol.h"
+#import "TNLRequestOperation.h"
+#import "TNLRequestOperationQueue.h"
+#import "TNLURLSessionManager.h"
+
+
+#define kFAKE_URL @"https://www.dummy.com/fake/url.html"
+
+@interface TNLURLSessionManagerTest : XCTestCase
+@end
+
+@implementation TNLURLSessionManagerTest
+
++ (void)setUp
+{
+    [super setUp];
+
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:kFAKE_URL]
+                                                              statusCode:200
+                                                             HTTPVersion:@"http/1.1"
+                                                            headerFields:nil];
+    NSData *data = [@"success" dataUsingEncoding:NSUTF8StringEncoding];
+    [TNLPseudoURLProtocol registerURLResponse:response
+                                         body:data
+                                 withEndpoint:response.URL];
+}
+
++ (void)tearDown
+{
+    [TNLPseudoURLProtocol unregisterEndpoint:[NSURL URLWithString:kFAKE_URL]];
+
+    [super tearDown];
+}
+
+- (void)setUp
+{
+}
+
+- (void)tearDown
+{
+    [TNLGlobalConfiguration sharedInstance].URLSessionInactivityThreshold = -1;
+    [TNLGlobalConfiguration sharedInstance].URLSessionPruneOptions = 0;
+}
+
+- (void)testAddingAndPruningSessions
+{
+    __block NSUInteger prevForegroundSessionCount = 0;
+    __block NSUInteger prevBackgroundSessionCount = 0;
+    __block NSUInteger currentForegroundSessionCount = 0;
+    __block NSUInteger currentBackgroundSessionCount = 0;
+    NSURL *url = [NSURL URLWithString:kFAKE_URL];
+    TNLMutableRequestConfiguration *config = [TNLMutableRequestConfiguration defaultConfiguration];
+    config.protocolOptions |= TNLRequestProtocolOptionPseudo;
+    TNLRequestOperation *op = nil;
+    XCTestExpectation *expectation = nil;
+
+    // Forcibly prune all sessions (must do in order to ensure we know what sessions are used)
+
+    [TNLGlobalConfiguration sharedInstance].URLSessionInactivityThreshold = 0.0;
+    [TNLGlobalConfiguration sharedInstance].URLSessionPruneOptions = TNLGlobalConfigurationURLSessionPruneOptionNow;
+
+    expectation = [self expectationWithDescription:@"Wait For New NSURLSessions after failed Prune"];
+    [[TNLURLSessionManager sharedInstance] getAllURLSessions:^(NSArray<NSURLSession *> *foregroundSessions, NSArray<NSURLSession *> *backgroundSessions) {
+        currentForegroundSessionCount = foregroundSessions.count;
+        currentBackgroundSessionCount = backgroundSessions.count;
+        [expectation fulfill];
+    }];
+    [self waitForExpectations:@[expectation] timeout:10.0];
+
+    XCTAssertEqual(currentForegroundSessionCount, 0);
+    XCTAssertEqual(currentBackgroundSessionCount, prevBackgroundSessionCount);
+    prevForegroundSessionCount = currentForegroundSessionCount;
+    prevBackgroundSessionCount = currentBackgroundSessionCount;
+
+    // Initial sessions
+
+    expectation = [self expectationWithDescription:@"Wait For Initial List of NSURLSessions"];
+    [[TNLURLSessionManager sharedInstance] getAllURLSessions:^(NSArray<NSURLSession *> *foregroundSessions, NSArray<NSURLSession *> *backgroundSessions) {
+        prevForegroundSessionCount = foregroundSessions.count;
+        prevBackgroundSessionCount = backgroundSessions.count;
+        [expectation fulfill];
+    }];
+    [self waitForExpectations:@[expectation] timeout:10.0];
+
+    // Add a session
+
+    op = [TNLRequestOperation operationWithURL:url
+                                 configuration:config
+                                      delegate:nil];
+    [[TNLRequestOperationQueue defaultOperationQueue] enqueueRequestOperation:op];
+    [op waitUntilFinishedWithoutBlockingRunLoop];
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]]; // brief delay
+
+    expectation = [self expectationWithDescription:@"Wait For New NSURLSessions"];
+    [[TNLURLSessionManager sharedInstance] getAllURLSessions:^(NSArray<NSURLSession *> *foregroundSessions, NSArray<NSURLSession *> *backgroundSessions) {
+        currentForegroundSessionCount = foregroundSessions.count;
+        currentBackgroundSessionCount = backgroundSessions.count;
+        [expectation fulfill];
+    }];
+    [self waitForExpectations:@[expectation] timeout:10.0];
+
+    XCTAssertGreaterThan(currentForegroundSessionCount, prevForegroundSessionCount);
+    XCTAssertEqual(currentBackgroundSessionCount, prevBackgroundSessionCount);
+    prevForegroundSessionCount = currentForegroundSessionCount;
+    prevBackgroundSessionCount = currentBackgroundSessionCount;
+
+    // Add session, different config
+
+    [config configureAsLowPriority];
+    op = [TNLRequestOperation operationWithURL:url
+                                 configuration:config
+                                      delegate:nil];
+    [[TNLRequestOperationQueue defaultOperationQueue] enqueueRequestOperation:op];
+    [op waitUntilFinishedWithoutBlockingRunLoop];
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]]; // brief delay
+
+    expectation = [self expectationWithDescription:@"Wait For New NSURLSessions"];
+    [[TNLURLSessionManager sharedInstance] getAllURLSessions:^(NSArray<NSURLSession *> *foregroundSessions, NSArray<NSURLSession *> *backgroundSessions) {
+        currentForegroundSessionCount = foregroundSessions.count;
+        currentBackgroundSessionCount = backgroundSessions.count;
+        [expectation fulfill];
+    }];
+    [self waitForExpectations:@[expectation] timeout:10.0];
+
+    XCTAssertGreaterThan(currentForegroundSessionCount, prevForegroundSessionCount);
+    XCTAssertEqual(currentBackgroundSessionCount, prevBackgroundSessionCount);
+    prevForegroundSessionCount = currentForegroundSessionCount;
+    prevBackgroundSessionCount = currentBackgroundSessionCount;
+
+    // Change Timeouts, don't change session count
+
+    config.idleTimeout = 10.0;
+    config.attemptTimeout = 20.0;
+    config.operationTimeout = 30.0;
+    op = [TNLRequestOperation operationWithURL:url
+                                 configuration:config
+                                      delegate:nil];
+    [[TNLRequestOperationQueue defaultOperationQueue] enqueueRequestOperation:op];
+    [op waitUntilFinishedWithoutBlockingRunLoop];
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]]; // brief delay
+
+    expectation = [self expectationWithDescription:@"Wait For More New NSURLSessions"];
+    [[TNLURLSessionManager sharedInstance] getAllURLSessions:^(NSArray<NSURLSession *> *foregroundSessions, NSArray<NSURLSession *> *backgroundSessions) {
+        currentForegroundSessionCount = foregroundSessions.count;
+        currentBackgroundSessionCount = backgroundSessions.count;
+        [expectation fulfill];
+    }];
+    [self waitForExpectations:@[expectation] timeout:10.0];
+
+    XCTAssertEqual(currentForegroundSessionCount, prevForegroundSessionCount);
+    XCTAssertEqual(currentBackgroundSessionCount, prevBackgroundSessionCount);
+    prevForegroundSessionCount = currentForegroundSessionCount;
+    prevBackgroundSessionCount = currentBackgroundSessionCount;
+
+    // Forcibly prune specific session
+
+    [[TNLGlobalConfiguration sharedInstance] pruneURLSessionMatchingRequestConfiguration:config
+                                                                        operationQueueId:nil];
+
+    expectation = [self expectationWithDescription:@"Wait For New NSURLSessions after Prune"];
+    [[TNLURLSessionManager sharedInstance] getAllURLSessions:^(NSArray<NSURLSession *> *foregroundSessions, NSArray<NSURLSession *> *backgroundSessions) {
+        currentForegroundSessionCount = foregroundSessions.count;
+        currentBackgroundSessionCount = backgroundSessions.count;
+        [expectation fulfill];
+    }];
+    [self waitForExpectations:@[expectation] timeout:10.0];
+
+    XCTAssertLessThan(currentForegroundSessionCount, prevForegroundSessionCount);
+    XCTAssertNotEqual(currentForegroundSessionCount, 0);
+    XCTAssertEqual(currentBackgroundSessionCount, prevBackgroundSessionCount);
+    prevForegroundSessionCount = currentForegroundSessionCount;
+    prevBackgroundSessionCount = currentBackgroundSessionCount;
+
+    // Forcibly prune all sessions (won't prune due to threshold)
+
+    [TNLGlobalConfiguration sharedInstance].URLSessionInactivityThreshold = -1;
+    [TNLGlobalConfiguration sharedInstance].URLSessionPruneOptions = TNLGlobalConfigurationURLSessionPruneOptionNow;
+
+    expectation = [self expectationWithDescription:@"Wait For New NSURLSessions after failed Prune"];
+    [[TNLURLSessionManager sharedInstance] getAllURLSessions:^(NSArray<NSURLSession *> *foregroundSessions, NSArray<NSURLSession *> *backgroundSessions) {
+        currentForegroundSessionCount = foregroundSessions.count;
+        currentBackgroundSessionCount = backgroundSessions.count;
+        [expectation fulfill];
+    }];
+    [self waitForExpectations:@[expectation] timeout:10.0];
+
+    XCTAssertNotEqual(currentForegroundSessionCount, 0);
+    XCTAssertEqual(currentBackgroundSessionCount, prevBackgroundSessionCount);
+    prevForegroundSessionCount = currentForegroundSessionCount;
+    prevBackgroundSessionCount = currentBackgroundSessionCount;
+
+    // Forcibly prune all sessions (will prune due to zero threshold)
+
+    [TNLGlobalConfiguration sharedInstance].URLSessionInactivityThreshold = 0.0;
+    [TNLGlobalConfiguration sharedInstance].URLSessionPruneOptions = TNLGlobalConfigurationURLSessionPruneOptionNow;
+
+    expectation = [self expectationWithDescription:@"Wait For New NSURLSessions after full Prune"];
+    [[TNLURLSessionManager sharedInstance] getAllURLSessions:^(NSArray<NSURLSession *> *foregroundSessions, NSArray<NSURLSession *> *backgroundSessions) {
+        currentForegroundSessionCount = foregroundSessions.count;
+        currentBackgroundSessionCount = backgroundSessions.count;
+        [expectation fulfill];
+    }];
+    [self waitForExpectations:@[expectation] timeout:10.0];
+
+    XCTAssertEqual(currentForegroundSessionCount, 0);
+    XCTAssertEqual(currentBackgroundSessionCount, prevBackgroundSessionCount);
+    prevForegroundSessionCount = currentForegroundSessionCount;
+    prevBackgroundSessionCount = currentBackgroundSessionCount;
+
+#if TARGET_OS_IOS || TARGET_OS_TVOS
+
+    // Update pruning criteria
+
+    [TNLGlobalConfiguration sharedInstance].URLSessionInactivityThreshold = 0.0;
+    [TNLGlobalConfiguration sharedInstance].URLSessionPruneOptions = TNLGlobalConfigurationURLSessionPruneOptionOnMemoryWarning | TNLGlobalConfigurationURLSessionPruneOptionOnApplicationBackground;
+
+    // Add a session back
+
+    op = [TNLRequestOperation operationWithURL:url
+                                 configuration:config
+                                      delegate:nil];
+    [[TNLRequestOperationQueue defaultOperationQueue] enqueueRequestOperation:op];
+    [op waitUntilFinishedWithoutBlockingRunLoop];
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]]; // brief delay
+
+    expectation = [self expectationWithDescription:@"Wait For another New NSURLSessions"];
+    [[TNLURLSessionManager sharedInstance] getAllURLSessions:^(NSArray<NSURLSession *> *foregroundSessions, NSArray<NSURLSession *> *backgroundSessions) {
+        currentForegroundSessionCount = foregroundSessions.count;
+        currentBackgroundSessionCount = backgroundSessions.count;
+        [expectation fulfill];
+    }];
+    [self waitForExpectations:@[expectation] timeout:10.0];
+
+    XCTAssertGreaterThan(currentForegroundSessionCount, prevForegroundSessionCount);
+    XCTAssertEqual(currentBackgroundSessionCount, prevBackgroundSessionCount);
+    prevForegroundSessionCount = currentForegroundSessionCount;
+    prevBackgroundSessionCount = currentBackgroundSessionCount;
+
+    // Prune on memory warnings
+
+    [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationDidReceiveMemoryWarningNotification object:nil];
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]]; // brief delay
+
+    expectation = [self expectationWithDescription:@"Wait For NSURLSessions pruning on memory warning"];
+    [[TNLURLSessionManager sharedInstance] getAllURLSessions:^(NSArray<NSURLSession *> *foregroundSessions, NSArray<NSURLSession *> *backgroundSessions) {
+        currentForegroundSessionCount = foregroundSessions.count;
+        currentBackgroundSessionCount = backgroundSessions.count;
+        [expectation fulfill];
+    }];
+    [self waitForExpectations:@[expectation] timeout:10.0];
+
+    XCTAssertEqual(currentForegroundSessionCount, 0);
+    XCTAssertEqual(currentBackgroundSessionCount, prevBackgroundSessionCount);
+    prevForegroundSessionCount = currentForegroundSessionCount;
+    prevBackgroundSessionCount = currentBackgroundSessionCount;
+
+    // Add a session back
+
+    op = [TNLRequestOperation operationWithURL:url
+                                 configuration:config
+                                      delegate:nil];
+    [[TNLRequestOperationQueue defaultOperationQueue] enqueueRequestOperation:op];
+    [op waitUntilFinishedWithoutBlockingRunLoop];
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]]; // brief delay
+
+    expectation = [self expectationWithDescription:@"Wait For another New NSURLSessions"];
+    [[TNLURLSessionManager sharedInstance] getAllURLSessions:^(NSArray<NSURLSession *> *foregroundSessions, NSArray<NSURLSession *> *backgroundSessions) {
+        currentForegroundSessionCount = foregroundSessions.count;
+        currentBackgroundSessionCount = backgroundSessions.count;
+        [expectation fulfill];
+    }];
+    [self waitForExpectations:@[expectation] timeout:10.0];
+
+    XCTAssertGreaterThan(currentForegroundSessionCount, prevForegroundSessionCount);
+    XCTAssertEqual(currentBackgroundSessionCount, prevBackgroundSessionCount);
+    prevForegroundSessionCount = currentForegroundSessionCount;
+    prevBackgroundSessionCount = currentBackgroundSessionCount;
+
+    // Prune on application background
+
+    [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillResignActiveNotification object:nil];
+    [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationDidEnterBackgroundNotification object:nil];
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]]; // brief delay
+    [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillEnterForegroundNotification object:nil];
+    [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationDidBecomeActiveNotification object:nil];
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]]; // brief delay
+
+    expectation = [self expectationWithDescription:@"Wait For NSURLSessions pruning on application background"];
+    [[TNLURLSessionManager sharedInstance] getAllURLSessions:^(NSArray<NSURLSession *> *foregroundSessions, NSArray<NSURLSession *> *backgroundSessions) {
+        currentForegroundSessionCount = foregroundSessions.count;
+        currentBackgroundSessionCount = backgroundSessions.count;
+        [expectation fulfill];
+    }];
+    [self waitForExpectations:@[expectation] timeout:10.0];
+
+    XCTAssertEqual(currentForegroundSessionCount, 0);
+    XCTAssertEqual(currentBackgroundSessionCount, prevBackgroundSessionCount);
+    prevForegroundSessionCount = currentForegroundSessionCount;
+    prevBackgroundSessionCount = currentBackgroundSessionCount;
+
+#endif
+
+    // Add a session, but it is removed immediately
+
+    [TNLGlobalConfiguration sharedInstance].URLSessionInactivityThreshold = 0.0;
+    [TNLGlobalConfiguration sharedInstance].URLSessionPruneOptions = TNLGlobalConfigurationURLSessionPruneOptionAfterEveryTask;
+
+    op = [TNLRequestOperation operationWithURL:url
+                                 configuration:config
+                                      delegate:nil];
+    [[TNLRequestOperationQueue defaultOperationQueue] enqueueRequestOperation:op];
+    [op waitUntilFinishedWithoutBlockingRunLoop];
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]]; // brief delay
+
+    expectation = [self expectationWithDescription:@"Wait For another New NSURLSessions but it will already be gone"];
+    [[TNLURLSessionManager sharedInstance] getAllURLSessions:^(NSArray<NSURLSession *> *foregroundSessions, NSArray<NSURLSession *> *backgroundSessions) {
+        currentForegroundSessionCount = foregroundSessions.count;
+        currentBackgroundSessionCount = backgroundSessions.count;
+        [expectation fulfill];
+    }];
+    [self waitForExpectations:@[expectation] timeout:10.0];
+
+    XCTAssertEqual(currentForegroundSessionCount, 0);
+    XCTAssertEqual(currentBackgroundSessionCount, prevBackgroundSessionCount);
+    prevForegroundSessionCount = currentForegroundSessionCount;
+    prevBackgroundSessionCount = currentBackgroundSessionCount;
+}
+
+@end
+


### PR DESCRIPTION
### 2.6.1

- Fix terrible bug where cancelling all request operations for *any* `TNLRequestOperationQueue` will cancel *all* request operations for *all* queues!

### 2.6.0

- Move away from mach time for metrics to `NSDate` instances
  - This better mirrors what Apple does
  - Avoids the pitfall of using mach times as more than just measurements of durations and using them as reference timestamps (which is frought)
  - Using `NSDate` now does have the problem of clock changes impacting timings, but this is so infrequent it practically won't ever affect metrics from **TNL**
- Add `sessionId` to `TNLAttemptMetaData`
  - Helps keep track of what `NSURLSession` was used
- Add `taskResumePriority` to `TNLAttemptMetaData`
  - Helps keep track of what QOS was used when `resume` was called for the underlying `NSURLSessionTask`
- Add `taskResumeLatency` to `TNLAttemptMetaData`
  - Helps diagnose if there is some unforseen stall between calling `resume` for the task and the fetching actuallying starting
- Add `taskMetricsAfterCompletionLatency` and `taskWithoutMetricsCompletionLatency` to `TNLAttemptMetaData`
  - Helps track when radar `#27098270` occurs

### 2.5.0

- Add `[TNLGlobalConfiguration URLSessionPruneOptions]`
  - These options offer ways for __TNL__ to prune inactive internal `NSURLSession` instances more aggressively than the 12 session limit does
  - Options can be a combination of: on memory warning, on app background and/or after every network task
  - Callers can also provide a special option to prune _now_
- Add `[TNLGlobalConfiguration URLSessionInactivityThreshold]`
  - Works with `URLSessionPruneOptions` by limiting what `NSURLSession` intances are _inactive_ by requiring a duration to elapse since the last network task ran
- Add `[TNLGlobalConfiguration pruneURLSessionMatchingRequestConfiguration:operationQueueId:]`
  - Offers a way to explicitely purge a specific underlying `NSURLSession` based on a given `TNLRequestConfiguration` and a `TNLRequestOperationQueue` instance's `identifier`

### 2.4.1

Author: Laurentiu Dascalu
- Expose method on `TNLLogger` to redact desired header fields from being logged
 - Good for redacting things you don't want to log like `Authorization` header field

### 2.4.0
- Add captive portal detection to `TNLCommunicationAgent`
  - detects when a known HTTP (non-HTTPS) endpoint is intercepted via a captive portal
  - this mechanism is a solid tradeoff in coverage vs complexity
    - there are many ways captive portals can manifest beyond what _TNL_ detects
    - a 100% coverage is extremely complicated and 100% accuracy is not feasible
    - supporting the simplest mechanism for detection is sufficient for most detection use cases