### PR TITLE
v2.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,41 @@
 
 ## Info
 
-**Document version:** 2.7.0
+**Document version:** 2.8.2
 
-**Last updated:** 06/05/2019
+**Last updated:** 08/30/2019
 
 **Author:** Nolan O'Brien
 
 ## History
+
+### 2.8.2
+
+- Add _expensive_ and _constrained_ conditions to the reachability flags on iOS 13+
+  - `TNLNetworkReachabilityMaskPathConditionExpensive` for when path is expensive
+  - `TNLNetworkReachabilityMaskPathConditionConstrained` for when path is constrained
+
+### 2.8.1
+
+- Disable `connectivityOptions` on `TNLRequestConfiguration` for iOS 13.0 (ok on iOS 13.1+)
+  - `connectivityOptions` are backed by `NSURLSessionConfiguration` `waitsForConnectivity`
+  - `waitsForConnectivity` regressed in iOS 13 betas and is unuseable as a feature on iOS 13.0.
+  - iOS 13.1 beta 1 addressed this issue.
+
+### 2.8.0
+
+- Expose `shouldUseExtendedBackgroundIdleMode` in `TNLRequestConfiguration`
+  - There's a lot of nuance to this configuration property, so take care when using it 
+
+### 2.7.5
+
+- Change it so that iOS 12 and above use __Network.framework__ for reachability instead of __SystemConfiguration.framework__
+  - Reachability in __SystemConfiguration.framework__ has been broken in simulator since iOS 11
+  - Reachability in __SystemConfiguration.framework__ will no longer work at all starting in iOS 13
+  - Reachability using `nw_path_monitor_t` is the new canonical way to observe reachability changes, so we'll use that
+- Change network reachability flags in `TNLCommunicationAgent` from `SCNetworkReachabilityFlags` to `TNLNetworkReachabilityFlags`
+  - On iOS 11 and below, the flags are exactly the same as `SCNetworkReachabilityFlags`
+  - On iOS 12 and above, the flags now map to the new `TNLNetworkReachabilityMask` flags
 
 ### 2.7.0
  

--- a/Source/NSData+TNLAdditions.h
+++ b/Source/NSData+TNLAdditions.h
@@ -16,7 +16,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface NSData (TNLAdditions)
-- (NSData *)tnl_safeSubdataNoCopyWithRange:(NSRange)range;
+- (NSData *)tnl_safeSubdataNoCopyWithRange:(NSRange)subRange; // throws `NSRangeException`
+- (nullable NSData *)tnl_safeSubdataNoCopyWithRange:(NSRange)range error:(out NSError * __nullable * __nullable)outError;
 - (NSString *)tnl_hexStringValue;
 @end
 

--- a/Source/NSData+TNLAdditions.m
+++ b/Source/NSData+TNLAdditions.m
@@ -13,18 +13,106 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation NSData (TNLAdditions)
 
-- (NSData *)tnl_safeSubdataNoCopyWithRange:(NSRange)range
+- (NSData *)tnl_safeSubdataNoCopyWithRange:(NSRange)subRange
 {
-    if (range.location == 0 && range.length == self.length) {
+    if (subRange.location == 0 && subRange.length == self.length) {
+        // exact match, return early
         return self;
     }
 
-    // TODO: optimize so that self.bytes doesn't have to be called,
-    // since it triggers a copy of all bytes when the NSData has non-continuous data
+    if (subRange.location + subRange.length > self.length) {
+        // out of range, throw exception just like [NSData subdataWithRange:]
+        NSString *subrangeString = NSStringFromRange(subRange);
+        NSString *rangeString = NSStringFromRange(NSMakeRange(0, self.length));
+        @throw [NSException exceptionWithName:NSRangeException
+                                       reason:[NSString stringWithFormat:@"subdata %@ is out of range %@!", subrangeString, rangeString]
+                                     userInfo:nil];
+    }
 
-    const void *bytePtr = self.bytes + range.location;
-    NSData *data = [NSData dataWithBytesNoCopy:(void *)bytePtr length:range.length freeWhenDone:NO];
-    objc_setAssociatedObject(data, _cmd, self, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    if (subRange.length == 0) {
+        // zero length is still valid
+        return [NSData data];
+    }
+
+#if __LP64__
+    __block dispatch_data_t dispatchData = dispatch_data_create("", 0, NULL, NULL);
+#else
+    NSMutableData *mutableData = [[NSMutableData alloc] init];
+#endif
+
+    [self enumerateByteRangesUsingBlock:^(const void * _Nonnull bytes, NSRange byteRange, BOOL * _Nonnull stop) {
+
+        if (byteRange.location >= (subRange.location + subRange.length)) {
+            // past the end
+            *stop = YES;
+            return;
+        }
+
+        if ((byteRange.location + byteRange.length) <= subRange.location) {
+            // before the beginning
+            return;
+        }
+
+        NSRange cutRange = byteRange;
+        NSInteger delta;
+
+        delta = (NSInteger)subRange.location - (NSInteger)cutRange.location;
+        if (delta > 0) {
+            // byteRange provided offers excess bytes at the beginning, disregard those
+            cutRange.length -= (NSUInteger)delta;
+            cutRange.location = subRange.location;
+        }
+
+        delta = (NSInteger)(cutRange.location + cutRange.length) - (NSInteger)(subRange.location + subRange.length);
+        if (delta > 0) {
+            // byteRange provided offers excess bytes at the end, disregard those
+            cutRange.length -= (NSUInteger)delta;
+        }
+
+        // find byte pointer, which is bytes plus our calculated offset for start of bytes
+        const void *bytePtr = bytes + (cutRange.location - byteRange.location);
+
+        // append the data as-is (no copy, no free when done)
+#if __LP64__
+        dispatch_data_t cutData = dispatch_data_create(bytePtr, cutRange.length, NULL, ^{ /*noop*/ });
+        dispatchData = dispatch_data_create_concat(dispatchData, cutData);
+#else // 32 bit
+        NSData *rData = [NSData dataWithBytesNoCopy:(void*)bytePtr length:cutRange.length freeWhenDone:NO];
+        [mutableData appendData:rData];
+#endif
+
+    }];
+
+    NSData *retData = nil;
+#if __LP64__
+    retData = (NSData *)dispatchData; // nice!
+#else // 32 bit
+    retData = (NSData *)mutableData;
+#endif
+
+    // preserve the source data for the lifetime of the subdata
+    objc_setAssociatedObject(retData, _cmd, self, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    return retData;
+}
+
+- (nullable NSData *)tnl_safeSubdataNoCopyWithRange:(NSRange)subRange error:(out NSError * __nullable * __nullable)outError
+{
+    NSData *data = nil;
+    @try {
+
+        data = [self tnl_safeSubdataNoCopyWithRange:subRange];
+
+    } @catch (NSException *e) {
+
+        // convert the exception to an error (then return nil)
+        if (outError) {
+            *outError = [NSError errorWithDomain:NSPOSIXErrorDomain
+                                            code:[e.name isEqualToString:NSRangeException] ? ERANGE : EBADMSG
+                                        userInfo:@{ @"exception" : e }];
+        }
+
+    }
+
     return data;
 }
 

--- a/Source/NSDictionary+TNLAdditions.m
+++ b/Source/NSDictionary+TNLAdditions.m
@@ -64,11 +64,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id)tnl_copyToMutable:(BOOL)mutable uppercase:(BOOL)uppercase
 {
-    NSMutableDictionary *d = [[NSMutableDictionary alloc] init];
+    NSMutableDictionary *replacementDict = nil;
+
     for (NSString *key in self) {
-        d[(uppercase) ? key.uppercaseString : key.lowercaseString] = self[key];
+        NSString *updatedKey = uppercase ? [key uppercaseString] : [key lowercaseString];
+        if (![key isEqualToString:updatedKey]) {
+            if (!replacementDict) {
+                replacementDict = [self mutableCopy];
+            }
+
+            [replacementDict removeObjectForKey:key];
+            replacementDict[updatedKey] = self[key];
+        }
     }
-    return (mutable) ? d : [d copy];
+
+    return replacementDict ?: (mutable ? [self mutableCopy] : [self copy]);
 }
 
 @end

--- a/Source/NSURLCache+TNLAdditions.m
+++ b/Source/NSURLCache+TNLAdditions.m
@@ -178,7 +178,7 @@ NSURLCache *TNLGetURLCacheDemuxProxy()
     return [self init];
 }
 
-#if !TARGET_OS_UIKITFORMAC
+#if !TARGET_OS_MACCATALYST
 - (id)initWithMemoryCapacity:(NSUInteger)memoryCapacity diskCapacity:(NSUInteger)diskCapacity diskPath:(nullable NSString *)path
 {
     return [self init];

--- a/Source/NSURLSessionConfiguration+TNLAdditions.h
+++ b/Source/NSURLSessionConfiguration+TNLAdditions.h
@@ -46,6 +46,20 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)tnl_URLSessionSupportsDecodingBrotliContentEncoding;
 
 /**
+ Introduced in iOS 11, `waitsForConnectivity` offers a great deal of control over network requests and
+ can help avoid needlessly failing a request that can wait until there is a network connection to execute.
+ With iOS 13.0 betas (and matching tvOS, macOS and watchOS versions), regressed `waitsForConnectivity`.
+ `NSURLSession` layer no longer calls `NSURLSessionTaskDelegate` `URLSession:taskIsWaitingForConnectivity:`
+ rendering the feature impotent and dangerous (easily leading to never finishing network requests which
+ can lead to interminable hangs based on the dependencies established on the `TNLRequestOperation`).
+ #FB7027774
+ For versions of iOS (and other matching OSes) that did not support `waitsForConnectivity` (below iOS 11), this will return `NO`.
+ For versions of iOS (and other matching OSes) that have the regression from iOS 13 (just iOS 13.0), this will return `NO`.
+ Otherwise, this will return `YES` and `waitsForConnectivity` features can be used.
+ */
++ (BOOL)tnl_URLSessionCanUseWaitsForConnectivity;
+
+/**
  Convenience method for appropriately mutating the session configuration's `protocolClasses`
  */
 - (void)tnl_insertProtocolClasses:(nullable NSArray<Class> *)additionalClasses;

--- a/Source/NSURLSessionConfiguration+TNLAdditions.m
+++ b/Source/NSURLSessionConfiguration+TNLAdditions.m
@@ -13,51 +13,45 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@implementation NSURLSessionConfiguration (TNLAdditions)
+static struct {
+    BOOL URLSessionCanReceiveResponseViaDelegate:1;
+    BOOL URLSessionCanUseTaskTransactionMetrics:1;
+    BOOL URLSessionSupportsDecodingBrotliContentEncoding:1;
+    BOOL URLSessionCanUseWaitsForConnectivity:1;
+} sFlags;
 
-+ (BOOL)tnl_URLSessionCanReceiveResponseViaDelegate
+static void _EnsureFlags(void);
+static void _EnsureFlags()
 {
-    static BOOL sBugExists;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
+
+        memset(&sFlags, 0, sizeof(sFlags)); // clear the flags before we set them
+
+        /// URLSessionCanReceiveResponseViaDelegate
 
         if (tnl_available_ios_9) {
             // ok
+            sFlags.URLSessionCanReceiveResponseViaDelegate = YES;
         } else {
-            // iOS 8 only has this bug
-            sBugExists = YES;
+            // iOS 8 only has this bug (TNL does not support iOS 7 or below)
         }
 
-    });
-
-    return !sBugExists;
-}
-
-+ (BOOL)tnl_URLSessionCanUseTaskTransactionMetrics
-{
-    static BOOL sTaskMetricsAvailable = NO;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
+        /// URLSessionCanUseTaskTransactionMetrics
 
         if (tnl_available_ios_10) {
             // task metrics added as an API in iOS 10
 
             if (tnl_available_ios_11) {
-                // Crashers of iOS 10 continue into iOS 11 betas
-                // Cannot differentiate iOS 11.0.0 and iOS 11 betas
-                // So...
-                //   On iOS 11.0.1, consider fixed
-                //   On iOS 11.0.0, consider bug present
-                //   On non-iOS targets, just presume non-beta and consider fixed
-#if TARGET_OS_IOS
-                if (@available(iOS 11.0.1, *)) {
-                    // definitely fixed on iOS 11.0.1
-                    sTaskMetricsAvailable = YES;
-                }
-#else
-                // non-iOS, consider fixed
-                sTaskMetricsAvailable = YES;
-#endif
+
+                // The crashers of iOS 10 continue into iOS 11 betas.
+                // The crash was fixed in iOS 11.0.0 GM.
+                // Since we cannot differentiate GM vs earlier beta, there can be crashing...
+                // ...but those betas are old enough now to not need special consideration.
+
+                // Consider fixed on iOS 11+
+                sFlags.URLSessionCanUseTaskTransactionMetrics = YES;
+
             } else {
                 // task metrics exist but have crashes on iOS 10.X
                 // iOS 10.0.X and iOS 10.1.X have a crashing bug that crashes 1 million times a day
@@ -65,16 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
             }
         }
 
-    });
-
-    return sTaskMetricsAvailable;
-}
-
-+ (BOOL)tnl_URLSessionSupportsDecodingBrotliContentEncoding
-{
-    static BOOL sBrotliSupported = NO;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
+        /// URLSessionSupportsDecodingBrotliContentEncoding
 
         // Brotli support requires 2 things:
         // - Running OS version of iOS 11 (or equivalent platform version) or greater
@@ -83,13 +68,58 @@ NS_ASSUME_NONNULL_BEGIN
 
 #if TARGET_SDK_SUPPORTS_BROTLI
         if (tnl_available_ios_11) {
-            sBrotliSupported = YES;
+            sFlags.URLSessionSupportsDecodingBrotliContentEncoding = YES;
         }
 #endif
 
-    });
+        /// URLSessionCanUseWaitsForConnectivity
 
