### PR TITLE
Update to v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,18 @@
 
 ## Info
 
-**Document version:** 2.6.1
+**Document version:** 2.7.0
 
-**Last updated:** 05/30/2019
+**Last updated:** 06/05/2019
 
 **Author:** Nolan O'Brien
 
 ## History
+
+### 2.7.0
+ 
+ - Change `TNLRequestConfiguration` to accept a `TNLResponseHashComputeAlgorithm` to specify how to hash
+   - MD5 was marked deprecated in iOS 13, so providing a wider range of algorithms without eliminating MD5 support is needed
 
 ### 2.6.1
 

--- a/Source/NSCoder+TNLAdditions.h
+++ b/Source/NSCoder+TNLAdditions.h
@@ -1,0 +1,39 @@
+//
+//  NSCoder+TNLAdditions.h
+//  TwitterNetworkLayer
+//
+//  Created by Nolan on 6/5/19.
+//  Copyright © 2019 Twitter. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Additional methods for `NSCoder`
+ */
+@interface NSCoder (TNLAdditions)
+
+/**
+ Convenience method for loading an array with a known item class it will contain.
+ It can handle the decoded object being an array of the known class or just being an instance of the class itself.
+
+ @param itemClass the class of items in the encoded array
+ @param key the key that the object was encoded with
+ @return an `NSArray` of objects of the given _itemClass_ if decoding succeeds.
+ */
+- (nullable NSArray *)tnl_decodeArrayOfItemsOfClass:(Class)itemClass forKey:(NSString *)key;
+/**
+ Convenience method for loading an array with a known set of classes its items will contain.
+ It can handle the decoded object being an array of the known classes or just being an instance of one of the classes.
+
+ @param itemClasses the classes of items in the encoded array
+ @param key the key that the object was encoded with
+ @return an `NSArray` of objects of the given _itemClasses_ if decoding succeeds.
+ */
+- (nullable NSArray *)tnl_decodeArrayOfItemsOfClasses:(NSSet<Class> *)itemClasses forKey:(NSString *)key;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/NSCoder+TNLAdditions.m
+++ b/Source/NSCoder+TNLAdditions.m
@@ -1,0 +1,66 @@
+//
+//  NSCoder+TNLAdditions.m
+//  TwitterNetworkLayer
+//
+//  Created by Nolan on 6/5/19.
+//  Copyright © 2019 Twitter. All rights reserved.
+//
+
+#import "NSCoder+TNLAdditions.h"
+#import "TNL_Project.h"
+
+@implementation NSCoder (TNLAdditions)
+
+- (nullable NSArray *)tnl_decodeArrayOfItemsOfClass:(Class)itemClass forKey:(NSString *)key
+{
+    return [self tnl_decodeArrayOfItemsOfClasses:[NSSet setWithObject:itemClass] forKey:key];
+}
+
+- (nullable NSArray *)tnl_decodeArrayOfItemsOfClasses:(NSSet<Class> *)itemClasses forKey:(NSString *)key
+{
+    /**
+     OK, decoding containers is wonky as heck with NSCoder w/ secure coding.
+     You MUST specify both the concrete object classes that will be in the container AND
+     the container(s) itself/themselves.
+
+     We just care about an array here, so we add the `[NSArray class]` to the classes to decode.
+     If we had an NSDictionary of NSArray instances of NSDate objects, we would need to provide
+     `[NSDictionary class]`, `[NSArray class]` and `[NSDate class]` as the classes 😬
+
+     Now, since we are decoding with support for `NSArray` and the given item classes, we could get
+     back either an `NSArray` of item classes OR just a single instance of any one of the item classes.
+     To avoid unexpected return values, we will coerce anything that is a single instance into an
+     array of 1 object - preserving our expectation for an array return value.
+
+     If we were to try to decode just as an `NSArray` class, the decode would fail.
+     If we were to try to decode with just the item class(es), the decode would fail.
+     So, we'll use this convenience method to make it easier to decode our expected arrays within TNL.
+
+     The documentation for how this works is pretty non-existant:
+     https://developer.apple.com/documentation/foundation/nscoder/1442560-decodeobjectofclasses?language=objc
+     and in `NSCoder.h` there is just the signature, no comment.
+     */
+
+    id valueRaw = [self decodeObjectOfClasses:[itemClasses setByAddingObject:[NSArray class]] forKey:key];
+    if (valueRaw != nil) {
+        if ([itemClasses containsObject:[valueRaw class]]) {
+            return @[valueRaw];
+        }
+        if ([valueRaw isKindOfClass:[NSArray class]]) {
+            return valueRaw;
+        }
+
+        // got the wrong value -- should NEVER happen since the decode should
+        // catch anything outside of expectations.
+        TNLAssertNever();
+        [self failWithError:[NSError errorWithDomain:NSCocoaErrorDomain
+                                                code:NSCoderReadCorruptError
+                                            userInfo:@{
+                                                       NSDebugDescriptionErrorKey:
+                                                       [NSString stringWithFormat:@"value for key '%@' was of unexpected class '%@'.  Allowed classes are '%@'.", key, NSStringFromClass([valueRaw class]), itemClasses.allObjects]
+                                                       }]];
+    }
+    return nil;
+}
+
+@end

--- a/Source/NSURLCache+TNLAdditions.m
+++ b/Source/NSURLCache+TNLAdditions.m
@@ -173,10 +173,17 @@ NSURLCache *TNLGetURLCacheDemuxProxy()
     return self;
 }
 
+- (id)initWithMemoryCapacity:(NSUInteger)memoryCapacity diskCapacity:(NSUInteger)diskCapacity directoryURL:(nullable NSURL *)url
+{
+    return [self init];
+}
+
+#if !TARGET_OS_UIKITFORMAC
 - (id)initWithMemoryCapacity:(NSUInteger)memoryCapacity diskCapacity:(NSUInteger)diskCapacity diskPath:(nullable NSString *)path
 {
     return [self init];
 }
