### PR TITLE
v2.8.1 Preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,35 @@
 
 ## Info
 
-**Document version:** 2.7.0
+**Document version:** 2.8.1
 
-**Last updated:** 06/05/2019
+**Last updated:** 08/26/2019
 
 **Author:** Nolan O'Brien
 
 ## History
+
+### 2.8.1
+
+- Disable `connectivityOptions` on `TNLRequestConfiguration` for iOS 13+
+  - `connectivityOptions` are backed by `NSURLSessionConfiguration` `waitsForConnectivity`
+  - `waitsForConnectivity` regressed in iOS 13 betas and is unuseable as a feature currently.
+  - _NOTE: if iOS 13 releases with this regression and it is not promptly fixed with an iOS 13.1, __TNL__ will completely disable support for `waitsForConnectivity` behavior by deprecating the `connectivityOptions` configuration property._
+
+### 2.8.0
+
+- Expose `shouldUseExtendedBackgroundIdleMode` in `TNLRequestConfiguration`
+  - There's a lot of nuance to this configuration property, so take care when using it 
+
+### 2.7.5
+
+- Change it so that iOS 12 and above use __Network.framework__ for reachability instead of __SystemConfiguration.framework__
+  - Reachability in __SystemConfiguration.framework__ has been broken in simulator since iOS 11
+  - Reachability in __SystemConfiguration.framework__ will no longer work at all starting in iOS 13
+  - Reachability using `nw_path_monitor_t` is the new canonical way to observe reachability changes, so we'll use that
+- Change network reachability flags in `TNLCommunicationAgent` from `SCNetworkReachabilityFlags` to `TNLNetworkReachabilityFlags`
+  - On iOS 11 and below, the flags are exactly the same as `SCNetworkReachabilityFlags`
+  - On iOS 12 and above, the flags now map to the new `TNLNetworkReachabilityMask` flags
 
 ### 2.7.0
  

--- a/Source/NSData+TNLAdditions.h
+++ b/Source/NSData+TNLAdditions.h
@@ -16,7 +16,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface NSData (TNLAdditions)
-- (NSData *)tnl_safeSubdataNoCopyWithRange:(NSRange)range;
+- (NSData *)tnl_safeSubdataNoCopyWithRange:(NSRange)subRange; // throws `NSRangeException`
+- (nullable NSData *)tnl_safeSubdataNoCopyWithRange:(NSRange)range error:(out NSError * __nullable * __nullable)outError;
 - (NSString *)tnl_hexStringValue;
 @end
 

--- a/Source/NSData+TNLAdditions.m
+++ b/Source/NSData+TNLAdditions.m
@@ -13,18 +13,106 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation NSData (TNLAdditions)
 
-- (NSData *)tnl_safeSubdataNoCopyWithRange:(NSRange)range
+- (NSData *)tnl_safeSubdataNoCopyWithRange:(NSRange)subRange
 {
-    if (range.location == 0 && range.length == self.length) {
+    if (subRange.location == 0 && subRange.length == self.length) {
+        // exact match, return early
         return self;
     }
 
-    // TODO: optimize so that self.bytes doesn't have to be called,
-    // since it triggers a copy of all bytes when the NSData has non-continuous data
+    if (subRange.location + subRange.length > self.length) {
+        // out of range, throw exception just like [NSData subdataWithRange:]
+        NSString *subrangeString = NSStringFromRange(subRange);
+        NSString *rangeString = NSStringFromRange(NSMakeRange(0, self.length));
+        @throw [NSException exceptionWithName:NSRangeException
+                                       reason:[NSString stringWithFormat:@"subdata %@ is out of range %@!", subrangeString, rangeString]
+                                     userInfo:nil];
+    }
 
-    const void *bytePtr = self.bytes + range.location;
-    NSData *data = [NSData dataWithBytesNoCopy:(void *)bytePtr length:range.length freeWhenDone:NO];
-    objc_setAssociatedObject(data, _cmd, self, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    if (subRange.length == 0) {
+        // zero length is still valid
+        return [NSData data];
+    }
+
+#if __LP64__
+    __block dispatch_data_t dispatchData = dispatch_data_create("", 0, NULL, NULL);
+#else
+    NSMutableData *mutableData = [[NSMutableData alloc] init];
+#endif
+
+    [self enumerateByteRangesUsingBlock:^(const void * _Nonnull bytes, NSRange byteRange, BOOL * _Nonnull stop) {
+
+        if (byteRange.location >= (subRange.location + subRange.length)) {
+            // past the end
+            *stop = YES;
+            return;
+        }
+
+        if ((byteRange.location + byteRange.length) <= subRange.location) {
+            // before the beginning
+            return;
+        }
+
+        NSRange cutRange = byteRange;
+        NSInteger delta;
+
+        delta = (NSInteger)subRange.location - (NSInteger)cutRange.location;
+        if (delta > 0) {
+            // byteRange provided offers excess bytes at the beginning, disregard those
+            cutRange.length -= (NSUInteger)delta;
+            cutRange.location = subRange.location;
+        }
+
+        delta = (NSInteger)(cutRange.location + cutRange.length) - (NSInteger)(subRange.location + subRange.length);
+        if (delta > 0) {
+            // byteRange provided offers excess bytes at the end, disregard those
+            cutRange.length -= (NSUInteger)delta;
+        }
+
+        // find byte pointer, which is bytes plus our calculated offset for start of bytes
+        const void *bytePtr = bytes + (cutRange.location - byteRange.location);
+
+        // append the data as-is (no copy, no free when done)
+#if __LP64__
+        dispatch_data_t cutData = dispatch_data_create(bytePtr, cutRange.length, NULL, ^{ /*noop*/ });
+        dispatchData = dispatch_data_create_concat(dispatchData, cutData);
+#else // 32 bit
+        NSData *rData = [NSData dataWithBytesNoCopy:(void*)bytePtr length:cutRange.length freeWhenDone:NO];
+        [mutableData appendData:rData];
+#endif
+
+    }];
+
+    NSData *retData = nil;
+#if __LP64__
+    retData = (NSData *)dispatchData; // nice!
+#else // 32 bit
+    retData = (NSData *)mutableData;
+#endif
+
+    // preserve the source data for the lifetime of the subdata
+    objc_setAssociatedObject(retData, _cmd, self, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    return retData;
+}
+
+- (nullable NSData *)tnl_safeSubdataNoCopyWithRange:(NSRange)subRange error:(out NSError * __nullable * __nullable)outError
+{
+    NSData *data = nil;
+    @try {
+
+        data = [self tnl_safeSubdataNoCopyWithRange:subRange];
+
+    } @catch (NSException *e) {
+
+        // convert the exception to an error (then return nil)
+        if (outError) {
+            *outError = [NSError errorWithDomain:NSPOSIXErrorDomain
+                                            code:[e.name isEqualToString:NSRangeException] ? ERANGE : EBADMSG
+                                        userInfo:@{ @"exception" : e }];
+        }
+
+    }
+
     return data;
 }
 

--- a/Source/NSDictionary+TNLAdditions.m
+++ b/Source/NSDictionary+TNLAdditions.m
@@ -64,11 +64,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id)tnl_copyToMutable:(BOOL)mutable uppercase:(BOOL)uppercase
 {
-    NSMutableDictionary *d = [[NSMutableDictionary alloc] init];
+    NSMutableDictionary *replacementDict = nil;
+
     for (NSString *key in self) {
-        d[(uppercase) ? key.uppercaseString : key.lowercaseString] = self[key];
+        NSString *updatedKey = uppercase ? [key uppercaseString] : [key lowercaseString];
+        if (![key isEqualToString:updatedKey]) {
+            if (!replacementDict) {
+                replacementDict = [self mutableCopy];
+            }
+
+            [replacementDict removeObjectForKey:key];
+            replacementDict[updatedKey] = self[key];
+        }
     }
-    return (mutable) ? d : [d copy];
+
+    return replacementDict ?: (mutable ? [self mutableCopy] : [self copy]);
 }
 
 @end

--- a/Source/NSURLCache+TNLAdditions.m
+++ b/Source/NSURLCache+TNLAdditions.m
@@ -178,7 +178,7 @@ NSURLCache *TNLGetURLCacheDemuxProxy()
     return [self init];
 }
 
-#if !TARGET_OS_UIKITFORMAC
+#if !TARGET_OS_MACCATALYST
 - (id)initWithMemoryCapacity:(NSUInteger)memoryCapacity diskCapacity:(NSUInteger)diskCapacity diskPath:(nullable NSString *)path
 {
     return [self init];

--- a/Source/NSURLSessionConfiguration+TNLAdditions.h
+++ b/Source/NSURLSessionConfiguration+TNLAdditions.h
@@ -46,6 +46,20 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)tnl_URLSessionSupportsDecodingBrotliContentEncoding;
 
 /**
+ Introduced in iOS 11, `waitsForConnectivity` offers a great deal of control over network requests and
+ can help avoid needlessly failing a request that can wait until there is a network connection to execute.
+ With iOS 13 beta (and matching tvOS, macOS and watchOS versions), Apple regressed `waitsForConnectivity`.
+ `NSURLSession` layer no longer calls `NSURLSessionTaskDelegate` `URLSession:taskIsWaitingForConnectivity:`
+ rendering the feature impotent and dangerous (easily leading to never finishing network requests which
+ can lead to interminable hangs based on the dependencies established on the `TNLRequestOperation`).
+ #FB7027774
+ For versions of iOS (and other matching OSes) that did not support `waitsForConnectivity` (below iOS 11), this will return `NO`.
+ For versions of iOS (and other matching OSes) that have the regression from iOS 13, this will return `NO`.
+ Otherwise, this will return `YES` and `waitsForConnectivity` features can be used.
+ */
++ (BOOL)tnl_URLSessionCanUseWaitsForConnectivity;
+
+/**
  Convenience method for appropriately mutating the session configuration's `protocolClasses`
  */
 - (void)tnl_insertProtocolClasses:(nullable NSArray<Class> *)additionalClasses;

--- a/Source/NSURLSessionTaskMetrics+TNLAdditions.h
+++ b/Source/NSURLSessionTaskMetrics+TNLAdditions.h
@@ -38,6 +38,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSDictionary<NSString *, id> *)tnl_dictionaryValue;
 
 /**
+ returns the `resourceFetchType` as a readable debug string
+ */
+- (NSString *)tnl_resourceFetchTypeDebugString;
+
+/**
  returns the earliest date of all the timing dates
  */
 - (nullable NSDate *)tnl_earliestDate;