-    return sBrotliSupported;
+        if (tnl_available_ios_11) {
+
+            // added iOS 11
+            sFlags.URLSessionCanUseWaitsForConnectivity = YES;
+
+            if (tnl_available_ios_13) {
+
+                // regressed iOS 13.0
+                sFlags.URLSessionCanUseWaitsForConnectivity = NO;
+
+                if (@available(iOS 13.1, tvOS 13.1, macOS 10.15.0, watchOS 6.1, *)) {
+
+                    // fixed iOS 13.1 beta 1
+                    // fixed macOS 10.15.0 beta 7
+                    sFlags.URLSessionCanUseWaitsForConnectivity = YES;
+
+                }
+            }
+        }
+    });
+}
+
+@implementation NSURLSessionConfiguration (TNLAdditions)
+
++ (BOOL)tnl_URLSessionCanReceiveResponseViaDelegate
+{
+    _EnsureFlags();
+    return sFlags.URLSessionCanReceiveResponseViaDelegate;
+}
+
++ (BOOL)tnl_URLSessionCanUseTaskTransactionMetrics
+{
+    _EnsureFlags();
+    return sFlags.URLSessionCanUseTaskTransactionMetrics;
+}
+
++ (BOOL)tnl_URLSessionSupportsDecodingBrotliContentEncoding
+{
+    _EnsureFlags();
+    return sFlags.URLSessionSupportsDecodingBrotliContentEncoding;
+}
+
++ (BOOL)tnl_URLSessionCanUseWaitsForConnectivity
+{
+    _EnsureFlags();
+    return sFlags.URLSessionCanUseWaitsForConnectivity;
 }
 
 - (void)tnl_insertProtocolClasses:(nullable NSArray<Class> *)additionalClasses

--- a/Source/NSURLSessionTaskMetrics+TNLAdditions.h
+++ b/Source/NSURLSessionTaskMetrics+TNLAdditions.h
@@ -38,6 +38,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSDictionary<NSString *, id> *)tnl_dictionaryValue;
 
 /**
+ returns the `resourceFetchType` as a readable debug string
+ */
+- (NSString *)tnl_resourceFetchTypeDebugString;
+
+/**
  returns the earliest date of all the timing dates
  */
 - (nullable NSDate *)tnl_earliestDate;
@@ -58,6 +63,12 @@ NS_ASSUME_NONNULL_BEGIN
  returns a string describing the timings
  */
 - (NSString *)tnl_timingDescription;
+
+/**
+ returns a dictionary of meta data info.
+ Does not provide timing info, request model data or response model data.
+ */
+- (NSDictionary<NSString *, id> *)tnl_medadata;
 
 /** convenience method for TCP start if connect includes TCP connect */
 @property (nonatomic, readonly, nullable) NSDate *tnl_transportConnectionStartDate;

--- a/Source/TNLAttemptMetaData.h
+++ b/Source/TNLAttemptMetaData.h
@@ -73,6 +73,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSTimeInterval taskWithoutMetricsCompletionLatency;
 - (BOOL)hasTaskWithoutMetricsCompletionLatency;
 
+/**
+ The headers from the URL response, converted to all lowercase
+ */
+@property (nonatomic, copy, readonly, nullable) NSDictionary *responseLowercaseHeaders;
+- (BOOL)hasResponseLowercaseHeaders;
 
 /**
  The number of bytes received in the response body at OSI layer 8.

--- a/Source/TNLAttemptMetaData_Project.h
+++ b/Source/TNLAttemptMetaData_Project.h
@@ -43,6 +43,7 @@ PRIMITIVE_FIELD(layer8BodyBytesTransmitted, Layer8BodyBytesTransmitted, SInt64, 
 PRIMITIVE_FIELD(serverResponseTime, ServerResponseTime, SInt64, longLongValue) \
 PRIMITIVE_FIELD(localCacheHit, LocalCacheHit, BOOL, boolValue) \
 PRIMITIVE_FIELD(responseBodyHashAlgorithm, ResponseBodyHashAlgorithm, TNLResponseHashComputeAlgorithm, integerValue) \
+OBJECT_FIELD(responseLowercaseHeaders, ResponseLowercaseHeaders, NSDictionary) \
 OBJECT_FIELD(responseBodyHash, ResponseBodyHash, NSData) \
 OBJECT_FIELD(sessionId, SessionId, NSString) \
 \

--- a/Source/TNLAttemptMetrics.h
+++ b/Source/TNLAttemptMetrics.h
@@ -78,7 +78,7 @@ static const NSInteger TNLAttemptCompleteDispositionCount = 3;
 /** attempt reachability status */
 @property (nonatomic, readonly) TNLNetworkReachabilityStatus reachabilityStatus;
 /** attempt reachability flags */