+#endif
 
 - (nullable NSCachedURLResponse *)cachedResponseForRequest:(NSURLRequest *)request
 {

--- a/Source/TNLAttemptMetaData.h
+++ b/Source/TNLAttemptMetaData.h
@@ -7,6 +7,7 @@
 //
 
 #import <TwitterNetworkLayer/TNLPriority.h>
+#import <TwitterNetworkLayer/TNLRequestConfiguration.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -92,13 +93,13 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) BOOL localCacheHit;
 - (BOOL)hasLocalCacheHit;
 
-/** Expected MD5 Hash of the response body */
-@property (nonatomic, readonly, nullable) NSData *expectedMD5Hash;
-- (BOOL)hasExpectedMD5Hash;
+/** The hash alogorithm of the response body */
+@property (nonatomic, readonly) TNLResponseHashComputeAlgorithm responseBodyHashAlgorithm;
+- (BOOL)hasResponseBodyHashAlgorithm;
 
-/** The MD5 Hash of the response body */
-@property (nonatomic, readonly, nullable) NSData *MD5Hash;
-- (BOOL)hasMD5Hash;
+/** The hash of the response body */
+@property (nonatomic, readonly, nullable) NSData *responseBodyHash;
+- (BOOL)hasResponseBodyHash;
 
 /** The Content-Length in the request */
 @property (nonatomic, readonly) SInt64 requestContentLength;

--- a/Source/TNLAttemptMetaData.m
+++ b/Source/TNLAttemptMetaData.m
@@ -49,7 +49,7 @@ static NSString * const kFinalKey = @"final";
 
 - (void)encodeWithCoder:(NSCoder *)aCoder
 {
-    [aCoder encodeObject:_metaDataDictionary forKey:kMetaDataDictionaryKey];
+    [aCoder encodeObject:[_metaDataDictionary copy] forKey:kMetaDataDictionaryKey];
     [aCoder encodeBool:_final forKey:kFinalKey];
 }
 

--- a/Source/TNLAttemptMetaData_Project.h
+++ b/Source/TNLAttemptMetaData_Project.h
@@ -42,8 +42,8 @@ PRIMITIVE_FIELD(layer8BodyBytesReceived, Layer8BodyBytesReceived, SInt64, longLo
 PRIMITIVE_FIELD(layer8BodyBytesTransmitted, Layer8BodyBytesTransmitted, SInt64, longLongValue) \
 PRIMITIVE_FIELD(serverResponseTime, ServerResponseTime, SInt64, longLongValue) \
 PRIMITIVE_FIELD(localCacheHit, LocalCacheHit, BOOL, boolValue) \
-OBJECT_FIELD(expectedMD5Hash, ExpectedMD5Hash, NSData) \
-OBJECT_FIELD(MD5Hash, MD5Hash, NSData) \
+PRIMITIVE_FIELD(responseBodyHashAlgorithm, ResponseBodyHashAlgorithm, TNLResponseHashComputeAlgorithm, integerValue) \
+OBJECT_FIELD(responseBodyHash, ResponseBodyHash, NSData) \
 OBJECT_FIELD(sessionId, SessionId, NSString) \
 \
 PRIMITIVE_FIELD(taskResumeLatency, TaskResumeLatency, NSTimeInterval, doubleValue) \

--- a/Source/TNLCommunicationAgent.h
+++ b/Source/TNLCommunicationAgent.h
@@ -80,6 +80,9 @@ FOUNDATION_EXTERN NSString * __nonnull TNLCaptivePortalStatusToString(TNLCaptive
 typedef NS_ENUM(NSInteger, TNLWWANRadioAccessTechnologyValue) {
     /** Unknown radio access tech */
     TNLWWANRadioAccessTechnologyValueUnknown    = 0,
+
+#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+
     /** 2G, `CTRadioAccessTechnologyGPRS` */
     TNLWWANRadioAccessTechnologyValueGPRS       = 1,
     /** 2G, `CTRadioAccessTechnologyEdge` */
@@ -110,6 +113,8 @@ typedef NS_ENUM(NSInteger, TNLWWANRadioAccessTechnologyValue) {
     TNLWWANRadioAccessTechnologyValueEHRPD      = 14,
     /** 4G, Not defined in `CTTelephonyNetworkInfo.h` */
     TNLWWANRadioAccessTechnologyValueHSPAP      = 15
+
+#endif // #if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
 };
 
 //! Convert a WWAN radio access technololgy `NSString` into a `TNLWWANRadioAccessTechnologyValue`
@@ -218,12 +223,12 @@ typedef void(^TNLCommunicationAgentIdentifyCaptivePortalStatusCallback)(TNLCapti
 @property (atomic, readonly) TNLNetworkReachabilityStatus currentReachabilityStatus;
 /** cached reachability flags */
 @property (atomic, readonly) SCNetworkReachabilityFlags currentReachabilityFlags;
-/** cached radio access technology */
+/** cached radio access technology. Note: `nil` for macOS and UIKit for Mac */
 @property (atomic, copy, readonly, nullable) NSString *currentWWANRadioAccessTechnology;
 /** cached captive portal status */
 @property (atomic, readonly) TNLCaptivePortalStatus currentCaptivePortalStatus;
 
-/** cached carrier info. Note: `nil` for macOS as there is no cellular carrier information */
+/** cached carrier info. Note: `nil` for macOS and UIKit for Mac as there is no cellular carrier information */
 @property (atomic, readonly, nullable) id<TNLCarrierInfo> currentCarrierInfo; // or use `synchronousCarrierInfo`, which is more robust but can be slower
 
 @end

--- a/Source/TNLCommunicationAgent.m
+++ b/Source/TNLCommunicationAgent.m
@@ -71,7 +71,7 @@ static void _agent_handleCaptivePortalResponse(SELF_ARG,
 @end
 
 @interface TNLCommunicationAgent (Private)
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
 static void _updateCarrier(SELF_ARG,
                            CTCarrier *carrier);
 #endif
@@ -95,7 +95,7 @@ static void _updateCarrier(SELF_ARG,
     TNLCommunicationAgentWeakWrapper *_agentWrapper;
 
     SCNetworkReachabilityRef _reachabilityRef;
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
     CTTelephonyNetworkInfo *_internalTelephonyNetworkInfo;
 #endif
     NSURLSessionConfiguration *_captivePortalSessionConfiguration;
@@ -152,7 +152,7 @@ static void _updateCarrier(SELF_ARG,
         CFRelease(_reachabilityRef);
     }
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
     [[NSNotificationCenter defaultCenter] removeObserver:self
                                                     name:CTRadioAccessTechnologyDidChangeNotification
                                                   object:nil];
@@ -276,7 +276,7 @@ static void _agent_initializeTelephony(SELF_ARG)
         return;
     }
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
     __weak typeof(self) weakSelf = self;
 
     self->_internalTelephonyNetworkInfo = [[CTTelephonyNetworkInfo alloc] init];
@@ -288,7 +288,7 @@ static void _agent_initializeTelephony(SELF_ARG)
                                                  name:CTRadioAccessTechnologyDidChangeNotification object:nil];
     self.currentCarrierInfo = [TNLCarrierInfoInternal carrierWithCarrier:self->_internalTelephonyNetworkInfo.subscriberCellularProvider];
     self.currentWWANRadioAccessTechnology = [self->_internalTelephonyNetworkInfo.currentRadioAccessTechnology copy];
-#endif
+#endif // #if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
 
     self->_flags.initializedCarrier = 1;
     self->_flags.initializedRadioTech = 1;
@@ -308,8 +308,8 @@ static void _agent_initializeCaptivePortalStatus(SELF_ARG)
     config.URLCache = nil;
     config.URLCredentialStorage = nil;
     config.HTTPCookieStorage = nil;
-    config.TLSMinimumSupportedProtocol = kSSLProtocolUnknown;
-    config.TLSMaximumSupportedProtocol = kSSLProtocolUnknown;
+    config.TLSMinimumSupportedProtocol = 0;
+    config.TLSMaximumSupportedProtocol = 0;
     config.allowsCellularAccess = YES;
     config.requestCachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
     config.HTTPShouldSetCookies = NO;
@@ -653,7 +653,7 @@ static void _agent_updateReachabilityFlags(SELF_ARG,
 
 @implementation TNLCommunicationAgent (Private)
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
 static void _updateCarrier(SELF_ARG,
                            CTCarrier *carrier)
 {
@@ -678,7 +678,7 @@ static void _updateCarrier(SELF_ARG,
         });
     });
 }
-#endif
+#endif // #if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
 
 - (void)private_updateRadioAccessTechnology:(NSNotification *)note
 {
@@ -707,7 +707,7 @@ static void _updateCarrier(SELF_ARG,
 
 @end
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
 @implementation TNLCarrierInfoInternal
 
 @synthesize carrierName = _carrierName;
@@ -776,7 +776,7 @@ static void _updateCarrier(SELF_ARG,
 }
 
 @end
-#endif
+#endif // #if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
 
 @implementation TNLCommunicationAgent (UnsafeSynchronousAccess)
 
@@ -845,7 +845,7 @@ TNLWWANRadioAccessTechnologyValue TNLWWANRadioAccessTechnologyValueFromString(NS
 
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
         sTechStringToValueMap = @{
                                   CTRadioAccessTechnologyGPRS : @(TNLWWANRadioAccessTechnologyValueGPRS),
                                   CTRadioAccessTechnologyEdge: @(TNLWWANRadioAccessTechnologyValueEDGE),
@@ -870,8 +870,8 @@ TNLWWANRadioAccessTechnologyValue TNLWWANRadioAccessTechnologyValueFromString(NS
 
 NSString *TNLWWANRadioAccessTechnologyValueToString(TNLWWANRadioAccessTechnologyValue value)
 {
+#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
     switch (value) {
-#if TARGET_OS_IOS
         case TNLWWANRadioAccessTechnologyValueGPRS:
             return CTRadioAccessTechnologyGPRS;
         case TNLWWANRadioAccessTechnologyValueEDGE:
@@ -894,19 +894,6 @@ NSString *TNLWWANRadioAccessTechnologyValueToString(TNLWWANRadioAccessTechnology
             return CTRadioAccessTechnologyLTE;
         case TNLWWANRadioAccessTechnologyValueEHRPD:
             return CTRadioAccessTechnologyeHRPD;
-#else
-        case TNLWWANRadioAccessTechnologyValueGPRS:
-        case TNLWWANRadioAccessTechnologyValueEDGE:
-        case TNLWWANRadioAccessTechnologyValueUMTS:
-        case TNLWWANRadioAccessTechnologyValueHSDPA:
-        case TNLWWANRadioAccessTechnologyValueHSUPA:
-        case TNLWWANRadioAccessTechnologyValueEVDO_0:
-        case TNLWWANRadioAccessTechnologyValueEVDO_A:
-        case TNLWWANRadioAccessTechnologyValueEVDO_B:
-        case TNLWWANRadioAccessTechnologyValue1xRTT:
-        case TNLWWANRadioAccessTechnologyValueLTE:
-        case TNLWWANRadioAccessTechnologyValueEHRPD:
-#endif
         case TNLWWANRadioAccessTechnologyValueHSPA:
         case TNLWWANRadioAccessTechnologyValueCDMA:
         case TNLWWANRadioAccessTechnologyValueIDEN:
@@ -914,12 +901,14 @@ NSString *TNLWWANRadioAccessTechnologyValueToString(TNLWWANRadioAccessTechnology
         case TNLWWANRadioAccessTechnologyValueUnknown:
             break;
     }
+#endif // TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
 
     return @"unknown";
 }
 
 TNLWWANRadioAccessGeneration TNLWWANRadioAccessGenerationForTechnologyValue(TNLWWANRadioAccessTechnologyValue value)
 {
+#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
     switch (value) {
         case TNLWWANRadioAccessTechnologyValueEVDO_0:
         case TNLWWANRadioAccessTechnologyValue1xRTT:
@@ -943,6 +932,7 @@ TNLWWANRadioAccessGeneration TNLWWANRadioAccessGenerationForTechnologyValue(TNLW
         case TNLWWANRadioAccessTechnologyValueUnknown:
             break;
     }
+#endif // #if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
 
     return TNLWWANRadioAccessGenerationUnknown;
 }
@@ -979,7 +969,7 @@ NSString *TNLCaptivePortalStatusToString(TNLCaptivePortalStatus status)
     return @"undetermined";
 }
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
 
 NSDictionary * __nullable TNLCarrierInfoToDictionary(id<TNLCarrierInfo> __nullable carrierInfo)
 {
@@ -1017,7 +1007,7 @@ id<TNLCarrierInfo> __nullable TNLCarrierInfoFromDictionary(NSDictionary * __null
                                                     allowsVOIP:[dict[@"allowsVOIP"] boolValue]];
 }
 
-#endif // TARGET_OS_IOS
+#endif // #if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
 
 NS_INLINE const char _DebugCharFromReachabilityFlag(SCNetworkReachabilityFlags flags, uint32_t flag, const char presentChar)
 {

--- a/Source/TNLCommunicationAgent_Project.h
+++ b/Source/TNLCommunicationAgent_Project.h
@@ -11,7 +11,7 @@
 
 #import <TwitterNetworkLayer/TNLCommunicationAgent.h>
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
 
 #pragma mark IOS only imports
 
@@ -40,4 +40,4 @@ FOUNDATION_EXTERN id<TNLCarrierInfo> __nullable TNLCarrierInfoFromDictionary(NSD
 
 NS_ASSUME_NONNULL_END
 
-#endif // TARGET_OS_IOS
+#endif // TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC

--- a/Source/TNLError.h
+++ b/Source/TNLError.h
@@ -236,4 +236,9 @@ FOUNDATION_EXTERN NSArray<NSNumber *> *TNLStandardRetriableURLErrorCodes(void);
 //! Standard error codes for `NSPOSIXErrorDomain` errors that can be retried
 FOUNDATION_EXTERN NSArray<NSNumber *> *TNLStandardRetriablePOSIXErrorCodes(void);
 
+//! Convert an NSError to be NSSecureCoding safe (strip unsafe values from userInfo).  Only returns `nil` if provided _error_ is `nil`.
+FOUNDATION_EXTERN NSError * __nullable TNLErrorToSecureCodingError(NSError * __nullable error);
+//! Check if the given NSError objects are equal by just checking their domain+code & underlying errors the same way.  Both provided errors being `nil` will also count as being equal.
+FOUNDATION_EXTERN BOOL TNLSecureCodingErrorsAreEqual(NSError * __nullable error1, NSError * __nullable error2);
+
 NS_ASSUME_NONNULL_END

--- a/Source/TNLParameterCollection.m
+++ b/Source/TNLParameterCollection.m
@@ -374,8 +374,10 @@ typedef NSString *(^TNLParameterCollectionUpdateKeysAndValuesIterativeKeyBlock)(
                     parameterString = [path substringFromIndex:range.location + 1];
                 }
             }
+#if !TARGET_OS_UIKITFORMAC
         } else {
             parameterString = URL.parameterString;
+#endif
         }
         [self addParametersWithURLEncodedString:parameterString options:options];
     }

--- a/Source/TNLRequest.h
+++ b/Source/TNLRequest.h
@@ -514,6 +514,11 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString *)HTTPMethodForRequest:(nullable id<TNLRequest>)request;
 
 /**
+ Convenience method to check if a given `TNLRequest` has an HTTP Body
+ */
++ (BOOL)requestHasBody:(nullable id<TNLRequest>)request;
+
+/**
  Convenience method for comparing two `TNLRequest` conforming objects that doesn't use the
  `[TNLRequest isEqualToRequest:]` method
 
@@ -524,6 +529,20 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (BOOL)isRequest:(nullable id<TNLRequest>)request1
           equalTo:(nullable id<TNLRequest>)request2;
+
+/**
+ Like `[TNLRequest isRequest:equalTo:]` method, but with a faster HTTP Body check.
+ Instead of checking the full bytes of the body, just check if there body exists or not.
+
+ @param request1 The first request
+ @param request2 The second request
+ @param quickBodyCheck Pass `YES` to just validate that both requests either had a body or both did not have a body
+
+ @return `YES` if equal, `NO` otherwise.
+ */
+  + (BOOL)isRequest:(nullable id<TNLRequest>)request1
+            equalTo:(nullable id<TNLRequest>)request2
+quickBodyComparison:(BOOL)quickBodyCheck;
 
 @end
 

--- a/Source/TNLRequest.m
+++ b/Source/TNLRequest.m
@@ -166,8 +166,29 @@ static NSUInteger const kMaxBytesToCompare = 1024;
     return method;
 }
 
++ (BOOL)requestHasBody:(nullable id<TNLRequest>)request
+{
+    if ([request respondsToSelector:@selector(HTTPBody)] && request.HTTPBody != nil) {
+        return YES;
+    }
+    if ([request respondsToSelector:@selector(HTTPBodyFilePath)] && request.HTTPBodyFilePath != nil) {
+        return YES;
+    }
+    if ([request respondsToSelector:@selector(HTTPBodyStream)] && request.HTTPBodyStream != nil) {
+        return YES;
+    }
+    return NO;
+}
+
 + (BOOL)isRequest:(nullable id<TNLRequest>)request1
           equalTo:(nullable id<TNLRequest>)request2
+{
+    return [self isRequest:request1 equalTo:request2 quickBodyComparison:NO];
+}
+
+  + (BOOL)isRequest:(nullable id<TNLRequest>)request1
+            equalTo:(nullable id<TNLRequest>)request2
+quickBodyComparison:(BOOL)quickBodyCheck;
 {
     if (request1 == request2) {
         return YES;
@@ -198,6 +219,10 @@ static NSUInteger const kMaxBytesToCompare = 1024;
         if (![lowerCaseHeaders1 isEqualToDictionary:lowerCaseHeaders2]) {
             return NO;
         }
+    }
+
+    if (quickBodyCheck) {
+        return [TNLRequest requestHasBody:request1] == [TNLRequest requestHasBody:request2];
     }
 
     NSData *data1 = [request1 respondsToSelector:@selector(HTTPBody)] ? [request1 HTTPBody] : nil;

--- a/Source/TNLRequestConfiguration.h
+++ b/Source/TNLRequestConfiguration.h
@@ -155,6 +155,19 @@ typedef NS_OPTIONS(NSInteger, TNLRequestConnectivityOptions) {
 };
 
 /**
+ The algorithm to compute a hash for the response body
+ */
+typedef NS_ENUM(NSInteger, TNLResponseHashComputeAlgorithm) {
+    TNLResponseHashComputeAlgorithmNone = 0,
+    TNLResponseHashComputeAlgorithmMD2 __attribute__((deprecated)) = 'md_2',
+    TNLResponseHashComputeAlgorithmMD4 __attribute__((deprecated)) = 'md_4',
+    TNLResponseHashComputeAlgorithmMD5 __attribute__((deprecated)) = 'md_5',
+    TNLResponseHashComputeAlgorithmSHA1 = 'sha1',
+    TNLResponseHashComputeAlgorithmSHA256 = 's256',
+    TNLResponseHashComputeAlgorithmSHA512 = 's512',
+};
+
+/**
  The expected anatomy of how a request will break down
  */
 typedef NS_ENUM(NSInteger, TNLRequestAnatomy) {
@@ -212,6 +225,7 @@ FOUNDATION_EXTERN NSTimeInterval TNLDeferrableIntervalForPriority(TNLPriority pr
         TNLResponseDataConsumptionMode responseDataConsumptionMode:8;
         TNLRequestProtocolOptions protocolOptions:8;
         TNLRequestConnectivityOptions connectivityOptions:8;
+        TNLResponseHashComputeAlgorithm responseComputeHashAlgorithm;
 
         // Timeout settings
         NSTimeInterval idleTimeout;
@@ -228,7 +242,6 @@ FOUNDATION_EXTERN NSTimeInterval TNLDeferrableIntervalForPriority(TNLPriority pr
         // TNL BOOLs
         BOOL contributeToExecutingNetworkConnectionsCount:1;
         BOOL skipHostSanitization:1;
-        BOOL computeMD5:1;
 
         // NSURLSessionConfiguration BOOLs
         BOOL allowsCellularAccess:1;
@@ -299,13 +312,13 @@ FOUNDATION_EXTERN NSTimeInterval TNLDeferrableIntervalForPriority(TNLPriority pr
 @property (nonatomic, readonly) BOOL skipHostSanitization;
 
 /**
- Whether the request operation should compute the md5 hash of the response body.
+ The algorithm the request operation should compute a hash of the response body with.
  `executionMode` MUST NOT be `TNLRequestExecutionModeBackground` and
  `responseDataConsumptionMode` MUST NOT be `TNLResponseDataConsumptionModeSaveToDisk`.
 
- Default is `NO`
+ Default is `TNLResponseHashComputeAlgorithmNone` (aka disabled)
  */
-@property (nonatomic, readonly) BOOL computeMD5;
+@property (nonatomic, readonly) TNLResponseHashComputeAlgorithm responseComputeHashAlgorithm;
 
 /**
  The retry policy provider to use.
@@ -512,13 +525,13 @@ FOUNDATION_EXTERN NSTimeInterval TNLDeferrableIntervalForPriority(TNLPriority pr
 
 @property (nonatomic, readwrite) BOOL contributeToExecutingNetworkConnectionsCount;
 @property (nonatomic, readwrite) BOOL skipHostSanitization;
-@property (nonatomic, readwrite) BOOL computeMD5;
 
 @property (nonatomic, readwrite) TNLRequestExecutionMode executionMode;
 @property (nonatomic, readwrite) TNLRequestRedirectPolicy redirectPolicy;
 @property (nonatomic, readwrite) TNLResponseDataConsumptionMode responseDataConsumptionMode;
 @property (nonatomic, readwrite) TNLRequestProtocolOptions protocolOptions;
 @property (nonatomic, readwrite) TNLRequestConnectivityOptions connectivityOptions;
+@property (nonatomic, readwrite) TNLResponseHashComputeAlgorithm responseComputeHashAlgorithm;
 
 @property (nonatomic, strong, readwrite, nullable) id<TNLRequestRetryPolicyProvider> retryPolicyProvider;
 @property (nonatomic, readwrite, nullable) id<TNLContentEncoder> contentEncoder;

--- a/Source/TNLRequestConfiguration.m
+++ b/Source/TNLRequestConfiguration.m
@@ -118,9 +118,9 @@ static const NSTimeInterval kConfigurationDeferrableIntervalDefault = 0.0;
     return _ivars.skipHostSanitization;
 }
 
-- (BOOL)computeMD5
+- (TNLResponseHashComputeAlgorithm)responseComputeHashAlgorithm
 {
-    return _ivars.computeMD5;
+    return _ivars.responseComputeHashAlgorithm;
 }
 
 - (NSTimeInterval)idleTimeout
@@ -282,7 +282,7 @@ static const NSTimeInterval kConfigurationDeferrableIntervalDefault = 0.0;
     D_SET(connectivityOptions);
     D_SET(contributeToExecutingNetworkConnectionsCount);
     D_SET(skipHostSanitization);
-    D_SET(computeMD5);
+    D_SET(responseComputeHashAlgorithm);
 
     D_SET(attemptTimeout);
     D_SET(idleTimeout);
@@ -329,10 +329,10 @@ static const NSTimeInterval kConfigurationDeferrableIntervalDefault = 0.0;
     TNLMutableParameterCollection *params = TNLMutableParametersFromRequestConfiguration(self, nil, nil, nil);
     TNLMutableParametersStripURLCacheAndURLCredentialStorageAndCookieStorage(params);
     return params.hash +
-           (NSUInteger)(self.executionMode) +
+           (NSUInteger)(self.responseComputeHashAlgorithm) +
            (NSUInteger)(self.contributeToExecutingNetworkConnectionsCount * 7) +
            (NSUInteger)(self.skipHostSanitization * 11) +
-           (NSUInteger)(self.computeMD5 * 17);
+           (NSUInteger)(self.executionMode * 17);
 }
 
 - (BOOL)isEqual:(id)object
@@ -382,7 +382,7 @@ static const NSTimeInterval kConfigurationDeferrableIntervalDefault = 0.0;
 
 @dynamic contributeToExecutingNetworkConnectionsCount;
 @dynamic skipHostSanitization;
-@dynamic computeMD5;
+@dynamic responseComputeHashAlgorithm;
 
 @dynamic executionMode;
 @dynamic redirectPolicy;
@@ -453,9 +453,9 @@ static const NSTimeInterval kConfigurationDeferrableIntervalDefault = 0.0;
     _ivars.skipHostSanitization = (skipHostSanitization != NO);
 }
 
-- (void)setComputeMD5:(BOOL)computeMD5
+- (void)setResponseComputeHashAlgorithm:(TNLResponseHashComputeAlgorithm)responseComputeHashAlgorithm
 {
-    _ivars.computeMD5 = (computeMD5 != NO);
+    _ivars.responseComputeHashAlgorithm = responseComputeHashAlgorithm;
 }
 
 - (void)setRetryPolicyProvider:(nullable id<TNLRequestRetryPolicyProvider>)retryPolicyProvider
@@ -785,7 +785,7 @@ TNLMutableParameterCollection * __nullable TNLMutableParametersFromRequestConfig
      Note:
      config.contributeToExecutingNetworkConnectionsCount,
      config.skipHostSanitization,
-     config.computeMD5,
+     config.responseComputeHashAlgorithm,
      config.contentEncoder,
      config.additionContentDecoders,
      config.retryPolicyProvider and

--- a/Source/TNLRequestOperation.m
+++ b/Source/TNLRequestOperation.m
@@ -2243,10 +2243,10 @@ static void _network_updateMetrics(SELF_ARG,
         if (TNLRequestOperationStateIsFinal(newState)) {
             if (attemptMetrics.completeDate) {
                 [self->_metrics setCompleteDate:attemptMetrics.completeDate
-#pragma clang diagnostics push
+#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
                                        machTime:attemptMetrics.completeMachTime];
-#pragma clang diagnostics pop
+#pragma clang diagnostic pop
             } else {
                 [self->_metrics setCompleteDate:dateNow machTime:machTime];
                 [attemptMetrics setCompleteDate:dateNow machTime:machTime];
@@ -2664,7 +2664,12 @@ static BOOL _network_shouldForciblyRetryInvalidatedURLSessionRequest(SELF_ARG,
 
     const unsigned int maxInvalidSessionRetryCount = 4;
     TNLStaticAssert(maxInvalidSessionRetryCount < 0b1111, Max_Invalid_Session_Retry_Count_must_be_within_4_bits);
-    const NSTimeInterval latestAttemptDuration = TNLComputeDuration(attemptResponse.metrics.currentAttemptStartMachTime, mach_absolute_time());
+    const NSTimeInterval latestAttemptDuration = TNLComputeDuration(
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                                                                    attemptResponse.metrics.currentAttemptStartMachTime,
+#pragma clang diagnostic pop
+                                                                    mach_absolute_time());
     const BOOL forciblyRetry = (attemptResponse.info.URLResponse == nil) &&
                                (latestAttemptDuration < 1.0) &&
                                (self->_backgroundFlags.invalidSessionRetryCount < maxInvalidSessionRetryCount);
@@ -2759,7 +2764,10 @@ static void _network_retryDuringStateTransition(SELF_ARG,
 
     const BOOL hasCachedCancel = self->_cachedCancelError != nil;
     const id<TNLRequestEventHandler> eventHandler = self.internalDelegate;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     const uint64_t enqueueMachTime = self->_metrics.enqueueMachTime;
+#pragma clang diagnostic pop
     TNLRequestConfiguration *requestConfig = self->_requestConfiguration;
 
     // Dispatch to the retry queue to get retry policy info

--- a/Source/TNLResponse.h
+++ b/Source/TNLResponse.h
@@ -7,11 +7,11 @@
 //
 
 #import <TwitterNetworkLayer/TNLHTTP.h>
+#import <TwitterNetworkLayer/TNLRequest.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol TNLTemporaryFile;
-@protocol TNLRequest;
 @class TNLAttemptMetrics;
 @class TNLResponseMetrics;
 @class TNLResponseInfo;
@@ -40,8 +40,8 @@ typedef NS_ENUM(NSInteger, TNLResponseSource) {
 
  __See also__: `TNLResponseInfo` and `TNLResponseMetrics`
 
- @warning `[TNLResponse supportsSecureCoding]` returns `NO` since `originalRequest` is not
- guaranteed to support `NSSecureCoding`.
+ @warning `[TNLResponse supportsSecureCoding]` returns `YES` even if `originalRequest` does not
+ support secure coding and will encode the `originalRequest` as a `TNLResponseEncodedRequest`.
  */
 @interface TNLResponse : NSObject <NSSecureCoding>
 {
@@ -244,6 +244,23 @@ NS_SWIFT_NAME(response(request:operationError:info:metrics:));
  Value can be negative if it occurs in the past.
  */
 - (NSTimeInterval)retryAfterDelayFromNow;
+
+@end
+
+/**
+ Converted request for Secure Coding
+ */
+@interface TNLResponseEncodedRequest : NSObject <TNLRequest, NSSecureCoding>
+
+/** The name of the source `TNLRequest` class that was encoded */
+@property (nonatomic, readonly, copy, nullable) NSString *encodedSourceRequestClassName;
+/** If the encoded source request has a body */
+@property (nonatomic, readonly) BOOL encodedSourceRequestHadBody;
+
+/** Unavailable */
+- (instancetype)init NS_UNAVAILABLE;
+/** Unavailable */
++ (instancetype)new NS_UNAVAILABLE;
 
 @end
 

--- a/Source/TNLResponse_Project.h
+++ b/Source/TNLResponse_Project.h
@@ -23,6 +23,12 @@ NS_ASSUME_NONNULL_BEGIN
                                 metrics:(TNLResponseMetrics *)metrics NS_DESIGNATED_INITIALIZER;
 @end
 
+@interface TNLResponseEncodedRequest ()
+
+- (instancetype)initWithSourceRequest:(id<TNLRequest>)request;
+
+@end
+
 @interface TNLResponseMetrics ()
 
 - (void)didEnqueue;

--- a/Source/TNLURLSessionManager.m
+++ b/Source/TNLURLSessionManager.m
@@ -1330,7 +1330,7 @@ static volatile atomic_int_fast32_t sSessionContextCount = ATOMIC_VAR_INIT(0);
         _ivars.protocolOptions = TNLRequestProtocolOptionsDefault;
         _ivars.contributeToExecutingNetworkConnectionsCount = YES;
         _ivars.skipHostSanitization = NO;
-        _ivars.computeMD5 = NO;
+        _ivars.responseComputeHashAlgorithm = TNLResponseHashComputeAlgorithmNone;
 
         [self applyDefaultTimeouts];
 

--- a/Source/TwitterNetworkLayer.h
+++ b/Source/TwitterNetworkLayer.h
@@ -49,6 +49,7 @@
 #pragma Categories
 
 #import <TwitterNetworkLayer/NSCachedURLResponse+TNLAdditions.h>
+#import <TwitterNetworkLayer/NSCoder+TNLAdditions.h>
 #import <TwitterNetworkLayer/NSDictionary+TNLAdditions.h>
 #import <TwitterNetworkLayer/NSHTTPCookieStorage+TNLAdditions.h>
 #import <TwitterNetworkLayer/NSNumber+TNLURLCoding.h>

--- a/TNLExample/Base.lproj/Main.storyboard
+++ b/TNLExample/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14269.12" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" colorMatched="YES" initialViewController="8YX-ce-x5E">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" colorMatched="YES" initialViewController="8YX-ce-x5E">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14252.5"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -43,7 +43,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Qh2-T1-AhA" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="653" y="-138"/>
+            <point key="canvasLocation" x="946.37681159420299" y="-92.410714285714278"/>
         </scene>
         <!--Tests-->
         <scene sceneID="0hc-2k-s6c">
@@ -63,7 +63,7 @@
                             </progressView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="flQ-lu-oSe">
                                 <rect key="frame" x="72" y="127" width="231" height="30"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Multiform Data Submit">
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
@@ -72,8 +72,8 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="0Jt-lF-Z7z">
-                                <rect key="frame" x="20" y="195" width="179" height="30"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                <rect key="frame" x="20" y="195" width="115" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Fav Tweet">
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
@@ -82,8 +82,8 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="PO2-C3-VCV">
-                                <rect key="frame" x="22" y="242" width="175" height="30"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                <rect key="frame" x="22" y="242" width="113" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Large File Load">
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
@@ -92,8 +92,8 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="vky-rH-eWE">
-                                <rect key="frame" x="176" y="195" width="179" height="30"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                <rect key="frame" x="227" y="195" width="128" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Unfav Tweet">
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
@@ -127,8 +127,8 @@
                                 <color key="backgroundColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="0gP-Kw-Y2J">
-                                <rect key="frame" x="178" y="242" width="175" height="30"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                <rect key="frame" x="227" y="242" width="126" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Delete/Cancel">
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
@@ -147,7 +147,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="fZ9-8E-MZ5">
-                                <rect key="frame" x="13" y="75" width="87" height="30"/>
+                                <rect key="frame" x="13" y="75" width="92" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <state key="normal" title="Go+Redirect">
@@ -157,19 +157,8 @@
                                     <action selector="goWithRedirects:" destination="JlI-pq-B5B" eventType="touchUpInside" id="dlW-0S-Vge"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="n3y-mI-NJY">
-                                <rect key="frame" x="129" y="75" width="107" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                <state key="normal" title="Go+NoRedirect">
-                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                </state>
-                                <connections>
-                                    <action selector="goWithNoRedirects:" destination="JlI-pq-B5B" eventType="touchUpInside" id="fpc-y8-dfq"/>
-                                </connections>
-                            </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="zo7-RU-ehg">
-                                <rect key="frame" x="263" y="75" width="111" height="30"/>
+                                <rect key="frame" x="272" y="75" width="92" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <state key="normal" title="Go+ShortRedirs">
@@ -216,7 +205,7 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="LTE, AT&amp;T, wifi, _________" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="MPx-tV-VPW">
+                            <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="LTE, AT&amp;T, wifi, _________" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="MPx-tV-VPW">
                                 <rect key="frame" x="13" y="410" width="350" height="163"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -224,6 +213,17 @@
                                 <color key="textColor" red="0.0" green="0.41072265625000004" blue="0.024205576833659242" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="n3y-mI-NJY">
+                                <rect key="frame" x="141" y="75" width="92" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                <state key="normal" title="Go+NoRedirect">
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="goWithNoRedirects:" destination="JlI-pq-B5B" eventType="touchUpInside" id="fpc-y8-dfq"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
@@ -248,7 +248,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="XSK-Yd-X3v" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="131.5" y="863.5"/>
+            <point key="canvasLocation" x="189.59999999999999" y="577.9610194902549"/>
         </scene>
         <!--Second-->
         <scene sceneID="ot8-2e-RuS">
@@ -373,7 +373,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="3qq-4t-Ow8" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="653" y="498"/>
+            <point key="canvasLocation" x="946.37681159420299" y="333.48214285714283"/>
         </scene>
         <!--Tab Bar Controller-->
         <scene sceneID="Vex-rW-GRa">
@@ -393,7 +393,7 @@
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="FNP-y4-bzi" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="132" y="180"/>
+            <point key="canvasLocation" x="191.30434782608697" y="120.53571428571428"/>
         </scene>
     </scenes>
     <resources>

--- a/TNLExample/TAPI/TAPIResponse.m
+++ b/TNLExample/TAPI/TAPIResponse.m
@@ -48,7 +48,8 @@ static NSArray *_ExtractAPIErrors(id parsedObject);
 {
     self = [super initWithCoder:coder];
     if (self) {
-        _parsedObject = [coder decodeObjectForKey:@"parsedObject"];
+        _parsedObject = [coder decodeObjectOfClasses:[NSSet setWithObjects:[NSString class], [NSNumber class], [NSArray class], [NSDictionary class], nil]
+                                              forKey:@"parsedObject"];
         _parseError = [coder decodeObjectOfClass:[NSError class] forKey:@"parseError"];
         _apiError = [coder decodeObjectOfClass:[NSError class] forKey:@"apiError"];
     }
@@ -58,9 +59,9 @@ static NSArray *_ExtractAPIErrors(id parsedObject);
 - (void)encodeWithCoder:(NSCoder *)aCoder
 {
     [super encodeWithCoder:aCoder];
-    [aCoder encodeObject:_parsedObject forKey:@"parsedObject"];
-    [aCoder encodeObject:_apiError forKey:@"apiError"];
-    [aCoder encodeObject:_parseError forKey:@"parseError"];
+    [aCoder encodeObject:TNLErrorToSecureCodingError(_parsedObject) forKey:@"parsedObject"];
+    [aCoder encodeObject:TNLErrorToSecureCodingError(_apiError) forKey:@"apiError"];
+    [aCoder encodeObject:TNLErrorToSecureCodingError(_parseError) forKey:@"parseError"];
 }
 
 - (NSError *)anyError

--- a/TNLExample/TNLXAppDelegate.m
+++ b/TNLExample/TNLXAppDelegate.m
@@ -121,7 +121,13 @@ NSString *TNLXCommunicationStatusUpdatedNotification = @"TNLXCommunicationStatus
 
 - (void)applicationDidBecomeActive:(UIApplication *)application
 {
-    application.networkActivityIndicatorVisible = [TNLNetwork hasExecutingNetworkConnections];
+#if !TARGET_OS_UIKITFORMAC
+    if (@available(iOS 13, *)) {
+
+    } else {
+        application.networkActivityIndicatorVisible = [TNLNetwork hasExecutingNetworkConnections];
+    }
+#endif
 }
 
 - (void)tnl_requestOperation:(TNLRequestOperation *)op
@@ -173,8 +179,10 @@ NSString *TNLXCommunicationStatusUpdatedNotification = @"TNLXCommunicationStatus
 - (void)networkingDidChange:(NSNotification *)note
 {
     assert([NSThread isMainThread]);
+#if !TARGET_OS_UIKITFORMAC
     BOOL on = [note.userInfo[TNLNetworkExecutingNetworkConnectionsExecutingKey] boolValue];
     [UIApplication sharedApplication].networkActivityIndicatorVisible = on;
+#endif
 }
 
 - (void)promptForTwitterAPIAccess:(TAPILoginAccessCompletionBlock)completion
@@ -191,6 +199,11 @@ NSString *TNLXCommunicationStatusUpdatedNotification = @"TNLXCommunicationStatus
 
 - (void)warnThatConsumerCredentialsAreMissing
 {
+    if (![NSThread isMainThread]) {
+        [self performSelectorOnMainThread:_cmd withObject:nil waitUntilDone:NO];
+        return;
+    }
+
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Missing Consumer Key & Secret"
                                                                    message:@"Twitter API credentials can be obtained by going to apps.twitter.com.\nPut them in TNLExample-Info.plist under `tnlx_oauth_consumer_key` and `tnlx_oauth_consumer_secret`."
                                                             preferredStyle:UIAlertControllerStyleAlert];
@@ -202,6 +215,11 @@ NSString *TNLXCommunicationStatusUpdatedNotification = @"TNLXCommunicationStatus
 
 - (void)warnThatAccessCredentialsAreMissing
 {
+    if (![NSThread isMainThread]) {
+        [self performSelectorOnMainThread:_cmd withObject:nil waitUntilDone:NO];
+        return;
+    }
+
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Enter Access Token & Secret"
                                                                    message:@"Twitter API credentials can be obtained by going to apps.twitter.com.\nPut them in TNLExample-Info.plist under `tnlx_oauth_access_token` and `tnlx_oauth_access_secret`."
                                                             preferredStyle:UIAlertControllerStyleAlert];

--- a/TNLExample/TNLXPlaygroundViewController.m
+++ b/TNLExample/TNLXPlaygroundViewController.m
@@ -205,11 +205,14 @@ typedef NS_ENUM(NSInteger, TNLXRedirectTestPolicy)
         self->_goWithoutRedirectsButton.enabled = YES;
         self->_goWithRedirectsButton.enabled = YES;
 
-        [[[UIAlertView alloc] initWithTitle:@"Response"
-                                    message:[NSString stringWithFormat:@"Redirect Count: %tu\nHeaders: %@\nMetrics: %@", response.metrics.redirectCount, response.info.allHTTPHeaderFields, response.metrics]
-                                   delegate:nil
-                          cancelButtonTitle:@"OK"
-                          otherButtonTitles:nil] show];
+        NSString *message = [NSString stringWithFormat:@"Redirect Count: %tu\nHeaders: %@\nMetrics: %@", response.metrics.redirectCount, response.info.allHTTPHeaderFields, response.metrics];
+        UIAlertController *alertVC = [UIAlertController alertControllerWithTitle:@"Response"
+                                                                         message:message
+                                                                  preferredStyle:UIAlertControllerStyleAlert];
+        [alertVC addAction:[UIAlertAction actionWithTitle:@"OK"
+                                                    style:UIAlertActionStyleCancel
+                                                  handler:nil]];
+        [self presentViewController:alertVC animated:YES completion:nil];
     };
     [testObj start];
 }
@@ -273,9 +276,12 @@ typedef NS_ENUM(NSInteger, TNLXRedirectTestPolicy)
     request.URL = [NSURL URLWithString:DOWNLOAD_URL];
     request.timeoutInterval = 10;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     _fileDownloadConnection = [[NSURLConnection alloc] initWithRequest:request
                                                               delegate:self
                                                       startImmediately:NO];
+#pragma clang diagnostic pop
     [_fileDownloadConnection setDelegateQueue:[NSOperationQueue mainQueue]];
     [self fileDownloadStarting];
     [_fileDownloadConnection start];
@@ -394,7 +400,12 @@ typedef NS_ENUM(NSInteger, TNLXRedirectTestPolicy)
     TNLRequestOperation *op = [TNLRequestOperation operationWithURL:[NSURL URLWithString:URLString]
                                                          completion:^(TNLRequestOperation *innerOp, TNLResponse *response) {
         self->_httpTestButton.enabled = YES;
-        [[[UIAlertView alloc] initWithTitle:@"HTTP Response" message:[NSString stringWithFormat:@"Status Code: %td", response.info.statusCode] delegate:nil cancelButtonTitle:@"OK" otherButtonTitles:nil] show];
+        NSString *message = [NSString stringWithFormat:@"Status Code: %td", response.info.statusCode];
+        UIAlertController *alertVC = [UIAlertController alertControllerWithTitle:@"HTTP Response"
+                                                                         message:message
+                                                                  preferredStyle:UIAlertControllerStyleAlert];
+        [alertVC addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil]];
+        [self presentViewController:alertVC animated:YES completion:nil];
     }];
     [[TNLRequestOperationQueue defaultOperationQueue] enqueueRequestOperation:op];
 }
@@ -432,11 +443,12 @@ typedef NS_ENUM(NSInteger, TNLXRedirectTestPolicy)
     TNLXCompletionBlock block = ^(TNLRequestOperation *innerOp, TNLResponse *response) {
         assert([NSThread isMainThread]);
         self->_httpsTwitterTestButton.enabled = YES;
-        [[[UIAlertView alloc] initWithTitle:@"HTTP Response"
-                                    message:[NSString stringWithFormat:@"Metrics: %@", response.metrics]
-                                   delegate:nil
-                          cancelButtonTitle:@"OK"
-                          otherButtonTitles:nil] show];
+        NSString *message = [NSString stringWithFormat:@"Metrics: %@", response.metrics];
+        UIAlertController *alertVC = [UIAlertController alertControllerWithTitle:@"HTTP Response"
+                                                                         message:message
+                                                                  preferredStyle:UIAlertControllerStyleAlert];
+        [alertVC addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil]];
+        [self presentViewController:alertVC animated:YES completion:nil];
         NSLog(@"(%zi) (CL: %@) %@ %@", response.info.statusCode, [response.info valueForResponseHeaderField:@"Content-Length"], response.operationError ?: @"", response.metrics);
         // TLSLogDebug(NSStringFromClass([self class]), @"Headers: %@", response.info.allHTTPHeaderFields);
     };
@@ -514,12 +526,11 @@ typedef NS_ENUM(NSInteger, TNLXRedirectTestPolicy)
     NSURL *originalURL = [op.originalRequest respondsToSelector:@selector(URL)] ? [(id)op.originalRequest URL] : nil;
     if ([originalURL.absoluteString isEqualToString:DOWNLOAD_URL]) {
         NSLog(@"[BG_DOWNLOAD] - %@ %@", op.originalRequest, response);
-        UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"BG Download"
-                                                        message:[NSString stringWithFormat:@"%@", response]
-                                                       delegate:NULL
-                                              cancelButtonTitle:@"Close"
-                                              otherButtonTitles:nil];
-        [alert show];
+        UIAlertController *alertVC = [UIAlertController alertControllerWithTitle:@"BG Download"
+                                                                         message:[NSString stringWithFormat:@"%@", response]
+                                                                  preferredStyle:UIAlertControllerStyleAlert];
+        [alertVC addAction:[UIAlertAction actionWithTitle:@"Close" style:UIAlertActionStyleCancel handler:nil]];
+        [self presentViewController:alertVC animated:YES completion:nil];
         return;
     }
 
@@ -594,12 +605,11 @@ didReceiveResponse:(NSURLResponse *)response
         info[@"error"] = error;
     }
     info[@"URL"] = connection.originalRequest.URL;
-    UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"BG Download"
-                                                    message:[NSString stringWithFormat:@"%@", info]
-                                                   delegate:nil
-                                          cancelButtonTitle:@"Close"
-                                          otherButtonTitles:nil];
-    [alert show];
+    UIAlertController *alertVC = [UIAlertController alertControllerWithTitle:@"BG Download"
+                                                                     message:[NSString stringWithFormat:@"%@", info]
+                                                              preferredStyle:UIAlertControllerStyleAlert];
+    [alertVC addAction:[UIAlertAction actionWithTitle:@"Close" style:UIAlertActionStyleCancel handler:nil]];
+    [self presentViewController:alertVC animated:YES completion:nil];
 }
 
 @end

--- a/TwitterNetworkLayer.xcodeproj/project.pbxproj
+++ b/TwitterNetworkLayer.xcodeproj/project.pbxproj
@@ -56,6 +56,14 @@
 		8B3DB55E1A699C8D00FFF836 /* TNLAttemptMetaData.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B3DB55A1A699C8D00FFF836 /* TNLAttemptMetaData.m */; };
 		8B427D551FB53DBF00C9E5CE /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B427D541FB53DBF00C9E5CE /* Security.framework */; };
 		8B472C4A1BC41CB900DEA3BF /* NSOperationQueue+TNLSafetyTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B472C491BC41CB900DEA3BF /* NSOperationQueue+TNLSafetyTest.m */; };
+		8B490DD722A82B9D002D2296 /* NSCoder+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B490DD522A82B9D002D2296 /* NSCoder+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B490DD822A82B9D002D2296 /* NSCoder+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B490DD522A82B9D002D2296 /* NSCoder+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B490DD922A82B9D002D2296 /* NSCoder+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B490DD522A82B9D002D2296 /* NSCoder+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B490DDA22A82B9D002D2296 /* NSCoder+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B490DD522A82B9D002D2296 /* NSCoder+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8B490DDB22A82B9D002D2296 /* NSCoder+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B490DD622A82B9D002D2296 /* NSCoder+TNLAdditions.m */; };
+		8B490DDC22A82B9D002D2296 /* NSCoder+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B490DD622A82B9D002D2296 /* NSCoder+TNLAdditions.m */; };
+		8B490DDD22A82B9D002D2296 /* NSCoder+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B490DD622A82B9D002D2296 /* NSCoder+TNLAdditions.m */; };
+		8B490DDE22A82B9D002D2296 /* NSCoder+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B490DD622A82B9D002D2296 /* NSCoder+TNLAdditions.m */; };
 		8B4AA7621E1F297C00BF7EA0 /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B4AA75D1E1F28DF00BF7EA0 /* CoreTelephony.framework */; };
 		8B4CBEA91A169A6800230318 /* TNLRequestRetryPolicyConfigurationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B4CBEA81A169A6800230318 /* TNLRequestRetryPolicyConfigurationTest.m */; };
 		8B4DEFF91986AA64008A31EB /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B4DEFF81986AA64008A31EB /* SystemConfiguration.framework */; };