@@ -58,6 +63,12 @@ NS_ASSUME_NONNULL_BEGIN
  returns a string describing the timings
  */
 - (NSString *)tnl_timingDescription;
+
+/**
+ returns a dictionary of meta data info.
+ Does not provide timing info, request model data or response model data.
+ */
+- (NSDictionary<NSString *, id> *)tnl_medadata;
 
 /** convenience method for TCP start if connect includes TCP connect */
 @property (nonatomic, readonly, nullable) NSDate *tnl_transportConnectionStartDate;

--- a/Source/TNLAttemptMetaData.h
+++ b/Source/TNLAttemptMetaData.h
@@ -73,6 +73,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSTimeInterval taskWithoutMetricsCompletionLatency;
 - (BOOL)hasTaskWithoutMetricsCompletionLatency;
 
+/**
+ The headers from the URL response, converted to all lowercase
+ */
+@property (nonatomic, copy, readonly, nullable) NSDictionary *responseLowercaseHeaders;
+- (BOOL)hasResponseLowercaseHeaders;
 
 /**
  The number of bytes received in the response body at OSI layer 8.

--- a/Source/TNLAttemptMetaData_Project.h
+++ b/Source/TNLAttemptMetaData_Project.h
@@ -43,6 +43,7 @@ PRIMITIVE_FIELD(layer8BodyBytesTransmitted, Layer8BodyBytesTransmitted, SInt64, 
 PRIMITIVE_FIELD(serverResponseTime, ServerResponseTime, SInt64, longLongValue) \
 PRIMITIVE_FIELD(localCacheHit, LocalCacheHit, BOOL, boolValue) \
 PRIMITIVE_FIELD(responseBodyHashAlgorithm, ResponseBodyHashAlgorithm, TNLResponseHashComputeAlgorithm, integerValue) \
+OBJECT_FIELD(responseLowercaseHeaders, ResponseLowercaseHeaders, NSDictionary) \
 OBJECT_FIELD(responseBodyHash, ResponseBodyHash, NSData) \
 OBJECT_FIELD(sessionId, SessionId, NSString) \
 \

--- a/Source/TNLAttemptMetrics.h
+++ b/Source/TNLAttemptMetrics.h
@@ -78,7 +78,7 @@ static const NSInteger TNLAttemptCompleteDispositionCount = 3;
 /** attempt reachability status */
 @property (nonatomic, readonly) TNLNetworkReachabilityStatus reachabilityStatus;
 /** attempt reachability flags */
-@property (nonatomic, readonly) SCNetworkReachabilityFlags reachabilityFlags;
+@property (nonatomic, readonly) TNLNetworkReachabilityFlags reachabilityFlags;
 /** attempt radio access technology */
 @property (nonatomic, copy, readonly, nullable) NSString *WWANRadioAccessTechnology;
 /** attempt carrier info. Note: `nil` for macOS since there is no cellular carrier information */