-@property (nonatomic, readonly) SCNetworkReachabilityFlags reachabilityFlags;
+@property (nonatomic, readonly) TNLNetworkReachabilityFlags reachabilityFlags;
 /** attempt radio access technology */
 @property (nonatomic, copy, readonly, nullable) NSString *WWANRadioAccessTechnology;
 /** attempt carrier info. Note: `nil` for macOS since there is no cellular carrier information */

--- a/Source/TNLAttemptMetrics.m
+++ b/Source/TNLAttemptMetrics.m
@@ -132,7 +132,7 @@ TNLStaticAssert(TNLAttemptCompleteDispositionCount == TNLAttemptTypeCount, ATTEM
 
 #endif
 
-#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
         _carrierInfo = TNLCarrierInfoFromDictionary([aDecoder decodeObjectOfClass:[NSDictionary class]
                                                                            forKey:@"carrierInfo"]);
 #endif
@@ -167,7 +167,7 @@ TNLStaticAssert(TNLAttemptCompleteDispositionCount == TNLAttemptTypeCount, ATTEM
     [aCoder encodeObject:_WWANRadioAccessTechnology forKey:@"WWANRadioAccessTechnology"];
 #endif
 
-#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
     [aCoder encodeObject:TNLCarrierInfoToDictionary(_carrierInfo) forKey:@"carrierInfo"];
 #endif
 }

--- a/Source/TNLCommunicationAgent.h
+++ b/Source/TNLCommunicationAgent.h
@@ -10,12 +10,41 @@
 
 #if !TARGET_OS_WATCH // no communication agent for watchOS
 
-#import <SystemConfiguration/SystemConfiguration.h>
+/**
+ `TNLNetworkReachabilityFlags` are the same as `SCNetworkReachability` on iOS 11 and below.
+ On iOS 12+, they are a different set of flags matching `TNLNetworkReachabilityMask` options.
+ */
+typedef uint32_t TNLNetworkReachabilityFlags;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol TNLCarrierInfo;
 @protocol TNLCommunicationAgentObserver;
+
+/**
+ Mask that is in place for `TNLNetworkReachabilityFlags` on iOS 12+
+ */
+typedef NS_OPTIONS(uint32_t, TNLNetworkReachabilityMask)
+{
+    TNLNetworkReachabilityMaskNone = 0,
+
+    TNLNetworkReachabilityMaskPathStatusSatisfied = 1 << 0,
+    TNLNetworkReachabilityMaskPathStatusUnsatisfied = 1 << 1,
+    TNLNetworkReachabilityMaskPathStatusSatisfiable = 1 << 2,
+    // 0 path status == invalid
+
+    TNLNetworkReachabilityMaskPathIntefaceTypeOther = (1 << 8) << 0,
+    TNLNetworkReachabilityMaskPathIntefaceTypeWifi = (1 << 8) << 1,
+    TNLNetworkReachabilityMaskPathIntefaceTypeCellular = (1 << 8) << 2,
+    TNLNetworkReachabilityMaskPathIntefaceTypeWired = (1 << 8) << 3,
+    TNLNetworkReachabilityMaskPathIntefaceTypeLoopback = (1 << 8) << 4,
+    // 0 path interface type == none
+
+    TNLNetworkReachabilityMaskPathConditionExpensive API_AVAILABLE(macos(10.15), ios(13.0), watchos(6.0), tvos(13.0)) = (1 << 16) << 0,
+    TNLNetworkReachabilityMaskPathConditionConstrained API_AVAILABLE(macos(10.15), ios(13.0), watchos(6.0), tvos(13.0)) = (1 << 16) << 1,
+    // 0 path condition == no condition
+
+} API_AVAILABLE(macos(10.14), ios(12.0), watchos(5.0), tvos(12.0));
 
 /**
  Enum of reachability statuses from the `TNLCommunicationAgent`
@@ -81,7 +110,7 @@ typedef NS_ENUM(NSInteger, TNLWWANRadioAccessTechnologyValue) {
     /** Unknown radio access tech */
     TNLWWANRadioAccessTechnologyValueUnknown    = 0,
 
-#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 
     /** 2G, `CTRadioAccessTechnologyGPRS` */
     TNLWWANRadioAccessTechnologyValueGPRS       = 1,
@@ -114,7 +143,7 @@ typedef NS_ENUM(NSInteger, TNLWWANRadioAccessTechnologyValue) {
     /** 4G, Not defined in `CTTelephonyNetworkInfo.h` */
     TNLWWANRadioAccessTechnologyValueHSPAP      = 15
 
-#endif // #if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+#endif // #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 };
 
 //! Convert a WWAN radio access technololgy `NSString` into a `TNLWWANRadioAccessTechnologyValue`
@@ -141,11 +170,11 @@ typedef NS_ENUM(NSInteger, TNLWWANRadioAccessGeneration) {
 //! Determine the `TNLWWANRadioAccessGeneration` from a `TNLWWANRadioAccessTechnologyValue`
 FOUNDATION_EXTERN TNLWWANRadioAccessGeneration TNLWWANRadioAccessGenerationForTechnologyValue(TNLWWANRadioAccessTechnologyValue value) __attribute__((const));
 
-//! String to break SCNetworkReachabilityFlags into a string of flags - for debug purposes only
-FOUNDATION_EXTERN NSString *TNLDebugStringFromNetworkReachabilityFlags(SCNetworkReachabilityFlags flags);
+//! String to break TNLNetworkReachabilityFlags into a string of flags - for debug purposes only.  Has different outputs for iOS 11- and iOS 12+.
+FOUNDATION_EXTERN NSString *TNLDebugStringFromNetworkReachabilityFlags(TNLNetworkReachabilityFlags flags);
 
 
-typedef void(^TNLCommunicationAgentIdentifyReachabilityCallback)(SCNetworkReachabilityFlags flags, TNLNetworkReachabilityStatus status);
+typedef void(^TNLCommunicationAgentIdentifyReachabilityCallback)(TNLNetworkReachabilityFlags flags, TNLNetworkReachabilityStatus status);
 typedef void(^TNLCommunicationAgentIdentifyCarrierInfoCallback)(id<TNLCarrierInfo> __nullable info);
 typedef void(^TNLCommunicationAgentIdentifyWWANRadioAccessTechnologyCallback)(NSString * __nullable info);
 typedef void(^TNLCommunicationAgentIdentifyCaptivePortalStatusCallback)(TNLCaptivePortalStatus status);
@@ -222,7 +251,7 @@ typedef void(^TNLCommunicationAgentIdentifyCaptivePortalStatusCallback)(TNLCapti
 /** cached reachability status */
 @property (atomic, readonly) TNLNetworkReachabilityStatus currentReachabilityStatus;
 /** cached reachability flags */
-@property (atomic, readonly) SCNetworkReachabilityFlags currentReachabilityFlags;
+@property (atomic, readonly) TNLNetworkReachabilityFlags currentReachabilityFlags;
 /** cached radio access technology. Note: `nil` for macOS and UIKit for Mac */
 @property (atomic, copy, readonly, nullable) NSString *currentWWANRadioAccessTechnology;
 /** cached captive portal status */
@@ -248,14 +277,14 @@ typedef void(^TNLCommunicationAgentIdentifyCaptivePortalStatusCallback)(TNLCapti
  called when the oberver is registered with the initial trait values at the time of registration
 
  @parameter communicationAgent related comminication agent for registration
- @parameter didRegisterObserverWithInitialReachabilityFlags Reachability configuration flags that were registered
+ @parameter flags Reachability configuration flags that were registered
  @parameter status current network reachability status
  @parameter carrierInfo Any available carrier information.  Note: This is `nil` in macOS as there is no cellular carrier involved.
  @parameter WWANRadioAccessTechnology GPRS, EDGE, LTE, etc. Note: This is `nil` in macOS as there is no cellular carrier involved.
  @parameter captivePortalStatus the `TNLCaptivePortalStatus` upon registration of an observer
  */
 - (void)tnl_communicationAgent:(TNLCommunicationAgent *)agent
-        didRegisterObserverWithInitialReachabilityFlags:(SCNetworkReachabilityFlags)flags
+        didRegisterObserverWithInitialReachabilityFlags:(TNLNetworkReachabilityFlags)flags
         status:(TNLNetworkReachabilityStatus)status
         carrierInfo:(nullable id<TNLCarrierInfo>)info
         WWANRadioAccessTechnology:(nullable NSString *)radioTech
@@ -263,9 +292,9 @@ typedef void(^TNLCommunicationAgentIdentifyCaptivePortalStatusCallback)(TNLCapti
 
 /** called when reachability changes */
 - (void)tnl_communicationAgent:(TNLCommunicationAgent *)agent
-        didUpdateReachabilityFromPreviousFlags:(SCNetworkReachabilityFlags)oldFlags
+        didUpdateReachabilityFromPreviousFlags:(TNLNetworkReachabilityFlags)oldFlags
         previousStatus:(TNLNetworkReachabilityStatus)oldStatus
-        toCurrentFlags:(SCNetworkReachabilityFlags)newFlags
+        toCurrentFlags:(TNLNetworkReachabilityFlags)newFlags
         currentStatus:(TNLNetworkReachabilityStatus)newStatus;
 
 /** called when carrier info changes

--- a/Source/TNLCommunicationAgent_Project.h
+++ b/Source/TNLCommunicationAgent_Project.h
@@ -11,7 +11,7 @@
 
 #import <TwitterNetworkLayer/TNLCommunicationAgent.h>
 
-#if TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 
 #pragma mark IOS only imports
 
@@ -40,4 +40,4 @@ FOUNDATION_EXTERN id<TNLCarrierInfo> __nullable TNLCarrierInfoFromDictionary(NSD
 
 NS_ASSUME_NONNULL_END
 
-#endif // TARGET_OS_IOS && !TARGET_OS_UIKITFORMAC
+#endif // TARGET_OS_IOS && !TARGET_OS_MACCATALYST

--- a/Source/TNLGlobalConfiguration.m
+++ b/Source/TNLGlobalConfiguration.m
@@ -145,7 +145,12 @@ const NSTimeInterval TNLGlobalConfigurationRequestOperationCallbackTimeoutDefaul
 
 - (void)_tnl_applicationWillEnterForeground:(NSNotification *)note
 {
-    self.lastApplicationState = UIApplicationStateInactive;
+    // When you adopt UIScene in iOS 13+, the foreground notification is sent
+    // on both cold start and return from background. We only want to update
+    // our application state for the latter
+    if (self.lastApplicationState == UIApplicationStateBackground) {
+        self.lastApplicationState = UIApplicationStateInactive;
+    }
 }
 
 - (void)_tnl_applicationDidBecomeActive:(NSNotification *)note

--- a/Source/TNLInternalKeys.h
+++ b/Source/TNLInternalKeys.h
@@ -24,6 +24,7 @@
 #define kSharedKeySharedContainerIdentifier @"scid"
 #define kSharedKeySessionSendsLaunchEvents  @"ssle"
 #define kSharedKeyMultiPathServiceType      @"mptcp" // Multipath TCP (MPTCP)
+#define kSharedKeyShouldUseExtendedBackgroundIdleMode   @"xbim"
 
 #pragma mark Keys for URL Sessions Configs
 
@@ -49,6 +50,7 @@
 #define TNLSessionConfigurationPropertyKeySharedContainerIdentifier     kSharedKeySharedContainerIdentifier
 #define TNLSessionConfigurationPropertyKeyProtocolClassPrefix           @"pc" // key will be this prefix concatenated with an index
 #define TNLSessionConfigurationPropertyKeyMultipathServiceType          kSharedKeyMultiPathServiceType
+#define TNLSessionConfigurationPropertyKeyShouldUseExtendedBackgroundIdleMode   kSharedKeyShouldUseExtendedBackgroundIdleMode
 
 #pragma mark Keys for TNL Request Configs
 
@@ -72,4 +74,5 @@
 #define TNLRequestConfigurationPropertyKeyCookieStorage                         kSharedKeyHTTPCookieStorage
 #define TNLRequestConfigurationPropertyKeySharedContainerIdentifier             kSharedKeySharedContainerIdentifier
 #define TNLRequestConfigurationPropertyKeyMultipathServiceType                  kSharedKeyMultiPathServiceType
+#define TNLRequestConfigurationPropertyKeyShouldUseExtendedBackgroundIdleMode   kSharedKeyShouldUseExtendedBackgroundIdleMode
 

--- a/Source/TNLParameterCollection.m
+++ b/Source/TNLParameterCollection.m
@@ -374,7 +374,7 @@ typedef NSString *(^TNLParameterCollectionUpdateKeysAndValuesIterativeKeyBlock)(
                     parameterString = [path substringFromIndex:range.location + 1];
                 }
             }
-#if !TARGET_OS_UIKITFORMAC
+#if !TARGET_OS_MACCATALYST
         } else {
             parameterString = URL.parameterString;
 #endif

--- a/Source/TNLRequestConfiguration.h
+++ b/Source/TNLRequestConfiguration.h
@@ -145,7 +145,7 @@ typedef NS_OPTIONS(NSInteger, TNLRequestConnectivityOptions) {
     /**
      Suspend the attempt timeout while waiting for connectivity, resuming when connectivity returns.
      No-op if `TNLRequestConnectivityOptionInvalidateAttemptTimeoutWhenWaitForConnectivityTriggered` is also set.
-     TODO: there is no event from NSURLSession when a task continues upon connectivity, so this is
+     TODO: there is no event from NSURLSession when a task continues upon connectivity, so this
            feature is out of reach right now.
      */
     // TNLRequestConnectivityOptionSuspendAttemptTimeoutDuringWaitForConnectivity = (1 << 3),
@@ -248,6 +248,7 @@ FOUNDATION_EXTERN NSTimeInterval TNLDeferrableIntervalForPriority(TNLPriority pr
         BOOL discretionary:1;
         BOOL shouldLaunchAppForBackgroundEvents:1;
         BOOL shouldSetCookies:1;
+        BOOL shouldUseExtendedBackgroundIdleMode:1;
 
     } _ivars;
 }
@@ -289,6 +290,15 @@ FOUNDATION_EXTERN NSTimeInterval TNLDeferrableIntervalForPriority(TNLPriority pr
 
  Default is `TNLRequestConnectivityOptionsDefault` (fail instead of waiting for connectivity)
  Requires iOS 11, macOS 10.13
+
+ @warning iOS 13.0 betas (and matching tvOS, macOS and watchOS versions) regressed `waitsForConnectivity`.
+ `NSURLSession` layer no longer calls `NSURLSessionTaskDelegate` `URLSession:taskIsWaitingForConnectivity:`
+ rendering the feature impotent and dangerous (easily leading to never finishing network requests which
+ can lead to interminable hangs based on the dependencies established on the `TNLRequestOperation`).
+ #FB7027774
+ To avoid this regression, `connectivityOptions` will be set to `TNLRequestConnectivityOptionsNone`
+ on for iOS 13.0 and attempting to mutate this property will log a warning to the `TNLLogger`.
+ Apple fixed this issue with iOS 13.1 beta 1 and thus this configuration is enabled again on iOS 13.1.
  */
 @property (nonatomic, readonly) TNLRequestConnectivityOptions connectivityOptions;
 
@@ -503,6 +513,33 @@ FOUNDATION_EXTERN NSTimeInterval TNLDeferrableIntervalForPriority(TNLPriority pr
 @property (nonatomic, readonly) NSURLSessionMultipathServiceType multipathServiceType API_AVAILABLE(ios(11.0)) API_UNAVAILABLE(macos, watchos, tvos);
 
 /**
+ Extended background idle mode for any tcp sockets created.
+ When enabled this mode asks the system to keep the socket open and delay reclaiming it when the process moves to the background.
+ (see https://developer.apple.com/library/ios/technotes/tn2277/_index.html)
+ Default value is `NO`
+
+ Introduced iOS 9.  Older version will ignore this setting.
+
+ See `[NSURLSessionConfiguration shouldUseExtendedBackgroundIdleMode]`
+
+ @note it is inefficient to have multiple connections to the same host, which
+ NSURLSession forces as it siloes connections per session.
+ Since different values for `shouldUseExtendedBackgroundIdleMode` will incur different
+ backing NSURLSession instances, it is inefficient for requests to the same host to be
+ configured with different values for `shouldUseExtendedBackgroundIdleMode` as they
+ will be forced by the NSURL layer to run on separate NSURLSession instances
+ and thus on different connections.  To take care of this risk, be considerate of when
+ you have `shouldUseExtendedBackgroundIdleMode` as a different value between requests
+ to the same host.  One simple/brute option: force all requests to a host to always have
+ the same value for `shouldUseExtendedBackgroundIdleMode`.  Another option is to be
+ very intentional with what requests have `shouldUseExtendedBackgroundIdleMode` as `YES`
+ and potentially only use background requests for those use cases instead.  Even more
+ complicated would be to rig a system where you dynamically shift all requests to move
+ their `shouldUseExtendedBackgroundIdleMode` config value based on the app behavior.
+ */
+@property (nonatomic, readonly) BOOL shouldUseExtendedBackgroundIdleMode;
+
+/**
  Create a new `TNLRequestConfiguration` instance with default values
  */
 + (instancetype)defaultConfiguration;
@@ -554,6 +591,7 @@ FOUNDATION_EXTERN NSTimeInterval TNLDeferrableIntervalForPriority(TNLPriority pr
 @property (nonatomic, readwrite, nullable) NSURLCache *URLCache;
 @property (nonatomic, readwrite, nullable) NSHTTPCookieStorage *cookieStorage;
 @property (nonatomic, readwrite) NSURLSessionMultipathServiceType multipathServiceType API_AVAILABLE(ios(11.0)) API_UNAVAILABLE(macos, watchos, tvos);
+@property (nonatomic, readwrite) BOOL shouldUseExtendedBackgroundIdleMode;
 
 /**
  Populates propertiest that effect prioritization.

--- a/Source/TNLRequestOperation.m
+++ b/Source/TNLRequestOperation.m
@@ -1431,19 +1431,19 @@ static void _network_applyGlobalHeadersToScratchURLRequest(SELF_ARG, tnl_request
         self->_scratchURLRequest.allHTTPHeaderFields = nil;
 
         // 1) default headers
-        for (NSString *key in defaultHeaders) {
-            [self->_scratchURLRequest setValue:defaultHeaders[key] forHTTPHeaderField:key];
-        }
+        [defaultHeaders enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull key, NSString * _Nonnull obj, BOOL * _Nonnull stop) {
+            [self->_scratchURLRequest setValue:obj forHTTPHeaderField:key];
+        }];
 
         // 2) specified headers
-        for (NSString *key in existingHeaders) {
-            [self->_scratchURLRequest setValue:existingHeaders[key] forHTTPHeaderField:key];
-        }
+        [existingHeaders enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull key, NSString * _Nonnull obj, BOOL * _Nonnull stop) {
+            [self->_scratchURLRequest setValue:obj forHTTPHeaderField:key];
+        }];
 
         // 3) override headers
-        for (NSString *key in overrideHeaders) {
-            [self->_scratchURLRequest setValue:overrideHeaders[key] forHTTPHeaderField:key];
-        }
+        [overrideHeaders enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull key, NSString * _Nonnull obj, BOOL * _Nonnull stop) {
+            [self->_scratchURLRequest setValue:obj forHTTPHeaderField:key];
+        }];
     }
 
     nextBlock();
@@ -1855,7 +1855,7 @@ static void _network_fail(SELF_ARG,
     NSURLSessionTaskMetrics *taskMetrics;
     TNLURLSessionTaskOperation *URLSessionTaskOperation = self.URLSessionTaskOperation;
     if (URLSessionTaskOperation) {
-        metadata = [URLSessionTaskOperation network_metaData];
+        metadata = [URLSessionTaskOperation network_metaDataWithLowerCaseHeaderFields:info.allHTTPHeaderFieldsWithLowerCaseKeys];
         taskMetrics = [URLSessionTaskOperation network_taskMetrics];
     } else {
         metadata = (TNLAttemptMetaData * __nonnull)nil;
@@ -2161,7 +2161,7 @@ static void _network_completeStateTransition(SELF_ARG,
 #if NS_BLOCK_ASSERTIONS
         assert(attemptResponse != nil);
 #else
-        NSCAssert(attemptResponse != nil, @"assertion failed: cannot finish a %@ with a nil TNLResponse!", NSStringFromClass([self class]));
+        TNLCAssert(attemptResponse != nil, @"assertion failed: cannot finish a %@ with a nil TNLResponse!", NSStringFromClass([self class]));
 #endif
 
         [self.requestOperationQueue operation:self

--- a/Source/TNLURLSessionTaskOperation.h
+++ b/Source/TNLURLSessionTaskOperation.h
@@ -79,7 +79,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 // call these from tnl_network_queue()
 - (void)network_priorityDidChangeForRequestOperation:(TNLRequestOperation *)op;
-- (TNLAttemptMetaData *)network_metaData;
+- (TNLAttemptMetaData *)network_metaDataWithLowerCaseHeaderFields:(nullable NSDictionary *)lowerCaseHeaderFields;
 - (nullable NSURLSessionTaskMetrics *)network_taskMetrics;
 
 @end

--- a/Source/TNL_Project.h
+++ b/Source/TNL_Project.h
@@ -137,6 +137,17 @@ FOUNDATION_EXTERN Class __nullable TNLDynamicUIApplicationClass(void);
 
 #define TNLLogVerboseEnabled() ([gTNLLogger respondsToSelector:@selector(tnl_shouldLogVerbosely)] ? [gTNLLogger tnl_shouldLogVerbosely] : NO)
 
+#if TARGET_OS_OSX
+#define TNL_LOG_WAITS_FOR_CONNECTIVITY_WARNING() \
+TNLLogWarning(@"#FB7027774: Cannot modify -[TNLRequestConfiguration connectivityOptions] on macOS %li.%li.%li", (long)[NSProcessInfo processInfo].operatingSystemVersion.majorVersion, (long)[NSProcessInfo processInfo].operatingSystemVersion.minorVersion, (long)[NSProcessInfo processInfo].operatingSystemVersion.patchVersion)
+#elif TARGET_OS_IPHONE && !TARGET_OS_WATCH
+#define TNL_LOG_WAITS_FOR_CONNECTIVITY_WARNING() \
+TNLLogWarning(@"#FB7027774: Cannot modify -[TNLRequestConfiguration connectivityOptions] on %@ %@", [UIDevice currentDevice].systemName, [UIDevice currentDevice].systemVersion)
+#else
+#define TNL_LOG_WAITS_FOR_CONNECTIVITY_WARNING() \
+TNLLogWarning(@"#FB7027774: Cannot modify -[TNLRequestConfiguration connectivityOptions]")
+#endif
+
 #pragma mark - Introspection
 
 #if DEBUG

--- a/Source/TNL_ProjectCommon.h
+++ b/Source/TNL_ProjectCommon.h
@@ -16,6 +16,26 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+
+#pragma mark - File Name macro
+
+/**
+ Helper macro for the file name macro.
+
+ `__FILE__` is the historical C macro that is replaced with the full file path of the current file being compiled (e.g. `/Users/username/workspace/project/source/subfolder/anotherfolder/implementation/file.c`)
+ `__FILE_NAME__` is the new C macro in clang that is replaced with the file name of the current file being compiled (e.g. `file.c`)
+
+ By default, if `__FILE_NAME__` is availble with the current compiler, it will be used.
+ This behavior can be overridden by providing a value for `TNL_FILE_NAME` to the compiler, like `-DTNL_FILE_NAME=__FILE__` or `-DTNL_FILE_NAME=\"redacted\"`
+ */
+#if !defined(TNL_FILE_NAME)
+#ifdef __FILE_NAME__
+#define TNL_FILE_NAME __FILE_NAME__
+#else
+#define TNL_FILE_NAME __FILE__
+#endif
+#endif
+
 #pragma mark - Binary
 
 FOUNDATION_EXTERN BOOL TNLIsExtension(void);
@@ -43,18 +63,41 @@ FOUNDATION_EXTERN BOOL TNLIsExtension(void);
 
 FOUNDATION_EXTERN BOOL gTwitterNetworkLayerAssertEnabled;
 
+#if !defined(NS_BLOCK_ASSERTIONS)
+
+#define TNLCAssert(condition, desc, ...) \
+do {                \
+    __PRAGMA_PUSH_NO_EXTRA_ARG_WARNINGS \
+    if (__builtin_expect(!(condition), 0)) {        \
+            NSString *__assert_fn__ = [NSString stringWithUTF8String:__PRETTY_FUNCTION__]; \
+            __assert_fn__ = __assert_fn__ ? __assert_fn__ : @"<Unknown Function>"; \
+            NSString *__assert_file__ = [NSString stringWithUTF8String:TNL_FILE_NAME]; \
+            __assert_file__ = __assert_file__ ? __assert_file__ : @"<Unknown File>"; \
+        [[NSAssertionHandler currentHandler] handleFailureInFunction:__assert_fn__ \
+        file:__assert_file__ \
+            lineNumber:__LINE__ description:(desc), ##__VA_ARGS__]; \
+    }                \
+    __PRAGMA_POP_NO_EXTRA_ARG_WARNINGS \
+} while(0)
+
+#else // NS_BLOCK_ASSERTIONS defined
+
+#define TNLCAssert(condition, desc, ...) do {} while (0)
+
+#endif // NS_BLOCK_ASSERTIONS not defined
+
 #define TNLAssert(expression) \
 ({ if (gTwitterNetworkLayerAssertEnabled) { \
     const BOOL __expressionValue = !!(expression); (void)__expressionValue; \
     __TNLAssert(__expressionValue); \
-    NSCAssert(__expressionValue, @"assertion failed: (" #expression ")"); \
+    TNLCAssert(__expressionValue, @"assertion failed: (" #expression ")"); \
 } })
 
 #define TNLAssertMessage(expression, format, ...) \
 ({ if (gTwitterNetworkLayerAssertEnabled) { \
     const BOOL __expressionValue = !!(expression); (void)__expressionValue; \
     __TNLAssert(__expressionValue); \
-    NSCAssert(__expressionValue, @"assertion failed: (" #expression ") message: %@", [NSString stringWithFormat:format, ##__VA_ARGS__]); \
+    TNLCAssert(__expressionValue, @"assertion failed: (" #expression ") message: %@", [NSString stringWithFormat:format, ##__VA_ARGS__]); \
 } })
 
 #define TNLAssertNever()      TNLAssert(0 && "this line should never get executed" )
@@ -64,7 +107,12 @@ FOUNDATION_EXTERN BOOL gTwitterNetworkLayerAssertEnabled;
 // NOTE: TNLStaticAssert's msg argument should be valid as a variable.  That is, composed of ASCII letters, numbers and underscore characters only.
 #define __TNLStaticAssert(line, msg) TNLStaticAssert_##line##_##msg
 #define _TNLStaticAssert(line, msg) __TNLStaticAssert( line , msg )
-#define TNLStaticAssert(condition, msg) typedef char _TNLStaticAssert( __LINE__ , msg ) [ (condition) ? 1 : -1 ]
+
+#define TNLStaticAssert(condition, msg) \
+_Pragma("clang diagnostic push") \
+_Pragma("clang diagnostic ignored \"-Wunused\"") \
+typedef char _TNLStaticAssert( __LINE__ , msg ) [ (condition) ? 1 : -1 ] \
+_Pragma("clang diagnostic pop" )
 
 #pragma twitter endignoreformatting
 
@@ -79,7 +127,7 @@ do { \
     id<TNLLogger> const __logger = gTNLLogger; \
     TNLLogLevel const __level = (level); \
     if (__logger && (![__logger respondsToSelector:@selector(tnl_canLogWithLevel:context:)] || [__logger tnl_canLogWithLevel:__level context:nil])) { \
-        [__logger tnl_logWithLevel:__level context:nil file:@(__FILE__) function:@(__FUNCTION__) line:__LINE__ message:[NSString stringWithFormat: __VA_ARGS__ ]]; \
+        [__logger tnl_logWithLevel:__level context:nil file:@(TNL_FILE_NAME) function:@(__FUNCTION__) line:__LINE__ message:[NSString stringWithFormat: __VA_ARGS__ ]]; \
     } \
 } while (0)
 

--- a/TNLExample/TNLXAppDelegate.m
+++ b/TNLExample/TNLXAppDelegate.m
@@ -121,7 +121,7 @@ NSString *TNLXCommunicationStatusUpdatedNotification = @"TNLXCommunicationStatus
 
 - (void)applicationDidBecomeActive:(UIApplication *)application
 {
-#if !TARGET_OS_UIKITFORMAC
+#if !TARGET_OS_MACCATALYST
     if (@available(iOS 13, *)) {
 
     } else {
@@ -179,7 +179,7 @@ NSString *TNLXCommunicationStatusUpdatedNotification = @"TNLXCommunicationStatus
 - (void)networkingDidChange:(NSNotification *)note
 {
     assert([NSThread isMainThread]);
-#if !TARGET_OS_UIKITFORMAC
+#if !TARGET_OS_MACCATALYST
     BOOL on = [note.userInfo[TNLNetworkExecutingNetworkConnectionsExecutingKey] boolValue];
     [UIApplication sharedApplication].networkActivityIndicatorVisible = on;
 #endif
@@ -232,7 +232,7 @@ NSString *TNLXCommunicationStatusUpdatedNotification = @"TNLXCommunicationStatus
 #pragma mark TNLCommunicationAgentObserver
 
 - (void)tnl_communicationAgent:(TNLCommunicationAgent *)agent
-        didRegisterObserverWithInitialReachabilityFlags:(SCNetworkReachabilityFlags)flags
+        didRegisterObserverWithInitialReachabilityFlags:(TNLNetworkReachabilityFlags)flags
         status:(TNLNetworkReachabilityStatus)status
         carrierInfo:(nullable id<TNLCarrierInfo>)info
         WWANRadioAccessTechnology:(nullable NSString *)radioTech
@@ -254,9 +254,9 @@ NSString *TNLXCommunicationStatusUpdatedNotification = @"TNLXCommunicationStatus
 }
 
 - (void)tnl_communicationAgent:(TNLCommunicationAgent *)agent
-        didUpdateReachabilityFromPreviousFlags:(SCNetworkReachabilityFlags)oldFlags
+        didUpdateReachabilityFromPreviousFlags:(TNLNetworkReachabilityFlags)oldFlags
         previousStatus:(TNLNetworkReachabilityStatus)oldStatus
-        toCurrentFlags:(SCNetworkReachabilityFlags)newFlags
+        toCurrentFlags:(TNLNetworkReachabilityFlags)newFlags
         currentStatus:(TNLNetworkReachabilityStatus)newStatus
 {
     _SCFlagsString = TNLDebugStringFromNetworkReachabilityFlags(newFlags);

--- a/TNLExample/TNLXLotsOfRequestsViewController.m
+++ b/TNLExample/TNLXLotsOfRequestsViewController.m
@@ -371,7 +371,7 @@ static const BOOL kUseThumbnail = NO;
                 delay++;
             }
         } else {
-            _progressView.backgroundColor = [UIColor colorWithRed:0.75 green:0.1 blue:0.1 alpha:0.0];
+            _progressView.backgroundColor = [UIColor colorWithRed:(CGFloat)0.75 green:(CGFloat)0.1 blue:(CGFloat)0.1 alpha:(CGFloat)0.0];
         }
     } else {
         NSString *tempPath = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]];

--- a/TwitterNetworkLayer.xcodeproj/project.pbxproj
+++ b/TwitterNetworkLayer.xcodeproj/project.pbxproj
@@ -255,6 +255,7 @@
 		8BCA626419C356AE00F3F8CA /* TNLRequestOperationState.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BCA626319C356AE00F3F8CA /* TNLRequestOperationState.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8BCAF8C519F716370043EB22 /* TNLRequestOperationCancelSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BCAF8C319F716370043EB22 /* TNLRequestOperationCancelSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8BCAF8C619F716370043EB22 /* TNLRequestOperationCancelSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BCAF8C419F716370043EB22 /* TNLRequestOperationCancelSource.m */; };
+		8BCC9EF022AC36C400A5D1C8 /* Network.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BCC9EEF22AC36C400A5D1C8 /* Network.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		8BD083C91FD9C2020090B7C3 /* TNLTimeoutOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BD083C71FD9C2020090B7C3 /* TNLTimeoutOperation.h */; };
 		8BD083CA1FD9C2020090B7C3 /* TNLTimeoutOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD083C81FD9C2020090B7C3 /* TNLTimeoutOperation.m */; };
 		8BD083CB1FD9C20E0090B7C3 /* TNLTimeoutOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BD083C71FD9C2020090B7C3 /* TNLTimeoutOperation.h */; };
@@ -265,6 +266,8 @@
 		8BD500E71D8765F200D828C7 /* TNLURLStringCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD500E61D8765F200D828C7 /* TNLURLStringCoding.m */; };
 		8BD500F51D87762200D828C7 /* TNL_ProjectCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BD500F31D87762200D828C7 /* TNL_ProjectCommon.h */; };
 		8BD500F61D87762200D828C7 /* TNL_ProjectCommon.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD500F41D87762200D828C7 /* TNL_ProjectCommon.m */; };
+		8BD8715D22AD82360011DACA /* Network.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BCC9EEF22AC36C400A5D1C8 /* Network.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		8BD8715E22AD823A0011DACA /* Network.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BCC9EEF22AC36C400A5D1C8 /* Network.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		8BDA9D2D197881DE00678D90 /* TNLError.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BDA9D2B197881DE00678D90 /* TNLError.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8BDA9D2F197881DE00678D90 /* TNLError.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BDA9D2C197881DE00678D90 /* TNLError.m */; };
 		8BDA9D331978822300678D90 /* TNLPriority.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BDA9D311978822300678D90 /* TNLPriority.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -687,7 +690,6 @@
 		8B022A8119AAD2F800DB3052 /* NSDictionary+TNLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+TNLAdditions.h"; sourceTree = "<group>"; };
 		8B022A8219AAD2F800DB3052 /* NSDictionary+TNLAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+TNLAdditions.m"; sourceTree = "<group>"; };
 		8B07EE681987E7DD00F9EF8E /* TNL_Project.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TNL_Project.m; sourceTree = "<group>"; };
-		8B0A07721C73E736002F63B1 /* TwitterLoggingService.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = TwitterLoggingService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8B0AFAA61A018EBE00C8C81F /* TNLPseudoURLProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TNLPseudoURLProtocol.h; sourceTree = "<group>"; };
 		8B0AFAA71A018EBE00C8C81F /* TNLPseudoURLProtocol.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TNLPseudoURLProtocol.m; sourceTree = "<group>"; };
 		8B0AFAAD1A01C20000C8C81F /* TNLPseudoRequestOperationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TNLPseudoRequestOperationTest.m; sourceTree = "<group>"; };
@@ -808,6 +810,7 @@
 		8BCA626319C356AE00F3F8CA /* TNLRequestOperationState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TNLRequestOperationState.h; sourceTree = "<group>"; };
 		8BCAF8C319F716370043EB22 /* TNLRequestOperationCancelSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TNLRequestOperationCancelSource.h; sourceTree = "<group>"; };
 		8BCAF8C419F716370043EB22 /* TNLRequestOperationCancelSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TNLRequestOperationCancelSource.m; sourceTree = "<group>"; };
+		8BCC9EEF22AC36C400A5D1C8 /* Network.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Network.framework; path = System/Library/Frameworks/Network.framework; sourceTree = SDKROOT; };
 		8BD083C71FD9C2020090B7C3 /* TNLTimeoutOperation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TNLTimeoutOperation.h; sourceTree = "<group>"; };
 		8BD083C81FD9C2020090B7C3 /* TNLTimeoutOperation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TNLTimeoutOperation.m; sourceTree = "<group>"; };
 		8BD317BE19A8DD0100DF1836 /* TNLXPlaygroundViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TNLXPlaygroundViewController.h; sourceTree = "<group>"; };
@@ -929,6 +932,7 @@
 				8BB26ABB1D8B142E00D1AB5A /* CFNetwork.framework in Frameworks */,
 				8B4AA7621E1F297C00BF7EA0 /* CoreTelephony.framework in Frameworks */,
 				8BE402CA1946743D00C7241E /* Foundation.framework in Frameworks */,
+				8BCC9EF022AC36C400A5D1C8 /* Network.framework in Frameworks */,
 				8B427D551FB53DBF00C9E5CE /* Security.framework in Frameworks */,
 				8BE3DB9D1CDB00B00081ACCE /* SystemConfiguration.framework in Frameworks */,
 				8BB26ABC1D8B143900D1AB5A /* UIKit.framework in Frameworks */,
@@ -962,6 +966,7 @@
 				8BFDF9402135AB2C002F6A80 /* Security.framework in Frameworks */,
 				8BFDF9412135AB2C002F6A80 /* SystemConfiguration.framework in Frameworks */,
 				8BFDF9422135AB2C002F6A80 /* UIKit.framework in Frameworks */,
+				8BD8715E22AD823A0011DACA /* Network.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -989,6 +994,7 @@
 				BF4AA0EF1EE61D46001647B5 /* libz.tbd in Frameworks */,
 				BF4AA0F01EE61D46001647B5 /* CFNetwork.framework in Frameworks */,
 				BF4AA0F21EE61D46001647B5 /* Foundation.framework in Frameworks */,
+				8BD8715D22AD82360011DACA /* Network.framework in Frameworks */,
 				8BFDF8FD2135A1FC002F6A80 /* Security.framework in Frameworks */,
 				BF4AA0F31EE61D46001647B5 /* SystemConfiguration.framework in Frameworks */,
 			);
@@ -1142,6 +1148,7 @@
 		8BE402C81946743D00C7241E /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				8BCC9EEF22AC36C400A5D1C8 /* Network.framework */,
 				8BFDF8FC2135A1FC002F6A80 /* Security.framework */,
 				8B022A7B19AA52F800DB3052 /* Accounts.framework */,
 				8B6DCB4B1974598300235576 /* CFNetwork.framework */,
@@ -1156,7 +1163,6 @@
 				8B427D541FB53DBF00C9E5CE /* Security.framework */,
 				8B022A7F19AA530000DB3052 /* Social.framework */,
 				8B4DEFF81986AA64008A31EB /* SystemConfiguration.framework */,
-				8B0A07721C73E736002F63B1 /* TwitterLoggingService.framework */,
 				8B6DCB491974583B00235576 /* UIKit.framework */,
 				8BE402D71946743E00C7241E /* XCTest.framework */,
 			);
@@ -1766,7 +1772,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = TNL;
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1030;
 				ORGANIZATIONNAME = Twitter;
 				TargetAttributes = {
 					8B9EBDB52135B4B100E6E466 = {
@@ -1801,7 +1807,6 @@
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 			);
@@ -2249,6 +2254,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_MODULES_AUTOLINK = NO;
+				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twitter.TwitterNetworkLayer;
@@ -2262,6 +2268,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_MODULES_AUTOLINK = NO;
+				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twitter.TwitterNetworkLayer;
@@ -2356,7 +2363,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 2.6;
+				CURRENT_PROJECT_VERSION = 2.8;
 				DEAD_CODE_STRIPPING = NO;
 				DYLIB_CURRENT_VERSION = "$(CURRENT_PROJECT_VERSION)";
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -2423,7 +2430,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2.6;
+				CURRENT_PROJECT_VERSION = 2.8;
 				DEAD_CODE_STRIPPING = NO;
 				DYLIB_CURRENT_VERSION = "$(CURRENT_PROJECT_VERSION)";
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -2517,6 +2524,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_MODULES_AUTOLINK = NO;
+				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twitter.TwitterNetworkLayer;
@@ -2530,6 +2538,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_MODULES_AUTOLINK = NO;
+				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twitter.TwitterNetworkLayer;

--- a/TwitterNetworkLayer.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/TwitterNetworkLayer.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TNLExample.xcscheme
+++ b/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TNLExample.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -41,8 +41,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -52,8 +50,8 @@
             ReferencedContainer = "container:TwitterNetworkLayer.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -75,8 +73,6 @@
             ReferencedContainer = "container:TwitterNetworkLayer.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer macOS.xcscheme
+++ b/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer tvOS.xcscheme
+++ b/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer watchOS.xcscheme
+++ b/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer.xcscheme
+++ b/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8BE402C51946743D00C7241E"
+            BuildableName = "TwitterNetworkLayer.framework"
+            BlueprintName = "TwitterNetworkLayer"
+            ReferencedContainer = "container:TwitterNetworkLayer.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO"
@@ -40,17 +49,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "8BE402C51946743D00C7241E"
-            BuildableName = "TwitterNetworkLayer.framework"
-            BlueprintName = "TwitterNetworkLayer"
-            ReferencedContainer = "container:TwitterNetworkLayer.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -71,8 +69,6 @@
             ReferencedContainer = "container:TwitterNetworkLayer.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/TwitterNetworkLayerTests/TNLRequestConfigurationTest.m
+++ b/TwitterNetworkLayerTests/TNLRequestConfigurationTest.m
@@ -38,6 +38,10 @@
 
 - (void)testConfigRoundTrips
 {
+    BOOL connectivityOptionsForciblyDisabled = NO;
+    if (tnl_available_ios_11) {
+        connectivityOptionsForciblyDisabled = ![NSURLSessionConfiguration tnl_URLSessionCanUseWaitsForConnectivity];
+    }
     TNLMutableRequestConfiguration *config = [TNLMutableRequestConfiguration defaultConfiguration];
     TNLMutableParameterCollection *params;
     TNLParameterCollection *roundTripParams;
@@ -52,9 +56,9 @@
     roundTripConfig = (id)[TNLRequestConfiguration configurationFromParameters:params executionMode:config.executionMode version:[TNLGlobalConfiguration version]];
 
 #if TARGET_OS_IPHONE // == IOS + WATCH + TV
-    testParamString = @"aca=1&atmpTO=60&ckiplcy=1&cnvty=0&dfrI=0&dis=0&double=3.14159265359&idlTO=30&nst=0&opTO=180&ptcls=0&rcp=0&rdcm=1&rdp=1&setcki=0&ssle=1";
+    testParamString = @"aca=1&atmpTO=60&ckiplcy=1&cnvty=0&dfrI=0&dis=0&double=3.14159265359&idlTO=30&nst=0&opTO=180&ptcls=0&rcp=0&rdcm=1&rdp=1&setcki=0&ssle=1&xbim=0";
 #else
-    testParamString = @"aca=1&atmpTO=60&ckiplcy=1&cnvty=0&dfrI=0&dis=0&double=3.14159265359&idlTO=30&nst=0&opTO=180&ptcls=0&rcp=0&rdcm=1&rdp=1&setcki=0&ssle=0";
+    testParamString = @"aca=1&atmpTO=60&ckiplcy=1&cnvty=0&dfrI=0&dis=0&double=3.14159265359&idlTO=30&nst=0&opTO=180&ptcls=0&rcp=0&rdcm=1&rdp=1&setcki=0&ssle=0&xbim=0";
 #endif
 
     XCTAssertEqualObjects(paramString, testParamString);
@@ -65,7 +69,7 @@
 #if TARGET_OS_IOS
     if (tnl_available_ios_11) {
         config.multipathServiceType = NSURLSessionMultipathServiceTypeInteractive;
-        testParamString = @"aca=1&atmpTO=60&ckiplcy=1&cnvty=0&dfrI=0&dis=0&idlTO=30&mptcp=2&nst=0&opTO=180&ptcls=0&rcp=0&rdcm=1&rdp=1&setcki=0&ssle=1";
+        testParamString = @"aca=1&atmpTO=60&ckiplcy=1&cnvty=0&dfrI=0&dis=0&idlTO=30&mptcp=2&nst=0&opTO=180&ptcls=0&rcp=0&rdcm=1&rdp=1&setcki=0&ssle=1&xbim=0";
         params = TNLMutableParametersFromRequestConfiguration(config, nil, nil, nil);
         paramString = params.stableURLEncodedStringValue;
         roundTripParams = [[TNLParameterCollection alloc] initWithURLEncodedString:paramString options:0];
@@ -97,6 +101,7 @@
     config.shouldLaunchAppForBackgroundEvents = NO;
     config.shouldSetCookies = NO;
     config.cookieAcceptPolicy = NSHTTPCookieAcceptPolicyNever;
+    config.shouldUseExtendedBackgroundIdleMode = YES;
 
     XCTAssertNotNil(config.sharedContainerIdentifier);
     XCTAssertEqualObjects(config, [config copy]);
@@ -108,7 +113,7 @@
     XCTAssertNotEqual(roundTripConfig.contributeToExecutingNetworkConnectionsCount, config.contributeToExecutingNetworkConnectionsCount);
     roundTripConfig.contributeToExecutingNetworkConnectionsCount = config.contributeToExecutingNetworkConnectionsCount;
 
-    testParamString = [NSString stringWithFormat:@"aca=0&atmpTO=360.1&ckiplcy=1&cnvty=5&dfrI=30.1&dis=1&idlTO=180.1&nst=3&opTO=720.1&ptcls=2&rcp=1&rdcm=2&rdp=0&%@setcki=0&ssle=0", config.sharedContainerIdentifier ? @"scid=container.id&" : @""];
+    testParamString = [NSString stringWithFormat:@"aca=0&atmpTO=360.1&ckiplcy=1&cnvty=%@&dfrI=30.1&dis=1&idlTO=180.1&nst=3&opTO=720.1&ptcls=2&rcp=1&rdcm=2&rdp=0&%@setcki=0&ssle=0&xbim=1", (connectivityOptionsForciblyDisabled) ? @0 : @5, config.sharedContainerIdentifier ? @"scid=container.id&" : @""];
     XCTAssertEqualObjects(paramString, testParamString);
     [self runTestParamsEqualBetweenOriginal:params roundTrip:roundTripParams];
     XCTAssertEqualObjects(roundTripConfig, config);
@@ -129,7 +134,7 @@
     roundTripConfig.URLCredentialStorage = config.URLCredentialStorage;
     roundTripConfig.URLCache = config.URLCache;
     roundTripConfig.cookieStorage = config.cookieStorage;
-    testParamString = [NSString stringWithFormat:@"aca=0&atmpTO=360.1&ckiplcy=1&ckisto=NSHTTPCookieStorage_%p&cnvty=5&crdsto=NSURLCredentialStorage_%p&dfrI=30.1&dis=1&idlTO=180.1&nst=3&opTO=720.1&ptcls=2&rcp=1&rdcm=2&rdp=0&%@setcki=0&ssle=0&urlcch=NSURLCache_%p", config.cookieStorage, config.URLCredentialStorage, config.sharedContainerIdentifier ? @"scid=container.id&" : @"", config.URLCache];
+    testParamString = [NSString stringWithFormat:@"aca=0&atmpTO=360.1&ckiplcy=1&ckisto=NSHTTPCookieStorage_%p&cnvty=%@&crdsto=NSURLCredentialStorage_%p&dfrI=30.1&dis=1&idlTO=180.1&nst=3&opTO=720.1&ptcls=2&rcp=1&rdcm=2&rdp=0&%@setcki=0&ssle=0&urlcch=NSURLCache_%p&xbim=1", config.cookieStorage, (connectivityOptionsForciblyDisabled) ? @0 : @5, config.URLCredentialStorage, config.sharedContainerIdentifier ? @"scid=container.id&" : @"", config.URLCache];
     XCTAssertEqualObjects(paramString, testParamString);
     [self runTestParamsEqualBetweenOriginal:params roundTrip:roundTripParams];
     XCTAssertEqualObjects(roundTripConfig, config);
@@ -150,9 +155,9 @@
     roundTripConfig.URLCredentialStorage = config.URLCredentialStorage;
     roundTripConfig.URLCache = config.URLCache;
     roundTripConfig.cookieStorage = config.cookieStorage;
-    testParamString = [NSString stringWithFormat:@"aca=0&atmpTO=360.1&ckiplcy=1&ckisto=NSHTTPCookieStorage_%p&cnvty=5&crdsto=NSURLCredentialStorage_%p&dfrI=30.1&dis=1&idlTO=180.1&nst=3&opTO=720.1&ptcls=2&rcp=1&rdcm=2&rdp=0&%@setcki=0&ssle=0&urlcch=NSURLCache_%p", config.cookieStorage, config.URLCredentialStorage, config.sharedContainerIdentifier ? @"scid=container.id&" : @"", config.URLCache];
+    testParamString = [NSString stringWithFormat:@"aca=0&atmpTO=360.1&ckiplcy=1&ckisto=NSHTTPCookieStorage_%p&cnvty=%@&crdsto=NSURLCredentialStorage_%p&dfrI=30.1&dis=1&idlTO=180.1&nst=3&opTO=720.1&ptcls=2&rcp=1&rdcm=2&rdp=0&%@setcki=0&ssle=0&urlcch=NSURLCache_%p&xbim=1", config.cookieStorage, (connectivityOptionsForciblyDisabled) ? @0 : @5, config.URLCredentialStorage, config.sharedContainerIdentifier ? @"scid=container.id&" : @"", config.URLCache];
     XCTAssertNotEqualObjects(paramString, testParamString);
-    testParamString = [NSString stringWithFormat:@"aca=0&atmpTO=360.1&ckiplcy=1&ckisto=NSHTTPCookieStorage_%p&cnvty=5&crdsto=NSURLCredentialStorage_%p&dfrI=30.1&dis=1&idlTO=180.1&nst=3&opTO=720.1&ptcls=2&rcp=1&rdcm=2&rdp=0&%@setcki=0&ssle=0&urlcch=NSURLCache_%p", TNLUnwrappedCookieStorage(config.cookieStorage), TNLUnwrappedURLCredentialStorage(config.URLCredentialStorage), config.sharedContainerIdentifier ? @"scid=container.id&" : @"", TNLUnwrappedURLCache(config.URLCache)];
+    testParamString = [NSString stringWithFormat:@"aca=0&atmpTO=360.1&ckiplcy=1&ckisto=NSHTTPCookieStorage_%p&cnvty=%@&crdsto=NSURLCredentialStorage_%p&dfrI=30.1&dis=1&idlTO=180.1&nst=3&opTO=720.1&ptcls=2&rcp=1&rdcm=2&rdp=0&%@setcki=0&ssle=0&urlcch=NSURLCache_%p&xbim=1", TNLUnwrappedCookieStorage(config.cookieStorage), (connectivityOptionsForciblyDisabled) ? @0 : @5, TNLUnwrappedURLCredentialStorage(config.URLCredentialStorage), config.sharedContainerIdentifier ? @"scid=container.id&" : @"", TNLUnwrappedURLCache(config.URLCache)];
     XCTAssertEqualObjects(paramString, testParamString);
     [self runTestParamsEqualBetweenOriginal:params roundTrip:roundTripParams];
     XCTAssertEqualObjects(roundTripConfig, config);

--- a/TwitterNetworkLayerTests/TNLRequestOperationTest.m
+++ b/TwitterNetworkLayerTests/TNLRequestOperationTest.m
@@ -1103,7 +1103,7 @@ typedef void(^TestCallbackBlock)(TestJSONResponse *response);
     XCTAssertEqualObjects(completedResponse.operationError.domain, TNLErrorDomain);
     XCTAssertEqual(completedResponse.operationError.code, TNLErrorCodeRequestOperationIdleTimedOut);
     XCTAssertGreaterThan(completedResponse.metrics.totalDuration, idleTimeout);
-    NSTimeInterval withConnectionTimeoutDuration = completedResponse.metrics.totalDuration;
+    XCTAssertLessThan(completedResponse.metrics.totalDuration, idleTimeout + latency);
     NSLog(@"Idle Timeout Includes Initial Connection: %.3fs", completedResponse.metrics.totalDuration);
 
     // Idle Timeout Excludes Initial Connection
@@ -1117,8 +1117,7 @@ typedef void(^TestCallbackBlock)(TestJSONResponse *response);
     XCTAssertEqualObjects(completedResponse.operationError.domain, TNLErrorDomain);
     XCTAssertEqual(completedResponse.operationError.code, TNLErrorCodeRequestOperationIdleTimedOut);
     XCTAssertGreaterThan(completedResponse.metrics.totalDuration, latency);
-    XCTAssertGreaterThan(completedResponse.metrics.totalDuration, withConnectionTimeoutDuration + latency);
-    NSTimeInterval withoutConnectionTimeoutDuration = completedResponse.metrics.totalDuration;
+    XCTAssertGreaterThan(completedResponse.metrics.totalDuration, idleTimeout + latency);
     NSLog(@"Idle Timeout Excludes Initial Connection: %.3fs", completedResponse.metrics.totalDuration);
 
     // No Idle Timeout
@@ -1130,7 +1129,8 @@ typedef void(^TestCallbackBlock)(TestJSONResponse *response);
     [[TNLRequestOperationQueue defaultOperationQueue] enqueueRequestOperation:operation];
     [operation waitUntilFinishedWithoutBlockingRunLoop];
     XCTAssertNil(completedResponse.operationError);
-    XCTAssertGreaterThan(completedResponse.metrics.totalDuration, withoutConnectionTimeoutDuration);
+    XCTAssertGreaterThan(completedResponse.metrics.totalDuration, latency);
+    XCTAssertGreaterThan(completedResponse.metrics.totalDuration, latency * 2);
     NSLog(@"Idle Timeout Disabled: %.3fs", completedResponse.metrics.totalDuration);
 
     [TNLGlobalConfiguration sharedInstance].idleTimeoutMode = TNLGlobalConfigurationIdleTimeoutModeDefault;


### PR DESCRIPTION
- Xcode 11 support
- Improved Mac Catalyst support
- Use Network.framework for reachability on iOS 12+
- Expose `shouldUseExtendedBackgroundIdleMode`
- Disable `connectivityOptions` on `TNLRequestConfiguration` for iOS 13.0 (ok on iOS 13.1+)
- Add _expensive_ and _constrained_ conditions to the reachability flags on iOS 13+
- Add new iOS 13 metadata from transaction metrics
- Use __FILE_NAME__ instead of __FILE__
- Optimize `tnl_safeSubdataNoCopyWithRange:`
- Optimize NSDictionary `tnl_copyToMutable:uppercase:`
- Fix unreliable temporary file writing for across app runs