@@ -719,6 +727,8 @@
 		8B3DB55A1A699C8D00FFF836 /* TNLAttemptMetaData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TNLAttemptMetaData.m; sourceTree = "<group>"; };
 		8B427D541FB53DBF00C9E5CE /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		8B472C491BC41CB900DEA3BF /* NSOperationQueue+TNLSafetyTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSOperationQueue+TNLSafetyTest.m"; sourceTree = "<group>"; };
+		8B490DD522A82B9D002D2296 /* NSCoder+TNLAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSCoder+TNLAdditions.h"; sourceTree = "<group>"; };
+		8B490DD622A82B9D002D2296 /* NSCoder+TNLAdditions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSCoder+TNLAdditions.m"; sourceTree = "<group>"; };
 		8B4AA75D1E1F28DF00BF7EA0 /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = System/Library/Frameworks/CoreTelephony.framework; sourceTree = SDKROOT; };
 		8B4CBEA81A169A6800230318 /* TNLRequestRetryPolicyConfigurationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TNLRequestRetryPolicyConfigurationTest.m; sourceTree = "<group>"; };
 		8B4DEFF81986AA64008A31EB /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
@@ -1158,6 +1168,8 @@
 			children = (
 				8B277E471C022B5C00279EA9 /* NSCachedURLResponse+TNLAdditions.h */,
 				8B277E481C022B5C00279EA9 /* NSCachedURLResponse+TNLAdditions.m */,