--- a/Source/TNLAttemptMetrics.m
+++ b/Source/TNLAttemptMetrics.m
@@ -132,7 +132,7 @@ TNLStaticAssert(TNLAttemptCompleteDispositionCount == TNLAttemptTypeCount, ATTEM
 
 #endif
 
-#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
         _carrierInfo = TNLCarrierInfoFromDictionary([aDecoder decodeObjectOfClass:[NSDictionary class]
                                                                            forKey:@"carrierInfo"]);
 #endif
@@ -167,7 +167,7 @@ TNLStaticAssert(TNLAttemptCompleteDispositionCount == TNLAttemptTypeCount, ATTEM
     [aCoder encodeObject:_WWANRadioAccessTechnology forKey:@"WWANRadioAccessTechnology"];
 #endif
 
-#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
     [aCoder encodeObject:TNLCarrierInfoToDictionary(_carrierInfo) forKey:@"carrierInfo"];
 #endif
 }

--- a/Source/TNLCommunicationAgent.m
+++ b/Source/TNLCommunicationAgent.m
@@ -6,14 +6,19 @@
 //  Copyright © 2016 Twitter. All rights reserved.
 //
 
+#include <TargetConditionals.h>
+
+#if !TARGET_OS_WATCH // no communication agent for watchOS
+
+#import <Network/Network.h>
+#import <SystemConfiguration/SystemConfiguration.h>
+
 #import "NSDictionary+TNLAdditions.h"
 #import "NSURLSessionConfiguration+TNLAdditions.h"
 #import "TNL_Project.h"
 #import "TNLCommunicationAgent_Project.h"
 #import "TNLHTTP.h"
 #import "TNLPseudoURLProtocol.h"
-
-#if !TARGET_OS_WATCH // no communication agent for watchOS
 
 #define SELF_ARG PRIVATE_SELF(TNLCommunicationAgent)
 
@@ -25,7 +30,26 @@ static NSString * const kCaptivePortalCheckEndpoint = @"http://connectivitycheck
 static void _ReachabilityCallback(__unused SCNetworkReachabilityRef target,
                                   const SCNetworkReachabilityFlags flags,
                                   void* info);
-static TNLNetworkReachabilityStatus _NetworkReachabilityStatusFromFlags(SCNetworkReachabilityFlags flags) __attribute__((const));
+static TNLNetworkReachabilityStatus _NetworkReachabilityStatusFromFlags(TNLNetworkReachabilityFlags flags) __attribute__((const));
+static TNLNetworkReachabilityFlags _NetworkReachabilityFlagsFromPath(nw_path_t path);
+
+#define _NWPathStatusToFlag(status) ((status > 0) ? ((uint32_t)1 << (uint32_t)((status) - 1)) : 0)
+#define _NWInterfaceTypeToFlag(itype) ((uint32_t)1 << (uint32_t)8 << (uint32_t)(itype))
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
+
+TNLStaticAssert(_NWPathStatusToFlag(nw_path_status_satisfied) == TNLNetworkReachabilityMaskPathStatusSatisfied, MISSMATCH_REACHABILITY_FLAGS);
+TNLStaticAssert(_NWPathStatusToFlag(nw_path_status_unsatisfied) == TNLNetworkReachabilityMaskPathStatusUnsatisfied, MISSMATCH_REACHABILITY_FLAGS);
+TNLStaticAssert(_NWPathStatusToFlag(nw_path_status_satisfiable) == TNLNetworkReachabilityMaskPathStatusSatisfiable, MISSMATCH_REACHABILITY_FLAGS);
+
+TNLStaticAssert(_NWInterfaceTypeToFlag(nw_interface_type_other) == TNLNetworkReachabilityMaskPathIntefaceTypeOther, MISSMATCH_REACHABILITY_FLAGS);
+TNLStaticAssert(_NWInterfaceTypeToFlag(nw_interface_type_wifi) == TNLNetworkReachabilityMaskPathIntefaceTypeWifi, MISSMATCH_REACHABILITY_FLAGS);
+TNLStaticAssert(_NWInterfaceTypeToFlag(nw_interface_type_cellular) == TNLNetworkReachabilityMaskPathIntefaceTypeCellular, MISSMATCH_REACHABILITY_FLAGS);
+TNLStaticAssert(_NWInterfaceTypeToFlag(nw_interface_type_wired) == TNLNetworkReachabilityMaskPathIntefaceTypeWired, MISSMATCH_REACHABILITY_FLAGS);
+TNLStaticAssert(_NWInterfaceTypeToFlag(nw_interface_type_loopback) == TNLNetworkReachabilityMaskPathIntefaceTypeLoopback, MISSMATCH_REACHABILITY_FLAGS);
+
+#pragma clang diagnostic pop
 
 @interface TNLCommunicationAgentWeakWrapper : NSObject
 @property (nonatomic, weak) TNLCommunicationAgent *communicationAgent;
@@ -34,7 +58,7 @@ static TNLNetworkReachabilityStatus _NetworkReachabilityStatusFromFlags(SCNetwor
 @interface TNLCommunicationAgent ()
 
 @property (atomic) TNLNetworkReachabilityStatus currentReachabilityStatus;
-@property (atomic) SCNetworkReachabilityFlags currentReachabilityFlags;
+@property (atomic) TNLNetworkReachabilityFlags currentReachabilityFlags;
 @property (atomic, copy, nullable) NSString *currentWWANRadioAccessTechnology;
 @property (atomic) TNLCaptivePortalStatus currentCaptivePortalStatus;
 @property (atomic, nullable) id<TNLCarrierInfo> currentCarrierInfo;
@@ -44,9 +68,10 @@ static TNLNetworkReachabilityStatus _NetworkReachabilityStatusFromFlags(SCNetwor
 @interface TNLCommunicationAgent (Agent)
 
 static void _agent_initialize(SELF_ARG);
-static void _agent_forciblyUpdateReachability(SELF_ARG);
-static void _agent_updateReachabilityFlags(SELF_ARG,
-                                           SCNetworkReachabilityFlags newFlags);
+static void _agent_forciblyUpdateLegacyReachability(SELF_ARG);
+static void _agent_updateReachability(SELF_ARG,
+                                      TNLNetworkReachabilityFlags newFlags,
+                                      TNLNetworkReachabilityStatus newStatus);
 
 static void _agent_addObserver(SELF_ARG,
                                id<TNLCommunicationAgentObserver> observer);
@@ -71,7 +96,7 @@ static void _agent_handleCaptivePortalResponse(SELF_ARG,
 @end
 
 @interface TNLCommunicationAgent (Private)
-#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 static void _updateCarrier(SELF_ARG,
                            CTCarrier *carrier);
 #endif
@@ -94,8 +119,10 @@ static void _updateCarrier(SELF_ARG,
     NSOperationQueue *_agentOperationQueue;
     TNLCommunicationAgentWeakWrapper *_agentWrapper;
 
-    SCNetworkReachabilityRef _reachabilityRef;
-#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+    SCNetworkReachabilityRef _legacyReachabilityRef;
+    nw_path_monitor_t _modernReachabilityNetworkPathMonitor; // supports ARC
+
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
     CTTelephonyNetworkInfo *_internalTelephonyNetworkInfo;
 #endif
     NSURLSessionConfiguration *_captivePortalSessionConfiguration;
@@ -146,13 +173,18 @@ static void _updateCarrier(SELF_ARG,
 
 - (void)dealloc
 {
-    if (_reachabilityRef) {
-        SCNetworkReachabilitySetCallback(_reachabilityRef, NULL, NULL);
-        SCNetworkReachabilitySetDispatchQueue(_reachabilityRef, NULL);
-        CFRelease(_reachabilityRef);
+    if (_legacyReachabilityRef) {
+        SCNetworkReachabilitySetCallback(_legacyReachabilityRef, NULL, NULL);
+        SCNetworkReachabilitySetDispatchQueue(_legacyReachabilityRef, NULL);
+        CFRelease(_legacyReachabilityRef);
+    }
+    if (tnl_available_ios_12) {
+        if (_modernReachabilityNetworkPathMonitor) {
+            nw_path_monitor_cancel(_modernReachabilityNetworkPathMonitor);
+        }
     }
 
-#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
     [[NSNotificationCenter defaultCenter] removeObserver:self
                                                     name:CTRadioAccessTechnologyDidChangeNotification
                                                   object:nil];
@@ -224,14 +256,16 @@ static void _updateCarrier(SELF_ARG,
 
 @implementation TNLCommunicationAgent (Agent)
 
-static void _agent_forciblyUpdateReachability(SELF_ARG)
+#pragma mark Legacy Reachability
+
+static void _agent_forciblyUpdateLegacyReachability(SELF_ARG)
 {
     if (!self) {
         return;
     }
 
     SCNetworkReachabilityFlags flags;
-    if (SCNetworkReachabilityGetFlags(self->_reachabilityRef, &flags)) {
+    if (SCNetworkReachabilityGetFlags(self->_legacyReachabilityRef, &flags)) {
         self.currentReachabilityFlags = flags;
         self.currentReachabilityStatus = _NetworkReachabilityStatusFromFlags(flags);
     } else {
@@ -240,35 +274,80 @@ static void _agent_forciblyUpdateReachability(SELF_ARG)
     }
 }
 
-static void _agent_initializeReachability(SELF_ARG)
+static void _agent_initializeLegacyReachability(SELF_ARG)
 {
     if (!self) {
         return;
     }
 
-    self->_reachabilityRef = SCNetworkReachabilityCreateWithName(kCFAllocatorDefault, self.host.UTF8String);
+    self->_legacyReachabilityRef = SCNetworkReachabilityCreateWithName(kCFAllocatorDefault, self.host.UTF8String);
 
-    _agent_forciblyUpdateReachability(self);
+    _agent_forciblyUpdateLegacyReachability(self);
 
     SCNetworkReachabilityContext context = { 0, (__bridge void*)self->_agentWrapper, NULL, NULL, NULL };
-    if (SCNetworkReachabilitySetCallback(self->_reachabilityRef, _ReachabilityCallback, &context)) {
-        if (SCNetworkReachabilitySetDispatchQueue(self->_reachabilityRef, self->_agentQueue)) {
+    if (SCNetworkReachabilitySetCallback(self->_legacyReachabilityRef, _ReachabilityCallback, &context)) {
+        if (SCNetworkReachabilitySetDispatchQueue(self->_legacyReachabilityRef, self->_agentQueue)) {
             self->_flags.initializedReachability = 1;
         } else {
-            SCNetworkReachabilitySetCallback(self->_reachabilityRef, NULL, NULL);
-            CFRelease(self->_reachabilityRef);
-            self->_reachabilityRef = NULL;
+            SCNetworkReachabilitySetCallback(self->_legacyReachabilityRef, NULL, NULL);
+            CFRelease(self->_legacyReachabilityRef);
+            self->_legacyReachabilityRef = NULL;
         }
     }
 
     if (!self->_flags.initializedReachability) {
         TNLLogError(@"Failed to start reachability: %@", self.host);
-        if (self->_reachabilityRef) {
-            CFRelease(self->_reachabilityRef);
-            self->_reachabilityRef = NULL;
+        if (self->_legacyReachabilityRef) {
+            CFRelease(self->_legacyReachabilityRef);
+            self->_legacyReachabilityRef = NULL;
         }
     }
 }
+
+#pragma mark Modern Reachability
+
+static void _agent_updateModernReachability(SELF_ARG, nw_path_t __nonnull path)
+{
+    if (!self) {
+        return;
+    }
+
+    if (tnl_available_ios_12) {
+
+#if DEBUG
+        TNLLogDebug(@"network path monitor update: %@", path.description);
+#endif
+
+        const TNLNetworkReachabilityFlags newFlags = _NetworkReachabilityFlagsFromPath(path);
+        const TNLNetworkReachabilityStatus newStatus = _NetworkReachabilityStatusFromFlags(newFlags);
+        _agent_updateReachability(self, newFlags, newStatus);
+    }
+}
+
+static void _agent_initializeModernReachability(SELF_ARG)
+{
+    if (!self) {
+        return;
+    }
+
+    if (tnl_available_ios_12) {
+        __weak typeof(self) weakSelf = self;
+        self->_modernReachabilityNetworkPathMonitor = nw_path_monitor_create();
+
+        nw_path_monitor_set_queue(self->_modernReachabilityNetworkPathMonitor, self->_agentQueue);
+        // nw_path_monitor_set_cancel_handler // don't need a cancel handler
+        nw_path_monitor_set_update_handler(self->_modernReachabilityNetworkPathMonitor, ^(nw_path_t  __nonnull path) {
+            __strong typeof(self) strongSelf = weakSelf;
+            _agent_updateModernReachability(strongSelf, path);
+        });
+
+        nw_path_monitor_start(self->_modernReachabilityNetworkPathMonitor); // will trigger an update callback (but async)
+
+        self->_flags.initializedReachability = 1;
+    }
+}
+
+#pragma mark Telephony
 
 static void _agent_initializeTelephony(SELF_ARG)
 {
@@ -276,7 +355,7 @@ static void _agent_initializeTelephony(SELF_ARG)
         return;
     }
 
-#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
     __weak typeof(self) weakSelf = self;
 
     self->_internalTelephonyNetworkInfo = [[CTTelephonyNetworkInfo alloc] init];
@@ -288,11 +367,13 @@ static void _agent_initializeTelephony(SELF_ARG)
                                                  name:CTRadioAccessTechnologyDidChangeNotification object:nil];
     self.currentCarrierInfo = [TNLCarrierInfoInternal carrierWithCarrier:self->_internalTelephonyNetworkInfo.subscriberCellularProvider];
     self.currentWWANRadioAccessTechnology = [self->_internalTelephonyNetworkInfo.currentRadioAccessTechnology copy];
-#endif // #if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+#endif // #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 
     self->_flags.initializedCarrier = 1;
     self->_flags.initializedRadioTech = 1;
 }
+
+#pragma mark Captive Portal
 
 static void _agent_initializeCaptivePortalStatus(SELF_ARG)
 {
@@ -323,6 +404,8 @@ static void _agent_initializeCaptivePortalStatus(SELF_ARG)
     [self->_queuedCaptivePortalCallbacks addObject:[callback copy]];
 }
 
+#pragma mark Private Methods
+
 static void _agent_initialize(SELF_ARG)
 {
     if (!self) {
@@ -333,9 +416,14 @@ static void _agent_initialize(SELF_ARG)
     TNLAssert(!self->_flags.initializedReachability);
     TNLAssert(!self->_flags.initializedCarrier);
     TNLAssert(!self->_flags.initializedRadioTech);
-    TNLAssert(!self->_reachabilityRef);
+    TNLAssert(!self->_legacyReachabilityRef);
+    TNLAssert(!self->_modernReachabilityNetworkPathMonitor);
 
-    _agent_initializeReachability(self);
+    if (tnl_available_ios_12) {
+        _agent_initializeModernReachability(self);
+    } else {
+        _agent_initializeLegacyReachability(self);
+    }
     _agent_initializeTelephony(self);
     _agent_initializeCaptivePortalStatus(self);
 
@@ -393,7 +481,7 @@ static void _agent_addObserver(SELF_ARG,
     }
 
     if ([observer respondsToSelector:modernSelector]) {
-        SCNetworkReachabilityFlags flags = self.currentReachabilityFlags;
+        TNLNetworkReachabilityFlags flags = self.currentReachabilityFlags;
         TNLNetworkReachabilityStatus status = self.currentReachabilityStatus;
         id<TNLCarrierInfo> info = self.currentCarrierInfo;
         NSString *radioTech = self.currentWWANRadioAccessTechnology;
@@ -439,7 +527,7 @@ static void _agent_identifyReachability(SELF_ARG,
         return;
     }
 
-    SCNetworkReachabilityFlags flags = self.currentReachabilityFlags;
+    TNLNetworkReachabilityFlags flags = self.currentReachabilityFlags;
     TNLNetworkReachabilityStatus status = self.currentReachabilityStatus;
     tnl_dispatch_async_autoreleasing(dispatch_get_main_queue(), ^{
         callback(flags, status);
@@ -610,21 +698,20 @@ static void _agent_handleCaptivePortalResponse(SELF_ARG,
     });
 }
 
-static void _agent_updateReachabilityFlags(SELF_ARG,
-                                           SCNetworkReachabilityFlags newFlags)
+static void _agent_updateReachability(SELF_ARG,
+                                      TNLNetworkReachabilityFlags newFlags,
+                                      TNLNetworkReachabilityStatus newStatus)
 {
     if (!self) {
         return;
     }
 
-    const SCNetworkReachabilityFlags oldFlags = self.currentReachabilityFlags;
+    const TNLNetworkReachabilityFlags oldFlags = self.currentReachabilityFlags;
     const TNLNetworkReachabilityStatus oldStatus = self.currentReachabilityStatus;
 
-    if (oldFlags == newFlags && oldStatus != TNLNetworkReachabilityUndetermined) {
+    if (oldFlags == newFlags && oldStatus == newStatus) {
         return;
     }
-
-    const TNLNetworkReachabilityStatus newStatus = _NetworkReachabilityStatusFromFlags(newFlags);
 
     self.currentReachabilityStatus = newStatus;
     self.currentReachabilityFlags = newFlags;
@@ -653,7 +740,7 @@ static void _agent_updateReachabilityFlags(SELF_ARG,
 
 @implementation TNLCommunicationAgent (Private)
 
-#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 static void _updateCarrier(SELF_ARG,
                            CTCarrier *carrier)
 {
@@ -678,7 +765,7 @@ static void _updateCarrier(SELF_ARG,
         });
     });
 }
-#endif // #if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+#endif // #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 
 - (void)private_updateRadioAccessTechnology:(NSNotification *)note
 {
@@ -707,7 +794,7 @@ static void _updateCarrier(SELF_ARG,
 
 @end
 
-#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 @implementation TNLCarrierInfoInternal
 
 @synthesize carrierName = _carrierName;
@@ -776,7 +863,7 @@ static void _updateCarrier(SELF_ARG,
 }
 
 @end
-#endif // #if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+#endif // #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 
 @implementation TNLCommunicationAgent (UnsafeSynchronousAccess)
 
@@ -807,12 +894,29 @@ static void _ReachabilityCallback(__unused SCNetworkReachabilityRef target,
 
     TNLCommunicationAgent *agent = [(__bridge TNLCommunicationAgentWeakWrapper *)info communicationAgent];
     if (agent) {
-        _agent_updateReachabilityFlags(agent, flags);
+        _agent_updateReachability(agent, flags, _NetworkReachabilityStatusFromFlags(flags));
     }
 }
 
-static TNLNetworkReachabilityStatus _NetworkReachabilityStatusFromFlags(SCNetworkReachabilityFlags flags)
+static TNLNetworkReachabilityStatus _NetworkReachabilityStatusFromFlags(TNLNetworkReachabilityFlags flags)
 {
+    if (tnl_available_ios_12) {
+        const TNLNetworkReachabilityMask mask = flags;
+        if ((mask & TNLNetworkReachabilityMaskPathStatusSatisfied) == 0) {
+            return TNLNetworkReachabilityNotReachable;
+        }
+
+        if ((mask & TNLNetworkReachabilityMaskPathIntefaceTypeWifi) != 0) {
+            return TNLNetworkReachabilityReachableViaWiFi;
+        }
+
+        if ((mask & TNLNetworkReachabilityMaskPathIntefaceTypeCellular) != 0) {
+            return TNLNetworkReachabilityReachableViaWWAN;
+        }
+
+        return TNLNetworkReachabilityUndetermined;
+    }
+
     if ((flags & kSCNetworkReachabilityFlagsReachable) == 0) {
         return TNLNetworkReachabilityNotReachable;
     }
@@ -839,13 +943,50 @@ static TNLNetworkReachabilityStatus _NetworkReachabilityStatusFromFlags(SCNetwor
     return TNLNetworkReachabilityNotReachable;
 }
 
+static TNLNetworkReachabilityFlags _NetworkReachabilityFlagsFromPath(nw_path_t path)
+{
+    if (tnl_available_ios_12) {
+        TNLNetworkReachabilityMask flags = 0;
+        if (path != nil) {
+            const nw_path_status_t status = nw_path_get_status(path);
+            if (status > 0) {
+#if DEBUG
+                if (gTwitterNetworkLayerAssertEnabled) {
+                    switch (status) {
+                        case nw_path_status_invalid:
+                        case nw_path_status_satisfied:
+                        case nw_path_status_unsatisfied:
+                        case nw_path_status_satisfiable:
+                            break;
+                        default:
+                            TNLAssertMessage(0, @"the nw_path_status_t enum has expanded!  Need to update TNLNetworkReachabilityMask.");
+                            break;
+                    }
+                }
+#endif
+                flags |= _NWPathStatusToFlag(status);
+            }
+
+            for (nw_interface_type_t itype = 0; itype <= 4; itype++) {
+                const bool usesInterface = nw_path_uses_interface_type(path, itype);
+                if (usesInterface) {
+                    flags |= _NWInterfaceTypeToFlag(itype);
+                }
+            }
+        }
+        return flags;
+    }
+
+    return 0;
+}
+
 TNLWWANRadioAccessTechnologyValue TNLWWANRadioAccessTechnologyValueFromString(NSString *WWANTechString)
 {
     static NSDictionary* sTechStringToValueMap = nil;
 
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
         sTechStringToValueMap = @{
                                   CTRadioAccessTechnologyGPRS : @(TNLWWANRadioAccessTechnologyValueGPRS),
                                   CTRadioAccessTechnologyEdge: @(TNLWWANRadioAccessTechnologyValueEDGE),
@@ -870,7 +1011,7 @@ TNLWWANRadioAccessTechnologyValue TNLWWANRadioAccessTechnologyValueFromString(NS
 
 NSString *TNLWWANRadioAccessTechnologyValueToString(TNLWWANRadioAccessTechnologyValue value)
 {
-#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
     switch (value) {
         case TNLWWANRadioAccessTechnologyValueGPRS:
             return CTRadioAccessTechnologyGPRS;
@@ -901,14 +1042,14 @@ NSString *TNLWWANRadioAccessTechnologyValueToString(TNLWWANRadioAccessTechnology
         case TNLWWANRadioAccessTechnologyValueUnknown:
             break;
     }
-#endif // TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+#endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 
     return @"unknown";
 }
 
 TNLWWANRadioAccessGeneration TNLWWANRadioAccessGenerationForTechnologyValue(TNLWWANRadioAccessTechnologyValue value)
 {
-#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
     switch (value) {
         case TNLWWANRadioAccessTechnologyValueEVDO_0:
         case TNLWWANRadioAccessTechnologyValue1xRTT:
@@ -932,7 +1073,7 @@ TNLWWANRadioAccessGeneration TNLWWANRadioAccessGenerationForTechnologyValue(TNLW
         case TNLWWANRadioAccessTechnologyValueUnknown:
             break;
     }
-#endif // #if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+#endif // #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 
     return TNLWWANRadioAccessGenerationUnknown;
 }
@@ -969,7 +1110,7 @@ NSString *TNLCaptivePortalStatusToString(TNLCaptivePortalStatus status)
     return @"undetermined";
 }
 
-#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 
 NSDictionary * __nullable TNLCarrierInfoToDictionary(id<TNLCarrierInfo> __nullable carrierInfo)
 {
@@ -1007,15 +1148,29 @@ id<TNLCarrierInfo> __nullable TNLCarrierInfoFromDictionary(NSDictionary * __null
                                                     allowsVOIP:[dict[@"allowsVOIP"] boolValue]];
 }
 
-#endif // #if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+#endif // #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 
-NS_INLINE const char _DebugCharFromReachabilityFlag(SCNetworkReachabilityFlags flags, uint32_t flag, const char presentChar)
+NS_INLINE const char _DebugCharFromReachabilityFlag(TNLNetworkReachabilityFlags flags, uint32_t flag, const char presentChar)
 {
     return TNL_BITMASK_HAS_SUBSET_FLAGS(flags, flag) ? presentChar : '_';
 }
 
-NSString *TNLDebugStringFromNetworkReachabilityFlags(SCNetworkReachabilityFlags flags)
+NSString *TNLDebugStringFromNetworkReachabilityFlags(TNLNetworkReachabilityFlags flags)
 {
+    if (tnl_available_ios_12) {
+        return [NSString stringWithFormat:
+                @"%c%c%c%c%c%c%c%c",
+                _DebugCharFromReachabilityFlag(flags, TNLNetworkReachabilityMaskPathStatusUnsatisfied, 'U'),
+                _DebugCharFromReachabilityFlag(flags, TNLNetworkReachabilityMaskPathStatusSatisfied, 'S'),
+                _DebugCharFromReachabilityFlag(flags, TNLNetworkReachabilityMaskPathStatusSatisfiable, 's'),
+                _DebugCharFromReachabilityFlag(flags, TNLNetworkReachabilityMaskPathIntefaceTypeOther, 'o'),
+                _DebugCharFromReachabilityFlag(flags, TNLNetworkReachabilityMaskPathIntefaceTypeWifi, 'w'),
+                _DebugCharFromReachabilityFlag(flags, TNLNetworkReachabilityMaskPathIntefaceTypeCellular, 'c'),
+                _DebugCharFromReachabilityFlag(flags, TNLNetworkReachabilityMaskPathIntefaceTypeWired, 'e'),
+                _DebugCharFromReachabilityFlag(flags, TNLNetworkReachabilityMaskPathIntefaceTypeLoopback, 'l')
+                ];
+    }
+
     return [NSString stringWithFormat:
 #if TARGET_OS_IOS
             @"%c%c%c%c%c%c%c%c%c",

--- a/Source/TNLCommunicationAgent_Project.h
+++ b/Source/TNLCommunicationAgent_Project.h
@@ -11,7 +11,7 @@
 
 #import <TwitterNetworkLayer/TNLCommunicationAgent.h>
 
-#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 
 #pragma mark IOS only imports
 
@@ -40,4 +40,4 @@ FOUNDATION_EXTERN id<TNLCarrierInfo> __nullable TNLCarrierInfoFromDictionary(NSD
 
 NS_ASSUME_NONNULL_END
 
-#endif // TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+#endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST

--- a/Source/TNLGlobalConfiguration.m
+++ b/Source/TNLGlobalConfiguration.m
@@ -145,7 +145,12 @@ const NSTimeInterval TNLGlobalConfigurationRequestOperationCallbackTimeoutDefaul
 
 - (void)_tnl_applicationWillEnterForeground:(NSNotification *)note
 {
-    self.lastApplicationState = UIApplicationStateInactive;
+    // When you adopt UIScene in iOS 13+, the foreground notification is sent
+    // on both cold start and return from background. We only want to update
+    // our application state for the latter
+    if (self.lastApplicationState == UIApplicationStateBackground) {
+        self.lastApplicationState = UIApplicationStateInactive;
+    }
 }
 
 - (void)_tnl_applicationDidBecomeActive:(NSNotification *)note

--- a/Source/TNLInternalKeys.h
+++ b/Source/TNLInternalKeys.h
@@ -24,6 +24,7 @@
 #define kSharedKeySharedContainerIdentifier @"scid"
 #define kSharedKeySessionSendsLaunchEvents  @"ssle"
 #define kSharedKeyMultiPathServiceType      @"mptcp" // Multipath TCP (MPTCP)
+#define kSharedKeyShouldUseExtendedBackgroundIdleMode   @"xbim"
 
 #pragma mark Keys for URL Sessions Configs
 
@@ -49,6 +50,7 @@
 #define TNLSessionConfigurationPropertyKeySharedContainerIdentifier     kSharedKeySharedContainerIdentifier
 #define TNLSessionConfigurationPropertyKeyProtocolClassPrefix           @"pc" // key will be this prefix concatenated with an index
 #define TNLSessionConfigurationPropertyKeyMultipathServiceType          kSharedKeyMultiPathServiceType
+#define TNLSessionConfigurationPropertyKeyShouldUseExtendedBackgroundIdleMode   kSharedKeyShouldUseExtendedBackgroundIdleMode
 
 #pragma mark Keys for TNL Request Configs
 
@@ -72,4 +74,5 @@
 #define TNLRequestConfigurationPropertyKeyCookieStorage                         kSharedKeyHTTPCookieStorage
 #define TNLRequestConfigurationPropertyKeySharedContainerIdentifier             kSharedKeySharedContainerIdentifier
 #define TNLRequestConfigurationPropertyKeyMultipathServiceType                  kSharedKeyMultiPathServiceType
+#define TNLRequestConfigurationPropertyKeyShouldUseExtendedBackgroundIdleMode   kSharedKeyShouldUseExtendedBackgroundIdleMode
 

--- a/Source/TNLParameterCollection.m
+++ b/Source/TNLParameterCollection.m
@@ -374,7 +374,7 @@ typedef NSString *(^TNLParameterCollectionUpdateKeysAndValuesIterativeKeyBlock)(
                     parameterString = [path substringFromIndex:range.location + 1];
                 }
             }
-#if !TARGET_OS_UIKITFORMAC
+#if !TARGET_OS_MACCATALYST
         } else {
             parameterString = URL.parameterString;
 #endif

--- a/Source/TNLRequestOperation.m
+++ b/Source/TNLRequestOperation.m
@@ -1431,19 +1431,19 @@ static void _network_applyGlobalHeadersToScratchURLRequest(SELF_ARG, tnl_request
         self->_scratchURLRequest.allHTTPHeaderFields = nil;
 
         // 1) default headers
-        for (NSString *key in defaultHeaders) {
-            [self->_scratchURLRequest setValue:defaultHeaders[key] forHTTPHeaderField:key];
-        }
+        [defaultHeaders enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull key, NSString * _Nonnull obj, BOOL * _Nonnull stop) {
+            [self->_scratchURLRequest setValue:obj forHTTPHeaderField:key];
+        }];
 
         // 2) specified headers
-        for (NSString *key in existingHeaders) {
-            [self->_scratchURLRequest setValue:existingHeaders[key] forHTTPHeaderField:key];
-        }
+        [existingHeaders enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull key, NSString * _Nonnull obj, BOOL * _Nonnull stop) {
+            [self->_scratchURLRequest setValue:obj forHTTPHeaderField:key];
+        }];
 
         // 3) override headers
-        for (NSString *key in overrideHeaders) {
-            [self->_scratchURLRequest setValue:overrideHeaders[key] forHTTPHeaderField:key];
-        }
+        [overrideHeaders enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull key, NSString * _Nonnull obj, BOOL * _Nonnull stop) {
+            [self->_scratchURLRequest setValue:obj forHTTPHeaderField:key];
+        }];
     }
 
     nextBlock();
@@ -1855,7 +1855,7 @@ static void _network_fail(SELF_ARG,
     NSURLSessionTaskMetrics *taskMetrics;
     TNLURLSessionTaskOperation *URLSessionTaskOperation = self.URLSessionTaskOperation;
     if (URLSessionTaskOperation) {
-        metadata = [URLSessionTaskOperation network_metaData];
+        metadata = [URLSessionTaskOperation network_metaDataWithLowerCaseHeaderFields:info.allHTTPHeaderFieldsWithLowerCaseKeys];
         taskMetrics = [URLSessionTaskOperation network_taskMetrics];
     } else {
         metadata = (TNLAttemptMetaData * __nonnull)nil;
@@ -2161,7 +2161,7 @@ static void _network_completeStateTransition(SELF_ARG,
 #if NS_BLOCK_ASSERTIONS
         assert(attemptResponse != nil);
 #else
-        NSCAssert(attemptResponse != nil, @"assertion failed: cannot finish a %@ with a nil TNLResponse!", NSStringFromClass([self class]));
+        TNLCAssert(attemptResponse != nil, @"assertion failed: cannot finish a %@ with a nil TNLResponse!", NSStringFromClass([self class]));
 #endif
 
         [self.requestOperationQueue operation:self

--- a/Source/TNLURLSessionTaskOperation.h
+++ b/Source/TNLURLSessionTaskOperation.h
@@ -79,7 +79,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 // call these from tnl_network_queue()
 - (void)network_priorityDidChangeForRequestOperation:(TNLRequestOperation *)op;
-- (TNLAttemptMetaData *)network_metaData;
+- (TNLAttemptMetaData *)network_metaDataWithLowerCaseHeaderFields:(nullable NSDictionary *)lowerCaseHeaderFields;
 - (nullable NSURLSessionTaskMetrics *)network_taskMetrics;
 
 @end

--- a/Source/TNL_Project.h
+++ b/Source/TNL_Project.h
@@ -137,6 +137,9 @@ FOUNDATION_EXTERN Class __nullable TNLDynamicUIApplicationClass(void);
 
 #define TNLLogVerboseEnabled() ([gTNLLogger respondsToSelector:@selector(tnl_shouldLogVerbosely)] ? [gTNLLogger tnl_shouldLogVerbosely] : NO)
 
+#define TNL_LOG_WAITS_FOR_CONNECTIVITY_WARNING() \
+TNLLogWarning(@"Cannot modify -[TNLRequestConfiguration connectivityOptions] on iOS 13+ (and matching tvOS, macOS, watchOS versions).  Apple bug introduced with `NSURLSessionConfiguration.waitsForConnectivity` in iOS 13 betas, #FB7027774.");
+
 #pragma mark - Introspection
 
 #if DEBUG

--- a/Source/TNL_ProjectCommon.h
+++ b/Source/TNL_ProjectCommon.h
@@ -16,6 +16,26 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+
+#pragma mark - File Name macro
+
+/**
+ Helper macro for the file name macro.
+
+ `__FILE__` is the historical C macro that is replaced with the full file path of the current file being compiled (e.g. `/Users/username/workspace/project/source/subfolder/anotherfolder/implementation/file.c`)
+ `__FILE_NAME__` is the new C macro in clang that is replaced with the file name of the current file being compiled (e.g. `file.c`)
+
+ By default, if `__FILE_NAME__` is availble with the current compiler, it will be used.
+ This behavior can be overridden by providing a value for `TNL_FILE_NAME` to the compiler, like `-DTNL_FILE_NAME=__FILE__` or `-DTNL_FILE_NAME=\"redacted\"`
+ */
+#if !defined(TNL_FILE_NAME)
+#ifdef __FILE_NAME__
+#define TNL_FILE_NAME __FILE_NAME__
+#else
+#define TNL_FILE_NAME __FILE__
+#endif
+#endif
+
 #pragma mark - Binary
 
 FOUNDATION_EXTERN BOOL TNLIsExtension(void);
@@ -43,18 +63,41 @@ FOUNDATION_EXTERN BOOL TNLIsExtension(void);
 
 FOUNDATION_EXTERN BOOL gTwitterNetworkLayerAssertEnabled;
 
+#if !defined(NS_BLOCK_ASSERTIONS)
+
+#define TNLCAssert(condition, desc, ...) \
+do {                \
+    __PRAGMA_PUSH_NO_EXTRA_ARG_WARNINGS \
+    if (__builtin_expect(!(condition), 0)) {        \
+            NSString *__assert_fn__ = [NSString stringWithUTF8String:__PRETTY_FUNCTION__]; \
+            __assert_fn__ = __assert_fn__ ? __assert_fn__ : @"<Unknown Function>"; \
+            NSString *__assert_file__ = [NSString stringWithUTF8String:TNL_FILE_NAME]; \
+            __assert_file__ = __assert_file__ ? __assert_file__ : @"<Unknown File>"; \
+        [[NSAssertionHandler currentHandler] handleFailureInFunction:__assert_fn__ \
+        file:__assert_file__ \
+            lineNumber:__LINE__ description:(desc), ##__VA_ARGS__]; \
+    }                \
+    __PRAGMA_POP_NO_EXTRA_ARG_WARNINGS \
+} while(0)
+
+#else // NS_BLOCK_ASSERTIONS defined
+
+#define TNLCAssert(condition, desc, ...) do {} while (0)
+
+#endif // NS_BLOCK_ASSERTIONS not defined
+
 #define TNLAssert(expression) \
 ({ if (gTwitterNetworkLayerAssertEnabled) { \
     const BOOL __expressionValue = !!(expression); (void)__expressionValue; \
     __TNLAssert(__expressionValue); \
-    NSCAssert(__expressionValue, @"assertion failed: (" #expression ")"); \
+    TNLCAssert(__expressionValue, @"assertion failed: (" #expression ")"); \
 } })
 
 #define TNLAssertMessage(expression, format, ...) \
 ({ if (gTwitterNetworkLayerAssertEnabled) { \
     const BOOL __expressionValue = !!(expression); (void)__expressionValue; \
     __TNLAssert(__expressionValue); \
-    NSCAssert(__expressionValue, @"assertion failed: (" #expression ") message: %@", [NSString stringWithFormat:format, ##__VA_ARGS__]); \
+    TNLCAssert(__expressionValue, @"assertion failed: (" #expression ") message: %@", [NSString stringWithFormat:format, ##__VA_ARGS__]); \
 } })
 
 #define TNLAssertNever()      TNLAssert(0 && "this line should never get executed" )
@@ -64,7 +107,12 @@ FOUNDATION_EXTERN BOOL gTwitterNetworkLayerAssertEnabled;
 // NOTE: TNLStaticAssert's msg argument should be valid as a variable.  That is, composed of ASCII letters, numbers and underscore characters only.
 #define __TNLStaticAssert(line, msg) TNLStaticAssert_##line##_##msg
 #define _TNLStaticAssert(line, msg) __TNLStaticAssert( line , msg )
-#define TNLStaticAssert(condition, msg) typedef char _TNLStaticAssert( __LINE__ , msg ) [ (condition) ? 1 : -1 ]
+
+#define TNLStaticAssert(condition, msg) \
+_Pragma("clang diagnostic push") \
+_Pragma("clang diagnostic ignored \"-Wunused\"") \
+typedef char _TNLStaticAssert( __LINE__ , msg ) [ (condition) ? 1 : -1 ] \
+_Pragma("clang diagnostic pop" )
 
 #pragma twitter endignoreformatting
 
@@ -79,7 +127,7 @@ do { \
     id<TNLLogger> const __logger = gTNLLogger; \
     TNLLogLevel const __level = (level); \
     if (__logger && (![__logger respondsToSelector:@selector(tnl_canLogWithLevel:context:)] || [__logger tnl_canLogWithLevel:__level context:nil])) { \
-        [__logger tnl_logWithLevel:__level context:nil file:@(__FILE__) function:@(__FUNCTION__) line:__LINE__ message:[NSString stringWithFormat: __VA_ARGS__ ]]; \
+        [__logger tnl_logWithLevel:__level context:nil file:@(TNL_FILE_NAME) function:@(__FUNCTION__) line:__LINE__ message:[NSString stringWithFormat: __VA_ARGS__ ]]; \
     } \
 } while (0)
 

--- a/TNLExample/TNLXAppDelegate.m
+++ b/TNLExample/TNLXAppDelegate.m
@@ -121,7 +121,7 @@ NSString *TNLXCommunicationStatusUpdatedNotification = @"TNLXCommunicationStatus
 
 - (void)applicationDidBecomeActive:(UIApplication *)application
 {
-#if !TARGET_OS_UIKITFORMAC
+#if !TARGET_OS_MACCATALYST
     if (@available(iOS 13, *)) {
 
     } else {
@@ -179,7 +179,7 @@ NSString *TNLXCommunicationStatusUpdatedNotification = @"TNLXCommunicationStatus
 - (void)networkingDidChange:(NSNotification *)note
 {
     assert([NSThread isMainThread]);
-#if !TARGET_OS_UIKITFORMAC
+#if !TARGET_OS_MACCATALYST
     BOOL on = [note.userInfo[TNLNetworkExecutingNetworkConnectionsExecutingKey] boolValue];
     [UIApplication sharedApplication].networkActivityIndicatorVisible = on;
 #endif
@@ -232,7 +232,7 @@ NSString *TNLXCommunicationStatusUpdatedNotification = @"TNLXCommunicationStatus
 #pragma mark TNLCommunicationAgentObserver
 
 - (void)tnl_communicationAgent:(TNLCommunicationAgent *)agent
-        didRegisterObserverWithInitialReachabilityFlags:(SCNetworkReachabilityFlags)flags
+        didRegisterObserverWithInitialReachabilityFlags:(TNLNetworkReachabilityFlags)flags
         status:(TNLNetworkReachabilityStatus)status
         carrierInfo:(nullable id<TNLCarrierInfo>)info
         WWANRadioAccessTechnology:(nullable NSString *)radioTech
@@ -254,9 +254,9 @@ NSString *TNLXCommunicationStatusUpdatedNotification = @"TNLXCommunicationStatus
 }
 
 - (void)tnl_communicationAgent:(TNLCommunicationAgent *)agent
-        didUpdateReachabilityFromPreviousFlags:(SCNetworkReachabilityFlags)oldFlags
+        didUpdateReachabilityFromPreviousFlags:(TNLNetworkReachabilityFlags)oldFlags
         previousStatus:(TNLNetworkReachabilityStatus)oldStatus
-        toCurrentFlags:(SCNetworkReachabilityFlags)newFlags
+        toCurrentFlags:(TNLNetworkReachabilityFlags)newFlags
         currentStatus:(TNLNetworkReachabilityStatus)newStatus
 {
     _SCFlagsString = TNLDebugStringFromNetworkReachabilityFlags(newFlags);

--- a/TwitterNetworkLayer.xcodeproj/project.pbxproj
+++ b/TwitterNetworkLayer.xcodeproj/project.pbxproj
@@ -255,6 +255,7 @@
 		8BCA626419C356AE00F3F8CA /* TNLRequestOperationState.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BCA626319C356AE00F3F8CA /* TNLRequestOperationState.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8BCAF8C519F716370043EB22 /* TNLRequestOperationCancelSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BCAF8C319F716370043EB22 /* TNLRequestOperationCancelSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8BCAF8C619F716370043EB22 /* TNLRequestOperationCancelSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BCAF8C419F716370043EB22 /* TNLRequestOperationCancelSource.m */; };
+		8BCC9EF022AC36C400A5D1C8 /* Network.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BCC9EEF22AC36C400A5D1C8 /* Network.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		8BD083C91FD9C2020090B7C3 /* TNLTimeoutOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BD083C71FD9C2020090B7C3 /* TNLTimeoutOperation.h */; };
 		8BD083CA1FD9C2020090B7C3 /* TNLTimeoutOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD083C81FD9C2020090B7C3 /* TNLTimeoutOperation.m */; };
 		8BD083CB1FD9C20E0090B7C3 /* TNLTimeoutOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BD083C71FD9C2020090B7C3 /* TNLTimeoutOperation.h */; };
@@ -265,6 +266,8 @@
 		8BD500E71D8765F200D828C7 /* TNLURLStringCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD500E61D8765F200D828C7 /* TNLURLStringCoding.m */; };
 		8BD500F51D87762200D828C7 /* TNL_ProjectCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BD500F31D87762200D828C7 /* TNL_ProjectCommon.h */; };
 		8BD500F61D87762200D828C7 /* TNL_ProjectCommon.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD500F41D87762200D828C7 /* TNL_ProjectCommon.m */; };
+		8BD8715D22AD82360011DACA /* Network.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BCC9EEF22AC36C400A5D1C8 /* Network.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		8BD8715E22AD823A0011DACA /* Network.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BCC9EEF22AC36C400A5D1C8 /* Network.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		8BDA9D2D197881DE00678D90 /* TNLError.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BDA9D2B197881DE00678D90 /* TNLError.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8BDA9D2F197881DE00678D90 /* TNLError.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BDA9D2C197881DE00678D90 /* TNLError.m */; };
 		8BDA9D331978822300678D90 /* TNLPriority.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BDA9D311978822300678D90 /* TNLPriority.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -687,7 +690,6 @@
 		8B022A8119AAD2F800DB3052 /* NSDictionary+TNLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+TNLAdditions.h"; sourceTree = "<group>"; };
 		8B022A8219AAD2F800DB3052 /* NSDictionary+TNLAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+TNLAdditions.m"; sourceTree = "<group>"; };
 		8B07EE681987E7DD00F9EF8E /* TNL_Project.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TNL_Project.m; sourceTree = "<group>"; };
-		8B0A07721C73E736002F63B1 /* TwitterLoggingService.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = TwitterLoggingService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8B0AFAA61A018EBE00C8C81F /* TNLPseudoURLProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TNLPseudoURLProtocol.h; sourceTree = "<group>"; };
 		8B0AFAA71A018EBE00C8C81F /* TNLPseudoURLProtocol.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TNLPseudoURLProtocol.m; sourceTree = "<group>"; };
 		8B0AFAAD1A01C20000C8C81F /* TNLPseudoRequestOperationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TNLPseudoRequestOperationTest.m; sourceTree = "<group>"; };
@@ -808,6 +810,7 @@
 		8BCA626319C356AE00F3F8CA /* TNLRequestOperationState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TNLRequestOperationState.h; sourceTree = "<group>"; };
 		8BCAF8C319F716370043EB22 /* TNLRequestOperationCancelSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TNLRequestOperationCancelSource.h; sourceTree = "<group>"; };
 		8BCAF8C419F716370043EB22 /* TNLRequestOperationCancelSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TNLRequestOperationCancelSource.m; sourceTree = "<group>"; };
+		8BCC9EEF22AC36C400A5D1C8 /* Network.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Network.framework; path = System/Library/Frameworks/Network.framework; sourceTree = SDKROOT; };
 		8BD083C71FD9C2020090B7C3 /* TNLTimeoutOperation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TNLTimeoutOperation.h; sourceTree = "<group>"; };
 		8BD083C81FD9C2020090B7C3 /* TNLTimeoutOperation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TNLTimeoutOperation.m; sourceTree = "<group>"; };
 		8BD317BE19A8DD0100DF1836 /* TNLXPlaygroundViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TNLXPlaygroundViewController.h; sourceTree = "<group>"; };
@@ -929,6 +932,7 @@
 				8BB26ABB1D8B142E00D1AB5A /* CFNetwork.framework in Frameworks */,
 				8B4AA7621E1F297C00BF7EA0 /* CoreTelephony.framework in Frameworks */,
 				8BE402CA1946743D00C7241E /* Foundation.framework in Frameworks */,
+				8BCC9EF022AC36C400A5D1C8 /* Network.framework in Frameworks */,
 				8B427D551FB53DBF00C9E5CE /* Security.framework in Frameworks */,
 				8BE3DB9D1CDB00B00081ACCE /* SystemConfiguration.framework in Frameworks */,
 				8BB26ABC1D8B143900D1AB5A /* UIKit.framework in Frameworks */,
@@ -962,6 +966,7 @@
 				8BFDF9402135AB2C002F6A80 /* Security.framework in Frameworks */,
 				8BFDF9412135AB2C002F6A80 /* SystemConfiguration.framework in Frameworks */,
 				8BFDF9422135AB2C002F6A80 /* UIKit.framework in Frameworks */,
+				8BD8715E22AD823A0011DACA /* Network.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -989,6 +994,7 @@
 				BF4AA0EF1EE61D46001647B5 /* libz.tbd in Frameworks */,
 				BF4AA0F01EE61D46001647B5 /* CFNetwork.framework in Frameworks */,
 				BF4AA0F21EE61D46001647B5 /* Foundation.framework in Frameworks */,
+				8BD8715D22AD82360011DACA /* Network.framework in Frameworks */,
 				8BFDF8FD2135A1FC002F6A80 /* Security.framework in Frameworks */,
 				BF4AA0F31EE61D46001647B5 /* SystemConfiguration.framework in Frameworks */,
 			);
@@ -1142,6 +1148,7 @@
 		8BE402C81946743D00C7241E /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				8BCC9EEF22AC36C400A5D1C8 /* Network.framework */,
 				8BFDF8FC2135A1FC002F6A80 /* Security.framework */,
 				8B022A7B19AA52F800DB3052 /* Accounts.framework */,
 				8B6DCB4B1974598300235576 /* CFNetwork.framework */,
@@ -1156,7 +1163,6 @@
 				8B427D541FB53DBF00C9E5CE /* Security.framework */,
 				8B022A7F19AA530000DB3052 /* Social.framework */,
 				8B4DEFF81986AA64008A31EB /* SystemConfiguration.framework */,
-				8B0A07721C73E736002F63B1 /* TwitterLoggingService.framework */,
 				8B6DCB491974583B00235576 /* UIKit.framework */,
 				8BE402D71946743E00C7241E /* XCTest.framework */,
 			);
@@ -1766,7 +1772,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = TNL;
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1030;
 				ORGANIZATIONNAME = Twitter;
 				TargetAttributes = {
 					8B9EBDB52135B4B100E6E466 = {
@@ -2249,6 +2255,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_MODULES_AUTOLINK = NO;
+				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twitter.TwitterNetworkLayer;
@@ -2262,6 +2269,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_MODULES_AUTOLINK = NO;
+				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twitter.TwitterNetworkLayer;
@@ -2517,6 +2525,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_MODULES_AUTOLINK = NO;
+				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twitter.TwitterNetworkLayer;
@@ -2530,6 +2539,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_MODULES_AUTOLINK = NO;
+				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twitter.TwitterNetworkLayer;

--- a/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TNLExample.xcscheme
+++ b/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TNLExample.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer macOS.xcscheme
+++ b/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer tvOS.xcscheme
+++ b/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer watchOS.xcscheme
+++ b/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer.xcscheme
+++ b/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TwitterNetworkLayerTests/TNLRequestConfigurationTest.m
+++ b/TwitterNetworkLayerTests/TNLRequestConfigurationTest.m
@@ -38,6 +38,10 @@
 
 - (void)testConfigRoundTrips
 {
+    BOOL connectivityOptionsForciblyDisabled = NO;
+    if (tnl_available_ios_11) {
+        connectivityOptionsForciblyDisabled = ![NSURLSessionConfiguration tnl_URLSessionCanUseWaitsForConnectivity];
+    }
     TNLMutableRequestConfiguration *config = [TNLMutableRequestConfiguration defaultConfiguration];
     TNLMutableParameterCollection *params;
     TNLParameterCollection *roundTripParams;
@@ -52,9 +56,9 @@
     roundTripConfig = (id)[TNLRequestConfiguration configurationFromParameters:params executionMode:config.executionMode version:[TNLGlobalConfiguration version]];
 
 #if TARGET_OS_IPHONE // == IOS + WATCH + TV
-    testParamString = @"aca=1&atmpTO=60&ckiplcy=1&cnvty=0&dfrI=0&dis=0&double=3.14159265359&idlTO=30&nst=0&opTO=180&ptcls=0&rcp=0&rdcm=1&rdp=1&setcki=0&ssle=1";
+    testParamString = @"aca=1&atmpTO=60&ckiplcy=1&cnvty=0&dfrI=0&dis=0&double=3.14159265359&idlTO=30&nst=0&opTO=180&ptcls=0&rcp=0&rdcm=1&rdp=1&setcki=0&ssle=1&xbim=0";
 #else
-    testParamString = @"aca=1&atmpTO=60&ckiplcy=1&cnvty=0&dfrI=0&dis=0&double=3.14159265359&idlTO=30&nst=0&opTO=180&ptcls=0&rcp=0&rdcm=1&rdp=1&setcki=0&ssle=0";
+    testParamString = @"aca=1&atmpTO=60&ckiplcy=1&cnvty=0&dfrI=0&dis=0&double=3.14159265359&idlTO=30&nst=0&opTO=180&ptcls=0&rcp=0&rdcm=1&rdp=1&setcki=0&ssle=0&xbim=0";
 #endif
 
     XCTAssertEqualObjects(paramString, testParamString);
@@ -65,7 +69,7 @@
 #if TARGET_OS_IOS
     if (tnl_available_ios_11) {
         config.multipathServiceType = NSURLSessionMultipathServiceTypeInteractive;
-        testParamString = @"aca=1&atmpTO=60&ckiplcy=1&cnvty=0&dfrI=0&dis=0&idlTO=30&mptcp=2&nst=0&opTO=180&ptcls=0&rcp=0&rdcm=1&rdp=1&setcki=0&ssle=1";
+        testParamString = @"aca=1&atmpTO=60&ckiplcy=1&cnvty=0&dfrI=0&dis=0&idlTO=30&mptcp=2&nst=0&opTO=180&ptcls=0&rcp=0&rdcm=1&rdp=1&setcki=0&ssle=1&xbim=0";
         params = TNLMutableParametersFromRequestConfiguration(config, nil, nil, nil);
         paramString = params.stableURLEncodedStringValue;
         roundTripParams = [[TNLParameterCollection alloc] initWithURLEncodedString:paramString options:0];
@@ -97,6 +101,7 @@
     config.shouldLaunchAppForBackgroundEvents = NO;
     config.shouldSetCookies = NO;
     config.cookieAcceptPolicy = NSHTTPCookieAcceptPolicyNever;
+    config.shouldUseExtendedBackgroundIdleMode = YES;
 
     XCTAssertNotNil(config.sharedContainerIdentifier);
     XCTAssertEqualObjects(config, [config copy]);
@@ -108,7 +113,7 @@
     XCTAssertNotEqual(roundTripConfig.contributeToExecutingNetworkConnectionsCount, config.contributeToExecutingNetworkConnectionsCount);
     roundTripConfig.contributeToExecutingNetworkConnectionsCount = config.contributeToExecutingNetworkConnectionsCount;
 
-    testParamString = [NSString stringWithFormat:@"aca=0&atmpTO=360.1&ckiplcy=1&cnvty=5&dfrI=30.1&dis=1&idlTO=180.1&nst=3&opTO=720.1&ptcls=2&rcp=1&rdcm=2&rdp=0&%@setcki=0&ssle=0", config.sharedContainerIdentifier ? @"scid=container.id&" : @""];
+    testParamString = [NSString stringWithFormat:@"aca=0&atmpTO=360.1&ckiplcy=1&cnvty=%@&dfrI=30.1&dis=1&idlTO=180.1&nst=3&opTO=720.1&ptcls=2&rcp=1&rdcm=2&rdp=0&%@setcki=0&ssle=0&xbim=1", (connectivityOptionsForciblyDisabled) ? @0 : @5, config.sharedContainerIdentifier ? @"scid=container.id&" : @""];
     XCTAssertEqualObjects(paramString, testParamString);
     [self runTestParamsEqualBetweenOriginal:params roundTrip:roundTripParams];
     XCTAssertEqualObjects(roundTripConfig, config);
@@ -129,7 +134,7 @@
     roundTripConfig.URLCredentialStorage = config.URLCredentialStorage;
     roundTripConfig.URLCache = config.URLCache;
     roundTripConfig.cookieStorage = config.cookieStorage;
-    testParamString = [NSString stringWithFormat:@"aca=0&atmpTO=360.1&ckiplcy=1&ckisto=NSHTTPCookieStorage_%p&cnvty=5&crdsto=NSURLCredentialStorage_%p&dfrI=30.1&dis=1&idlTO=180.1&nst=3&opTO=720.1&ptcls=2&rcp=1&rdcm=2&rdp=0&%@setcki=0&ssle=0&urlcch=NSURLCache_%p", config.cookieStorage, config.URLCredentialStorage, config.sharedContainerIdentifier ? @"scid=container.id&" : @"", config.URLCache];
+    testParamString = [NSString stringWithFormat:@"aca=0&atmpTO=360.1&ckiplcy=1&ckisto=NSHTTPCookieStorage_%p&cnvty=%@&crdsto=NSURLCredentialStorage_%p&dfrI=30.1&dis=1&idlTO=180.1&nst=3&opTO=720.1&ptcls=2&rcp=1&rdcm=2&rdp=0&%@setcki=0&ssle=0&urlcch=NSURLCache_%p&xbim=1", config.cookieStorage, (connectivityOptionsForciblyDisabled) ? @0 : @5, config.URLCredentialStorage, config.sharedContainerIdentifier ? @"scid=container.id&" : @"", config.URLCache];
     XCTAssertEqualObjects(paramString, testParamString);
     [self runTestParamsEqualBetweenOriginal:params roundTrip:roundTripParams];
     XCTAssertEqualObjects(roundTripConfig, config);
@@ -150,9 +155,9 @@
     roundTripConfig.URLCredentialStorage = config.URLCredentialStorage;
     roundTripConfig.URLCache = config.URLCache;
     roundTripConfig.cookieStorage = config.cookieStorage;
-    testParamString = [NSString stringWithFormat:@"aca=0&atmpTO=360.1&ckiplcy=1&ckisto=NSHTTPCookieStorage_%p&cnvty=5&crdsto=NSURLCredentialStorage_%p&dfrI=30.1&dis=1&idlTO=180.1&nst=3&opTO=720.1&ptcls=2&rcp=1&rdcm=2&rdp=0&%@setcki=0&ssle=0&urlcch=NSURLCache_%p", config.cookieStorage, config.URLCredentialStorage, config.sharedContainerIdentifier ? @"scid=container.id&" : @"", config.URLCache];
+    testParamString = [NSString stringWithFormat:@"aca=0&atmpTO=360.1&ckiplcy=1&ckisto=NSHTTPCookieStorage_%p&cnvty=%@&crdsto=NSURLCredentialStorage_%p&dfrI=30.1&dis=1&idlTO=180.1&nst=3&opTO=720.1&ptcls=2&rcp=1&rdcm=2&rdp=0&%@setcki=0&ssle=0&urlcch=NSURLCache_%p&xbim=1", config.cookieStorage, (connectivityOptionsForciblyDisabled) ? @0 : @5, config.URLCredentialStorage, config.sharedContainerIdentifier ? @"scid=container.id&" : @"", config.URLCache];
     XCTAssertNotEqualObjects(paramString, testParamString);
-    testParamString = [NSString stringWithFormat:@"aca=0&atmpTO=360.1&ckiplcy=1&ckisto=NSHTTPCookieStorage_%p&cnvty=5&crdsto=NSURLCredentialStorage_%p&dfrI=30.1&dis=1&idlTO=180.1&nst=3&opTO=720.1&ptcls=2&rcp=1&rdcm=2&rdp=0&%@setcki=0&ssle=0&urlcch=NSURLCache_%p", TNLUnwrappedCookieStorage(config.cookieStorage), TNLUnwrappedURLCredentialStorage(config.URLCredentialStorage), config.sharedContainerIdentifier ? @"scid=container.id&" : @"", TNLUnwrappedURLCache(config.URLCache)];
+    testParamString = [NSString stringWithFormat:@"aca=0&atmpTO=360.1&ckiplcy=1&ckisto=NSHTTPCookieStorage_%p&cnvty=%@&crdsto=NSURLCredentialStorage_%p&dfrI=30.1&dis=1&idlTO=180.1&nst=3&opTO=720.1&ptcls=2&rcp=1&rdcm=2&rdp=0&%@setcki=0&ssle=0&urlcch=NSURLCache_%p&xbim=1", TNLUnwrappedCookieStorage(config.cookieStorage), (connectivityOptionsForciblyDisabled) ? @0 : @5, TNLUnwrappedURLCredentialStorage(config.URLCredentialStorage), config.sharedContainerIdentifier ? @"scid=container.id&" : @"", TNLUnwrappedURLCache(config.URLCache)];
     XCTAssertEqualObjects(paramString, testParamString);
     [self runTestParamsEqualBetweenOriginal:params roundTrip:roundTripParams];
     XCTAssertEqualObjects(roundTripConfig, config);


### PR DESCRIPTION
- Move to Network.framework for reachability
- Expose shouldUseExtendedBackgroundIdleMode
- Improve perf with NSData subranges
- Improve perf with copying lowercase string headers
- Fix up things for MACCATALYST support

Also:
- Disable connectivityOptions support on iOS 13+
  - a.k.a. waitForConnectivity on NSURLSessionConfiguration
- This regressed on iOS 13 betas and breaks the feature
- This patch is provided as a preview update of TNL for
working around this iOS 13 bug.
  - If this bug is fixed before the GM of iOS 13, we will do a
different update without disabling this feature.
  - If this bug is not fixed before the GM of iOS 13, we will
merge this update to TNL, disabling the feature for iOS 13.
  - If this bug is not fixed before iOS 13.1, we will deprecate
support for waitForConnectivity altogether