+				8B490DD522A82B9D002D2296 /* NSCoder+TNLAdditions.h */,
+				8B490DD622A82B9D002D2296 /* NSCoder+TNLAdditions.m */,
 				8BB1190E1D83537C00E75CD9 /* NSData+TNLAdditions.m */,
 				8B022A8119AAD2F800DB3052 /* NSDictionary+TNLAdditions.h */,
 				8B022A8219AAD2F800DB3052 /* NSDictionary+TNLAdditions.m */,
@@ -1332,6 +1344,7 @@
 				8B9EBE082135B4B100E6E466 /* TNLRequestAuthorizer.h in Headers */,
 				8B9EBE092135B4B100E6E466 /* TNLRequest.h in Headers */,
 				8B9EBE0A2135B4B100E6E466 /* TNL_Project.h in Headers */,
+				8B490DDA22A82B9D002D2296 /* NSCoder+TNLAdditions.h in Headers */,
 				8B9EBE0B2135B4B100E6E466 /* TNL_ProjectCommon.h in Headers */,
 				8B9EBE0C2135B4B100E6E466 /* TNLNetworkObserver.h in Headers */,
 				8B9EBE0D2135B4B100E6E466 /* TNLTiming.h in Headers */,
@@ -1407,6 +1420,7 @@
 				8B2DF7D7199D7F9F00A064B3 /* TNLRequestAuthorizer.h in Headers */,
 				8BE403171946794300C7241E /* TNLRequest.h in Headers */,
 				8BE4030F1946794300C7241E /* TNL_Project.h in Headers */,
+				8B490DD722A82B9D002D2296 /* NSCoder+TNLAdditions.h in Headers */,
 				8BD500F51D87762200D828C7 /* TNL_ProjectCommon.h in Headers */,
 				8B82A5A71948D3E900A16237 /* TNLNetworkObserver.h in Headers */,
 				8B5141231CE530E100830987 /* TNLTiming.h in Headers */,
@@ -1482,6 +1496,7 @@
 				8BFDF95F2135AB2C002F6A80 /* TNLRequestAuthorizer.h in Headers */,
 				8BFDF9602135AB2C002F6A80 /* TNLRequest.h in Headers */,
 				8BFDF9612135AB2C002F6A80 /* TNL_Project.h in Headers */,
+				8B490DD922A82B9D002D2296 /* NSCoder+TNLAdditions.h in Headers */,
 				8BFDF9622135AB2C002F6A80 /* TNL_ProjectCommon.h in Headers */,
 				8BFDF9632135AB2C002F6A80 /* TNLNetworkObserver.h in Headers */,
 				8BFDF9642135AB2C002F6A80 /* TNLTiming.h in Headers */,
@@ -1567,6 +1582,7 @@
 				BF4AA11B1EE61D46001647B5 /* TNLAttemptMetrics.h in Headers */,
 				BF4AA11C1EE61D46001647B5 /* TNLPriority.h in Headers */,
 				BF4AA11D1EE61D46001647B5 /* NSURLRequest+TNLAdditions.h in Headers */,
+				8B490DD822A82B9D002D2296 /* NSCoder+TNLAdditions.h in Headers */,
 				BF4AA11E1EE61D46001647B5 /* NSOperationQueue+TNLSafety.h in Headers */,
 				BF4AA11F1EE61D46001647B5 /* NSCachedURLResponse+TNLAdditions.h in Headers */,
 				BF4AA1201EE61D46001647B5 /* NSData+TNLAdditions.h in Headers */,
@@ -1883,6 +1899,7 @@
 				8B9EBDD12135B4B100E6E466 /* TNLPriority.m in Sources */,
 				8B9EBDD22135B4B100E6E466 /* TNLRequest.m in Sources */,
 				8B9EBDD32135B4B100E6E466 /* NSURL+TNLAdditions.m in Sources */,
+				8B490DDE22A82B9D002D2296 /* NSCoder+TNLAdditions.m in Sources */,
 				8B9EBDD42135B4B100E6E466 /* NSNumber+TNLURLCoding.m in Sources */,
 				8B9EBDD52135B4B100E6E466 /* NSOperationQueue+TNLSafety.m in Sources */,
 				8B9EBDD62135B4B100E6E466 /* TNLAttemptMetrics.m in Sources */,
@@ -1959,6 +1976,7 @@
 				8BDA9D351978822300678D90 /* TNLPriority.m in Sources */,
 				8BE403181946794300C7241E /* TNLRequest.m in Sources */,
 				8B87BA401E09DA20005A8926 /* NSURL+TNLAdditions.m in Sources */,
+				8B490DDB22A82B9D002D2296 /* NSCoder+TNLAdditions.m in Sources */,
 				8B959C2B1BAB6BA3007858C0 /* NSNumber+TNLURLCoding.m in Sources */,
 				8BE68D021B7E421100A0F853 /* NSOperationQueue+TNLSafety.m in Sources */,
 				8BF953E01A67DD3F00E9C1AA /* TNLAttemptMetrics.m in Sources */,
@@ -2041,6 +2059,7 @@
 				8BFDF9282135AB2C002F6A80 /* TNLPriority.m in Sources */,
 				8BFDF9292135AB2C002F6A80 /* TNLRequest.m in Sources */,
 				8BFDF92A2135AB2C002F6A80 /* NSURL+TNLAdditions.m in Sources */,
+				8B490DDD22A82B9D002D2296 /* NSCoder+TNLAdditions.m in Sources */,
 				8BFDF92B2135AB2C002F6A80 /* NSNumber+TNLURLCoding.m in Sources */,
 				8BFDF92C2135AB2C002F6A80 /* NSOperationQueue+TNLSafety.m in Sources */,
 				8BFDF92D2135AB2C002F6A80 /* TNLAttemptMetrics.m in Sources */,
@@ -2123,6 +2142,7 @@
 				BF4AA0DC1EE61D46001647B5 /* TNLPriority.m in Sources */,
 				BF4AA0DD1EE61D46001647B5 /* TNLRequest.m in Sources */,
 				BF4AA0DE1EE61D46001647B5 /* NSURL+TNLAdditions.m in Sources */,
+				8B490DDC22A82B9D002D2296 /* NSCoder+TNLAdditions.m in Sources */,
 				BF4AA0DF1EE61D46001647B5 /* NSNumber+TNLURLCoding.m in Sources */,
 				BF4AA0E01EE61D46001647B5 /* NSOperationQueue+TNLSafety.m in Sources */,
 				BF4AA0E11EE61D46001647B5 /* TNLAttemptMetrics.m in Sources */,


### PR DESCRIPTION
- change `computeMD5` to `responseComputeHashAlgorithm`
  - provides choice in what hash algo to use
- Make `TNLResponse` fully support secure coding
  - Necessary for iOS 13
- Introduce TARGET_OS_UIKITFORMAC conditional code
  - Project settings still not update for iOS on Mac support (yet)