### PR TITLE
Update to v2.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,9 +508,44 @@ APPRetrieveBlobRequest *request = [[APPRetrieveBlobRequest alloc] initWithBlobId
  // APISendMessageResponse's implementation for messageId is just:
  //    return self.result[@"newMessageId"];
 ```
+
+## Using the Command-Line-Interface
+
+__Twitter Network Layer__ includes a target for building a _macOS_ tool called `tnlcli`.  You can build this tool
+run it from _Terminal_ from you _Mac_, similar to _cURL_ or other networking command line utilities.
+
+### Usage
+
+```
+Usage: tnlcli [options] url
+
+    Example: tnlcli --request-method HEAD --response-header-mode file,print --response-header-file response_headers.json https://google.com
+
+Argument Options:
+-----------------
+
+    --request-config-file <filepath>     TNLRequestConfiguration as a json file
+    --request-headers-file <filepath>    json file of key-value-pairs for using as headers
+    --request-body-file <filepath>       file for the HTTP body
+
+    --request-header "Field: Value"      A header to provide with the request (will override the header if also in the request header file). Can provide multiple headers.
+    --request-config "config: value"     A config setting for the TNLRequestConfiguration of the request (will override the config if also in the request config file). Can provide multiple configs.
+    --request-method <method>            HTTP Method from Section 9 in HTTP/1.1 spec (RFC 2616), such as GET, POST, HEAD, etc
+
+    --response-body-mode <mode>          "file" or "print" or a combo using commas
+    --response-body-file <filepath>      file for the response body to save to (requires "file" for --response-body-mode
+    --response-headers-mode <mode>       "file" or "print" or a combo using commas
+    --response-headers-file <filepath>   file for the response headers to save to (as json)
+
+    --dump-cert-chain-directory <dir>    directory for the certification chain to be dumped to (as DER files)
+
+    --verbose                            Will print verbose information and force the --response-body-mode and --responde-headers-mode to have "print".
+    --version                            Will print ther version information.
+```
+
 # License
 
-Copyright 2014-2018 Twitter, Inc.
+Copyright 2014-2020 Twitter, Inc.
 
 Licensed under the Apache License, Version 2.0: https://www.apache.org/licenses/LICENSE-2.0
 

--- a/Source/NSCachedURLResponse+TNLAdditions.h
+++ b/Source/NSCachedURLResponse+TNLAdditions.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 11/22/15.
-//  Copyright © 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/NSCachedURLResponse+TNLAdditions.m
+++ b/Source/NSCachedURLResponse+TNLAdditions.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 11/22/15.
-//  Copyright © 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "NSCachedURLResponse+TNLAdditions.h"

--- a/Source/NSCoder+TNLAdditions.h
+++ b/Source/NSCoder+TNLAdditions.h
@@ -2,8 +2,8 @@
 //  NSCoder+TNLAdditions.h
 //  TwitterNetworkLayer
 //
-//  Created by Nolan on 6/5/19.
-//  Copyright © 2019 Twitter. All rights reserved.
+//  Created on 6/5/19.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/NSCoder+TNLAdditions.m
+++ b/Source/NSCoder+TNLAdditions.m
@@ -2,8 +2,8 @@
 //  NSCoder+TNLAdditions.m
 //  TwitterNetworkLayer
 //
-//  Created by Nolan on 6/5/19.
-//  Copyright © 2019 Twitter. All rights reserved.
+//  Created on 6/5/19.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "NSCoder+TNLAdditions.h"

--- a/Source/NSData+TNLAdditions.h
+++ b/Source/NSData+TNLAdditions.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 9/9/16.
-//  Copyright © 2016 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/NSData+TNLAdditions.m
+++ b/Source/NSData+TNLAdditions.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 9/9/16.
-//  Copyright © 2016 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <objc/runtime.h>

--- a/Source/NSDictionary+TNLAdditions.h
+++ b/Source/NSDictionary+TNLAdditions.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 8/24/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/NSDictionary+TNLAdditions.m
+++ b/Source/NSDictionary+TNLAdditions.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 8/24/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "NSDictionary+TNLAdditions.h"

--- a/Source/NSHTTPCookieStorage+TNLAdditions.h
+++ b/Source/NSHTTPCookieStorage+TNLAdditions.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 2/9/15.
-//  Copyright (c) 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/NSHTTPCookieStorage+TNLAdditions.m
+++ b/Source/NSHTTPCookieStorage+TNLAdditions.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 2/9/15.
-//  Copyright (c) 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "NSHTTPCookieStorage+TNLAdditions.h"

--- a/Source/NSNumber+TNLURLCoding.h
+++ b/Source/NSNumber+TNLURLCoding.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 9/17/15.
-//  Copyright © 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
  For convenience, `TNLBoolean` is provided so that the object can be encoded as `@"true"` or
  `@"false"` based on the `boolValue` of the object always, regardless of encoding format or options.
  */
-@interface NSNumber (TNLURLCoding)
+@interface NSNumber (TNLBooleanCoding)
 
 /**
  Returns a `TNLBoolean` object that will encode as `@"true"` or `@"false"` based on the receiver's
@@ -38,6 +38,27 @@ NS_ASSUME_NONNULL_BEGIN
  Is the underlying number a boolean?
  */
 - (BOOL)tnl_isBoolean;
+
+@end
+
+/**
+ Category for converting numbers to strings
+ */
+@interface NSNumber (TNLStringCoding)
+
+/**
+ For most `NSNumber` instances, this is a faster way of getting the string value than `stringValue`
+ or `descriptionWithLocale:`.
+ Interally falls back to `descriptionWithLocale:` if it cannot convert (never encountered a case yet).
+
+ Random sampling on 124,000 NSNumbers on 1 thread (via Xcode Simulator on 10-core 3GHz Xeon W)
+ -[NSNumber stringValue] = 1.149726s
+ -[NSNumber tnl_quickStringValue] = 0.775426s
+ Pretty consistently achieves 33% speedup on average.
+ Using `TNLURLEncodeDictionary` for converting a `TNLRequestConfiguration` into an identifier string
+ (very regular within TNL) has more than 60% speedup.
+ */
+- (NSString *)tnl_quickStringValue;
 
 @end
 

--- a/Source/NSNumber+TNLURLCoding.m
+++ b/Source/NSNumber+TNLURLCoding.m
@@ -3,14 +3,14 @@
 //  TwitterNetworkLayer
 //
 //  Created on 9/17/15.
-//  Copyright © 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "NSNumber+TNLURLCoding.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@implementation NSNumber (TNLURLCoding)
+@implementation NSNumber (TNLBooleanCoding)
 
 - (BOOL)tnl_isBoolean
 {

--- a/Source/NSOperationQueue+TNLSafety.h
+++ b/Source/NSOperationQueue+TNLSafety.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 8/14/15.
-//  Copyright (c) 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/NSOperationQueue+TNLSafety.m
+++ b/Source/NSOperationQueue+TNLSafety.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 8/14/15.
-//  Copyright (c) 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "NSOperationQueue+TNLSafety.h"
@@ -84,16 +84,18 @@ static NSTimeInterval const TNLOperationSafetyGuardCheckForAlreadyFinishedOperat
         return;
     }
 
-    dispatch_async(_queue, ^{
+    tnl_dispatch_async_autoreleasing(_queue, ^{
         [self->_operations addObject:op];
         [op addObserver:self forKeyPath:@"isFinished" options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionInitial context:NULL];
 
         // There are race conditions where the isFinished KVO may never be observed.
         // Use this async check to weed out any early finishing operations that we didn't observe finishing.
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(TNLOperationSafetyGuardCheckForAlreadyFinishedOperationDelay * NSEC_PER_SEC)), self->_queue, ^{
-            if (op.isFinished) {
-                // Call our KVO observer to unify the code path for removing the observer
-                [self observeValueForKeyPath:@"isFinished" ofObject:op change:@{ NSKeyValueChangeNewKey : @YES } context:NULL];
+            @autoreleasepool {
+                if (op.isFinished) {
+                    // Call our KVO observer to unify the code path for removing the observer
+                    [self observeValueForKeyPath:@"isFinished" ofObject:op change:@{ NSKeyValueChangeNewKey : @YES } context:NULL];
+                }
             }
         });
     });
@@ -119,7 +121,9 @@ static NSTimeInterval const TNLOperationSafetyGuardCheckForAlreadyFinishedOperat
     if ([keyPath isEqualToString:@"isFinished"] && [change[NSKeyValueChangeNewKey] boolValue]) {
         NSOperation *op = object;
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(TNLOperationSafetyGuardRemoveOperationAfterFinishedDelay * NSEC_PER_SEC)), _queue, ^{
-            [self _tnl_background_removeOperation:op];
+            @autoreleasepool {
+                [self _tnl_background_removeOperation:op];
+            }
         });
     }
 }

--- a/Source/NSURL+TNLAdditions.h
+++ b/Source/NSURL+TNLAdditions.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 12/20/16.
-//  Copyright © 2016 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/NSURL+TNLAdditions.m
+++ b/Source/NSURL+TNLAdditions.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 12/20/16.
-//  Copyright © 2016 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "NSURL+TNLAdditions.h"

--- a/Source/NSURLAuthenticationChallenge+TNLAdditions.h
+++ b/Source/NSURLAuthenticationChallenge+TNLAdditions.h
@@ -1,0 +1,34 @@
+//
+//  NSURLAuthenticationChallenge+TNLAdditions.h
+//  TwitterNetworkLayer
+//
+//  Created on 3/17/20.
+//  Copyright © 2020 Twitter. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+//! `NSURLAuthenticationMethodOAuth` which Apple uses but doesn't expose
+FOUNDATION_EXTERN NSString * const TNLNSURLAuthenticationMethodOAuth;
+//! `NSURLAuthenticationMethodOAuth2` which Apple uses but doesn't expose
+FOUNDATION_EXTERN NSString * const TNLNSURLAuthenticationMethodOAuth2;
+
+//! Is the given challenge method a password challenge?
+FOUNDATION_EXTERN BOOL TNLIsPasswordChallengeAuthenticationChallengeMethod(NSString * __nullable method);
+
+/**
+ __TNL__ additions for `NSURLAuthenticationChallenge`
+ */
+@interface NSURLAuthenticationChallenge (TNLAdditions)
+
+/**
+ @return `YES` if this challenge is an HTTP WWW Authenticate based challenge from an HTTP 401.
+ @note By default, __TNL__ will reject this kind of challenge's protection space if there is no `proposedCredential`, use `TNLAuthenticationChallengeHandler` to specify a different behavior if desired.  This differs from `NSURLSession` default behavior!
+ */
+- (BOOL)tnl_isHTTPWWWAuthenticationChallenge;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/NSURLAuthenticationChallenge+TNLAdditions.m
+++ b/Source/NSURLAuthenticationChallenge+TNLAdditions.m
@@ -1,0 +1,64 @@
+//
+//  NSURLAuthenticationChallenge+TNLAdditions.m
+//  TwitterNetworkLayer
+//
+//  Created on 3/17/20.
+//  Copyright © 2020 Twitter. All rights reserved.
+//
+
+#import "NSURLAuthenticationChallenge+TNLAdditions.h"
+
+NSString * const TNLNSURLAuthenticationMethodOAuth = @"NSURLAuthenticationMethodOAuth";
+NSString * const TNLNSURLAuthenticationMethodOAuth2 = @"NSURLAuthenticationMethodOAuth2";
+
+BOOL TNLIsPasswordChallengeAuthenticationChallengeMethod(NSString * __nullable method)
+{
+    return [method isEqualToString:NSURLAuthenticationMethodHTTPBasic] ||
+           [method isEqualToString:TNLNSURLAuthenticationMethodOAuth] ||
+           [method isEqualToString:TNLNSURLAuthenticationMethodOAuth2];
+}
+
+@implementation NSURLAuthenticationChallenge (TNLAdditions)
+
+- (BOOL)tnl_isHTTPWWWAuthenticationChallenge
+{
+    // Must be an HTTP response
+    NSHTTPURLResponse *failureResponse = (id)self.failureResponse;
+    if (![failureResponse isKindOfClass:[NSHTTPURLResponse class]]) {
+        return NO;
+    }
+
+    // Must be an HTTP 401
+    if (401 != failureResponse.statusCode) {
+        return NO;
+    }
+
+    NSURLProtectionSpace *protectionSpace = self.protectionSpace;
+
+    // Must be fore the `http` or `https` protocols
+    if (![protectionSpace.protocol isEqualToString:NSURLProtectionSpaceHTTPS] && ![protectionSpace.proxyType isEqualToString:NSURLProtectionSpaceHTTP]) {
+        return NO;
+    }
+
+    // Uncomment to log WWW-Authenticate header for debugging
+//#if DEBUG
+//    NSLog(@"WWW-Authenticate: %@", [failureResponse valueForHTTPHeaderField:@"WWW-Authenticate"]);
+//#endif
+
+    // Must have an auth `realm`
+    if (!protectionSpace.realm) {
+        return NO;
+    }
+
+    NSString * method = protectionSpace.authenticationMethod;
+
+    // Password auth challenge
+    if (TNLIsPasswordChallengeAuthenticationChallengeMethod(method)) {
+        return YES;
+    }
+
+    // other HTTP challenge, maybe digest?
+    return NO;
+}
+
+@end

--- a/Source/NSURLCache+TNLAdditions.h
+++ b/Source/NSURLCache+TNLAdditions.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 8/12/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
  This is useful for setting on a `TNLRequestConfiguration` so that if the configuration is reused
  for multiple `TNLRequestOperation` instances, the `NSURLCache` that will be used will be the
  `[NSURLCache sharedURLCache]` at the time the `TNLRequestOperation` run.  This is in contrast to
- having the `[TNLRequestConfiguration URLCached]` being set to the `[NSURLCache sharedURLCache]`
+ having the `[TNLRequestConfiguration URLCache]` being set to the `[NSURLCache sharedURLCache]`
  since that will not updated as the shared `NSURLCache` is updated.
 
  @return the shared `NSURLCache` proxy

--- a/Source/NSURLCache+TNLAdditions.m
+++ b/Source/NSURLCache+TNLAdditions.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 8/12/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #include <objc/message.h>

--- a/Source/NSURLCredentialStorage+TNLAdditions.h
+++ b/Source/NSURLCredentialStorage+TNLAdditions.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 12/5/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/NSURLCredentialStorage+TNLAdditions.m
+++ b/Source/NSURLCredentialStorage+TNLAdditions.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 12/5/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "NSURLCredentialStorage+TNLAdditions.h"

--- a/Source/NSURLRequest+TNLAdditions.h
+++ b/Source/NSURLRequest+TNLAdditions.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 11/9/16.
-//  Copyright © 2016 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/NSURLRequest+TNLAdditions.m
+++ b/Source/NSURLRequest+TNLAdditions.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 11/9/16.
-//  Copyright © 2016 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "NSURL+TNLAdditions.h"

--- a/Source/NSURLResponse+TNLAdditions.h
+++ b/Source/NSURLResponse+TNLAdditions.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 11/13/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -29,12 +29,19 @@ NS_ASSUME_NONNULL_BEGIN
 @interface NSHTTPURLResponse (TNLAdditions)
 
 /**
- Convenience method for converting the `"Retry-After"` value into a delay.
+ Convenience method for converting the `"Retry-After"` value into a value.
  Returns `NSDate` if the string was for a date.
  Returns `NSNumber` wrapped `NSTimeInterval` (aka `double`) if the string was for a delay.
  Returns `nil` if the string could not be parsed.
  */
 + (nullable id)tnl_parseRetryAfterValueFromString:(nullable NSString *)retryAfterValueString;
+
+/**
+ Convenience method for converting the value of `"Retry-After"` into a delay.
+ Provide the `id` result from `tnl_parseRetryAfterValueFromString:`.
+ Returns `0` on `nil` or unexpected _retryAfterValue_.
+ */
++ (NSTimeInterval)tnl_delayFromRetryAfterValue:(nullable id)retryAfterValue;
 
 /**
  Calls `tnl_parseRetryAfterValueFromString:` with the `"Retry-After"` response header's value as the

--- a/Source/NSURLResponse+TNLAdditions.m
+++ b/Source/NSURLResponse+TNLAdditions.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 11/13/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #include <objc/runtime.h>
@@ -78,6 +78,16 @@ static const char TNLContentEncodingAssociatedObjectKey[] = "tnl.content.encodin
         // value is a string that MUST be an HTTP date (otherwise, the value is invalid)
         return TNLHTTPDateFromString(retryAfterStringValue, NULL);
     }
+}
+
++ (NSTimeInterval)tnl_delayFromRetryAfterValue:(nullable id)retryAfterValue
+{
+    if ([retryAfterValue isKindOfClass:[NSNumber class]]) {
+        return [(NSNumber *)retryAfterValue doubleValue];
+    } else if ([retryAfterValue isKindOfClass:[NSDate class]]) {
+        return [(NSDate *)retryAfterValue timeIntervalSinceNow];
+    }
+    return 0;
 }
 
 - (nullable id)tnl_parsedRetryAfterValue

--- a/Source/NSURLSessionConfiguration+TNLAdditions.h
+++ b/Source/NSURLSessionConfiguration+TNLAdditions.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 8/12/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/NSURLSessionConfiguration+TNLAdditions.m
+++ b/Source/NSURLSessionConfiguration+TNLAdditions.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 8/12/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "NSURLSessionConfiguration+TNLAdditions.h"

--- a/Source/NSURLSessionTaskMetrics+TNLAdditions.h
+++ b/Source/NSURLSessionTaskMetrics+TNLAdditions.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 7/25/16.
-//  Copyright © 2016 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -36,6 +36,11 @@ NS_ASSUME_NONNULL_BEGIN
  A dictionary representation of the transaction metrics
  */
 - (NSDictionary<NSString *, id> *)tnl_dictionaryValue;
+
+/**
+ A dictionary description of the transaction metrics that is serializable
+ */
+- (NSDictionary<NSString *, id> *)tnl_dictionaryDescription;
 
 /**
  returns the `resourceFetchType` as a readable debug string

--- a/Source/TNLAttemptMetaData.h
+++ b/Source/TNLAttemptMetaData.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 1/16/15.
-//  Copyright (c) 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <TwitterNetworkLayer/TNLPriority.h>
@@ -19,6 +19,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface TNLAttemptMetaData : NSObject <NSSecureCoding>
 /** The meta data as a dictionary */
 - (NSDictionary<NSString *, id> *)metaDataDictionary;
+/** Meta data in a serializable format (can be lossy and drop info if not serializable!) */
+- (NSDictionary<NSString *, id> *)dictionaryDescription;
 @end
 
 /**

--- a/Source/TNLAttemptMetaData.m
+++ b/Source/TNLAttemptMetaData.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 1/16/15.
-//  Copyright (c) 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNLAttemptMetaData_Project.h"
@@ -15,7 +15,7 @@ static NSString * const kFinalKey = @"final";
 
 @interface TNLAttemptMetaData ()
 {
-    NSDictionary *_metaDataDictionary;
+    NSDictionary<NSString *, id> *_metaDataDictionary;
     BOOL _final;
 }
 @end
@@ -94,6 +94,28 @@ static NSString * const kFinalKey = @"final";
 
     _final = YES;
     _metaDataDictionary = [_metaDataDictionary copy];
+}
+
+- (NSDictionary<NSString *, id> *)dictionaryDescription
+{
+    NSMutableDictionary *d = [[NSMutableDictionary alloc] initWithCapacity:_metaDataDictionary.count];
+    [_metaDataDictionary enumerateKeysAndObjectsUsingBlock:^(NSString *key, id obj, BOOL *stop) {
+        if ([obj isKindOfClass:[NSString class]] || [obj isKindOfClass:[NSNumber class]]) {
+            d[key] = obj;
+            return;
+        }
+        if ([obj isKindOfClass:[NSData class]]) {
+            const NSUInteger length = [(NSData *)obj length];
+            if (length <= 256) {
+                d[key] = [(NSData *)obj base64EncodedStringWithOptions:0];
+            } else {
+                d[key] = [NSString stringWithFormat:@"NSData: %lu bytes", (unsigned long)length];
+            }
+            return;
+        }
+        // other types, just skip
+    }];
+    return d;
 }
 
 @end

--- a/Source/TNLAttemptMetaData_Project.h
+++ b/Source/TNLAttemptMetaData_Project.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 1/15/15.
-//  Copyright (c) 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNLAttemptMetaData.h"

--- a/Source/TNLAttemptMetrics.h
+++ b/Source/TNLAttemptMetrics.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 1/15/15.
-//  Copyright (c) 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <TwitterNetworkLayer/TNLCommunicationAgent.h>
@@ -140,6 +140,9 @@ static const NSInteger TNLAttemptCompleteDispositionCount = 3;
 
 /** calculate the duration of the attempt */
 - (NSTimeInterval)duration;
+
+/** description of the attempt metrics in a serializable dictionary */
+- (NSDictionary *)dictionaryDescription:(BOOL)verbose;
 
 @end
 

--- a/Source/TNLAttemptMetrics_Project.h
+++ b/Source/TNLAttemptMetrics_Project.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 1/15/15.
-//  Copyright (c) 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNLAttemptMetrics.h"

--- a/Source/TNLAuthenticationChallengeHandler.h
+++ b/Source/TNLAuthenticationChallengeHandler.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 4/10/18.
-//  Copyright © 2018 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -12,7 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class TNLRequestOperation;
 
-typedef void(^TNLURLSessionAuthChallengeCompletionBlock)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential * __nullable credential);
+typedef void(^TNLURLSessionAuthChallengeCompletionBlock)(NSURLSessionAuthChallengeDisposition disposition,
+                                                         id __nullable credentialOrCancelContext);
 
 /**
  Protocol for handling authentication challenges
@@ -31,12 +32,13 @@ typedef void(^TNLURLSessionAuthChallengeCompletionBlock)(NSURLSessionAuthChallen
 
  See `NSURLSessionAuthChallengeDisposition`
 
-    typedef void(^TNLURLSessionAuthChallengeCompletionBlock)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *credential);
+    typedef void(^TNLURLSessionAuthChallengeCompletionBlock)(NSURLSessionAuthChallengeDisposition disposition, id credentialOrCancelContext);
 
  - _disposition_
    - the way to handle the _challenge_ (default == `NSURLSessionAuthChallengePerformDefaultHandling`)
- - _credential_
-   - the credential to use in handling the _challenge_
+ - _credentialOrCancelContext_
+   - the credential to use in handling the _challenge_ for `NSURLSessionAuthChallengeUseCredential`
+   - the context to the error that will be yielded from `NSURLSessionAuthChallengeCancelAuthenticationChallenge` (using
 
  @param challenge  The `NSURLAuthenticationChallenge` to respond to
  @param op The `TNLRequestOperation` that triggered the challenge, `nil` is a global challenge

--- a/Source/TNLBackgroundURLSessionTaskOperationManager.h
+++ b/Source/TNLBackgroundURLSessionTaskOperationManager.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 8/6/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/TNLBackgroundURLSessionTaskOperationManager.m
+++ b/Source/TNLBackgroundURLSessionTaskOperationManager.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 8/6/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <mach/mach_time.h>

--- a/Source/TNLBackoff.h
+++ b/Source/TNLBackoff.h
@@ -1,0 +1,150 @@
+//
+//  TNLBackoff.h
+//  TwitterNetworkLayer
+//
+//  Created on 3/31/20.
+//  Copyright © 2020 Twitter. All rights reserved.
+//
+
+#import <TwitterNetworkLayer/TNLHTTP.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+#pragma mark Constants
+
+//! Default "Backoff" value for the `TNLSimpleBackoffBehaviorProvider`
+FOUNDATION_EXTERN const NSTimeInterval TNLSimpleRetryAfterBackoffValueDefault;
+//! Minimum "Backoff" value for the `TNLSimpleBackoffBehaviorProvider`
+FOUNDATION_EXTERN const NSTimeInterval TNLSimpleRetryAfterBackoffValueMinimum;
+//! Maximum "Backoff" value before reverting to use the `Default` value for the `TNLSimpleBackoffBehaviorProvider`
+FOUNDATION_EXTERN const NSTimeInterval TNLSimpleRetryAfterMaximumBackoffValueBeforeTreatedAsGoAway;
+
+#pragma mark Structs
+
+//! `TNLBackoffBehavior` struct to encapsulate the settings that control "Backoff" behavior
+typedef struct TNLBackoffBehavior_T {
+    /**
+     The "Backoff" duration...
+     how long all future enqueued matching requests will wait before any fire (based on the `TNLGlobalConfigurationBackoffMode`).
+
+     If `0.0` or less, no "backoff" will happen.
+     */
+    NSTimeInterval backoffDuration;
+    /**
+     The "Serialize Requests" duration...
+     how long requests being enqueued will continue to execute serially after the backoff signal was
+     encountered (based on the `TNLGlobalConfigurationBackoffMode`).
+
+     Once this duration expires (or if `<= 0.0`),
+     serialization of requests will continue as long as there are requests in the queue that were serialized
+     (which will continue to enqueue serially while there is an outstanding "backoff" duration running).
+     Requests being sent after both "Serialize Requests" and "Backoff" durations have expired will
+     wait for the existing serially enqueued requests to complete before executing concurrently.
+
+     Default == `0.0`
+     */
+    NSTimeInterval serializeDuration;
+    /**
+     The minimum amount of time to elapse between the _start_ of each serial request.
+     This does not indicate the duration between serial requests...that will vary based on the duration of any given request's duration.
+
+     Default == `0.0`
+     */
+    NSTimeInterval serialDelayDuration;
+} TNLBackoffBehavior;
+
+//! Make a `TNLBackoffBehavior`
+NS_INLINE TNLBackoffBehavior TNLBackoffBehaviorMake(NSTimeInterval backoff,
+                                                    NSTimeInterval serialize,
+                                                    NSTimeInterval delay)
+{
+    TNLBackoffBehavior behavior;
+    behavior.backoffDuration = backoff;
+    behavior.serializeDuration = serialize;
+    behavior.serialDelayDuration = delay;
+    return behavior;
+}
+
+//! Make a disabled `TNLBackoffBehavior`
+#define TNLBackoffBehaviorDisabled() TNLBackoffBehaviorMake(0, 0, 0)
+
+#pragma mark Protocols
+
+/**
+ The `TNLBackoffBehaviorProvider` protocol provides the callback for selecting the
+ `TNLBackoffBehavior` for an encountered backoff signal.
+
+ Due to opaque nature of signaling backoffs, only the _URL_ and _headers_ are provided.
+ */
+@protocol TNLBackoffBehaviorProvider <NSObject>
+
+/**
+ The callback to provide the backoff behavior for a `503` _Service Unavailable_ signal.
+ @param URL the `NSURL` of the request that raised the signal.
+ @param headers the HTTP response headers of the request that raised the signal.
+ @return the `TNLBackoffBehavior` for how to backoff (or not).
+ */
+- (TNLBackoffBehavior)tnl_backoffBehaviorForURL:(NSURL *)URL
+                                responseHeaders:(nullable NSDictionary<NSString *, NSString *> *)headers;
+
+@end
+
+/**
+ The `TNLBackoffSignaler` protocol provides an abstraction point for deciding if a backoff signal should be raised or not.
+ */
+@protocol TNLBackoffSignaler <NSObject>
+
+/**
+ The callback to check if the given response information should signal a backoff.
+ @param URL the `NSURL` of the request that might raise the signal.
+ @param host the (optional) host override for the request that might raise the signal.
+ @param statusCode the `TNLHTTPStatusCode` of the response that might raise the signal.
+ @param responseHeaders the HTTP headers of the response that might raise the signal.
+ @return `YES` if backoff signal should be raised, `NO` otherwise.
+ */
+- (BOOL)tnl_shouldSignalBackoffForURL:(NSURL *)URL
+                                 host:(nullable NSString *)host
+                           statusCode:(TNLHTTPStatusCode)statusCode
+                      responseHeaders:(nullable NSDictionary<NSString *, NSString *> *)responseHeaders;
+
+@end
+
+#pragma mark Simple Concrete Classes (Default Implementations)
+
+/**
+ A simple `TNLBackoffBehaviorProvider` implemenation.
+
+ The behavior's `backoffDuration` will be set to the `"Retry-After"` duration
+ (computed from the value either being a date or a duration in seconds).
+ If no `"Retry-After"` header is present, `TNLSimpleRetryAfterBackoffValueDefault` will be used.
+ If the duration would be greater than `TNLSimpleRetryAfterMaximumBackoffValueBeforeTreatedAsGoAway`,
+ then `TNLSimpleRetryAfterBackoffValueDefault` will be used.
+ The duration will have a minimum value of `TNLSimpleRetryAfterBackoffValueMinimum`.
+
+ The default **TNL** behavior provider is an instance of this class with `serializeDuration` set to `0.0`.
+ */
+@interface TNLSimpleBackoffBehaviorProvider : NSObject <TNLBackoffBehaviorProvider>
+
+/**
+ The `serializeDuration` for any `TNLBackoffBehavior` this provider would return.
+ Default value == `0.0`
+ */
+@property (atomic) NSTimeInterval serializeDuration;
+
+/**
+ The `serialDelayDuration` for any `TNLBackoffBehavior` this provider would return.
+ Default value == `0.0`
+ */
+@property (atomic) NSTimeInterval serialDelayDuration;
+
+@end
+
+/**
+ A simple `TNLBackoffSignaler` implementation.
+
+ Simply triggers the backoff signal if the _statusCode_ is `503` _Service Unavailable_.
+ */
+@interface TNLSimpleBackoffSignaler : NSObject <TNLBackoffSignaler>
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/TNLBackoff.m
+++ b/Source/TNLBackoff.m
@@ -1,0 +1,55 @@
+//
+//  TNLBackoff.m
+//  TwitterNetworkLayer
+//
+//  Created on 3/31/20.
+//  Copyright © 2020 Twitter. All rights reserved.
+//
+
+#import "NSDictionary+TNLAdditions.h"
+#import "NSURLResponse+TNLAdditions.h"
+#import "TNLBackoff.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+const NSTimeInterval TNLSimpleRetryAfterBackoffValueDefault = 1.0;
+const NSTimeInterval TNLSimpleRetryAfterBackoffValueMinimum = 0.1;
+const NSTimeInterval TNLSimpleRetryAfterMaximumBackoffValueBeforeTreatedAsGoAway = 10.0;
+
+@implementation TNLSimpleBackoffBehaviorProvider
+
+- (TNLBackoffBehavior)tnl_backoffBehaviorForURL:(NSURL *)URL
+                                responseHeaders:(nullable NSDictionary<NSString *, NSString *> *)headers
+{
+    NSTimeInterval backoff = TNLSimpleRetryAfterBackoffValueDefault;
+
+    NSString *retryAfterString = [headers tnl_objectsForCaseInsensitiveKey:@"retry-after"].firstObject;
+    id retryAfterValue = [NSHTTPURLResponse tnl_parseRetryAfterValueFromString:retryAfterString];
+    if (retryAfterValue) {
+        backoff = [NSHTTPURLResponse tnl_delayFromRetryAfterValue:retryAfterValue];
+    }
+
+    if (backoff < TNLSimpleRetryAfterBackoffValueMinimum) {
+        backoff = TNLSimpleRetryAfterBackoffValueMinimum;
+    } else if (backoff > TNLSimpleRetryAfterMaximumBackoffValueBeforeTreatedAsGoAway) {
+        backoff = TNLSimpleRetryAfterBackoffValueDefault;
+    }
+
+    return TNLBackoffBehaviorMake(backoff, self.serializeDuration, self.serialDelayDuration);
+}
+
+@end
+
+@implementation TNLSimpleBackoffSignaler
+
+- (BOOL)tnl_shouldSignalBackoffForURL:(NSURL *)URL
+                                 host:(nullable NSString *)host
+                           statusCode:(TNLHTTPStatusCode)statusCode
+                      responseHeaders:(nullable NSDictionary<NSString *,NSString *> *)responseHeaders
+{
+    return TNLHTTPStatusCodeServiceUnavailable == statusCode;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/TNLCommunicationAgent.h
+++ b/Source/TNLCommunicationAgent.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 5/2/16.
-//  Copyright © 2016 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -55,10 +55,13 @@ typedef NS_ENUM(NSInteger, TNLNetworkReachabilityStatus)
     TNLNetworkReachabilityUndetermined = -1,
     /** Unreachable */
     TNLNetworkReachabilityNotReachable = 0,
-    /** reachable via 802.11 WiFi */
-    TNLNetworkReachabilityReachableViaWiFi = 1,
+    /** reachable via 802.3 Ethernet or 802.11 WiFi */
+    TNLNetworkReachabilityReachableViaEthernet = 1,
     /** reachabile via WWAN (cellular) */
     TNLNetworkReachabilityReachableViaWWAN = 2,
+
+    /** deprecated, use `TNLNetworkReachabilityReachableViaEthernet` instead */
+    TNLNetworkReachabilityReachableViaWiFi __attribute__((deprecated)) = TNLNetworkReachabilityReachableViaEthernet,
 };
 
 //! Convert a `TNLNetworkReachabilityStatus` to an `NSString`
@@ -200,6 +203,9 @@ typedef void(^TNLCommunicationAgentIdentifyCaptivePortalStatusCallback)(TNLCapti
 
 /** the network host for the agent */
 @property (nonatomic, copy, readonly) NSString *host;
+
+/** if there is a cellular interface or not */
+@property (class, nonatomic, readonly) BOOL hasCellularInterface;
 
 /** designated initializer */
 - (instancetype)initWithInternetReachabilityHost:(NSString *)host NS_DESIGNATED_INITIALIZER;
@@ -352,6 +358,9 @@ typedef void(^TNLCommunicationAgentIdentifyCaptivePortalStatusCallback)(TNLCapti
 @property (nonatomic, readonly) BOOL allowsVOIP;
 
 @end
+
+//! Convert a `TNLCarrierInfo` into a serializable dictionary, will contain `[NSNull null]` for `nil` properties
+FOUNDATION_EXTERN NSDictionary<NSString *, id> *TNLCarrierInfoToDictionaryDescription(id<TNLCarrierInfo> carrierInfo);
 
 NS_ASSUME_NONNULL_END
 

--- a/Source/TNLCommunicationAgent_Project.h
+++ b/Source/TNLCommunicationAgent_Project.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 03/29/2018.
-//  Copyright © 2018 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 

--- a/Source/TNLContentCoding.h
+++ b/Source/TNLContentCoding.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 11/19/16.
-//  Copyright © 2016 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/TNLError.h
+++ b/Source/TNLError.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 7/17/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -21,9 +21,12 @@ FOUNDATION_EXTERN NSString * const TNLErrorCancelSourceLocalizedDescriptionKey;
 FOUNDATION_EXTERN NSString * const TNLErrorCodeStringKey;
 FOUNDATION_EXTERN NSString * const TNLErrorHostKey;
 FOUNDATION_EXTERN NSString * const TNLErrorRequestKey;
+FOUNDATION_EXTERN NSString * const TNLErrorResponseKey;
 FOUNDATION_EXTERN NSString * const TNLErrorProtectionSpaceHostKey;
 FOUNDATION_EXTERN NSString * const TNLErrorCertificateChainDescriptionsKey;
 FOUNDATION_EXTERN NSString * const TNLErrorAuthenticationChallengeMethodKey;
+FOUNDATION_EXTERN NSString * const TNLErrorAuthenticationChallengeRealmKey;
+FOUNDATION_EXTERN NSString * const TNLErrorAuthenticationChallengeCancelContextKey;
 
 #define TNLErrorCodePageSize        (100)
 

--- a/Source/TNLError.m
+++ b/Source/TNLError.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 7/17/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNL_Project.h"
@@ -22,9 +22,12 @@ NSString * const TNLErrorCancelSourceLocalizedDescriptionKey = @"localizedCancel
 NSString * const TNLErrorCodeStringKey = @"TNLError.string";
 NSString * const TNLErrorHostKey = @"host";
 NSString * const TNLErrorRequestKey = @"request";
+NSString * const TNLErrorResponseKey = @"response";
 NSString * const TNLErrorProtectionSpaceHostKey = @"protectionSpaceHost";
 NSString * const TNLErrorCertificateChainDescriptionsKey = @"certificateChainDescriptions";
-NSString * const TNLErrorAuthenticationChallengeMethodKey = @"authenticationChallengeMethod";
+NSString * const TNLErrorAuthenticationChallengeMethodKey = @"authChallengeMethod";
+NSString * const TNLErrorAuthenticationChallengeRealmKey = @"authChallengeRealm";
+NSString * const TNLErrorAuthenticationChallengeCancelContextKey = @"authChallengeCancelContext";
 
 NSString *TNLErrorCodeToString(TNLErrorCode code)
 {

--- a/Source/TNLGlobalConfiguration_Project.h
+++ b/Source/TNLGlobalConfiguration_Project.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 12/1/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #include <TargetConditionals.h>

--- a/Source/TNLHTTP.h
+++ b/Source/TNLHTTP.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 6/9/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -218,7 +218,7 @@ NS_INLINE BOOL TNLHTTPStatusCodeIsDefinitiveSuccess(TNLHTTPStatusCode statusCode
     }
 }
 
-// HTTP Content-Type constants
+#pragma mark - HTTP Content-Type constants
 
 FOUNDATION_EXTERN NSString * const TNLHTTPContentTypeJPEGImage;
 FOUNDATION_EXTERN NSString * const TNLHTTPContentTypeQuicktimeVideo;
@@ -230,6 +230,8 @@ FOUNDATION_EXTERN NSString * const TNLHTTPContentTypeURLEncodedString;
 
 //! Is the content type a textual format (limited to UTF8 [default] and ASCII currently), helpful for determining if something is printable or compressable
 FOUNDATION_EXTERN BOOL TNLHTTPContentTypeIsTextual(NSString * __nullable contentType);
+
+#pragma mark - HTTP Dates
 
 /**
  Enum for the different HTTP formats specified by the HTTP specification.

--- a/Source/TNLHTTP.m
+++ b/Source/TNLHTTP.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 6/9/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNL_Project.h"

--- a/Source/TNLHTTPHeaderProvider.h
+++ b/Source/TNLHTTPHeaderProvider.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 4/13/15.
-//  Copyright (c) 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/TNLHTTPRequest.h
+++ b/Source/TNLHTTPRequest.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 2/28/15.
-//  Copyright (c) 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <TwitterNetworkLayer/TNLRequest.h>

--- a/Source/TNLHTTPRequest.m
+++ b/Source/TNLHTTPRequest.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 2/28/15.
-//  Copyright (c) 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "NSDictionary+TNLAdditions.h"

--- a/Source/TNLHostSanitizer.h
+++ b/Source/TNLHostSanitizer.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 11/21/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/TNLInternalKeys.h
+++ b/Source/TNLInternalKeys.h
@@ -2,8 +2,8 @@
 //  TNLInternalKeys.h
 //  TwitterNetworkLayer
 //
-//  Created by Nolan O'Brien on 6/15/18.
-//  Copyright © 2018 Twitter. All rights reserved.
+//  Created on 6/15/18.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #pragma mark Global Keys

--- a/Source/TNLLRUCache.h
+++ b/Source/TNLLRUCache.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/27/15.
-//  Copyright © 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/TNLLRUCache.m
+++ b/Source/TNLLRUCache.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/27/15.
-//  Copyright © 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNL_Project.h"

--- a/Source/TNLLogger.h
+++ b/Source/TNLLogger.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 3/23/16.
-//  Copyright © 2016 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/TNLNetwork.h
+++ b/Source/TNLNetwork.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 9/15/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -105,27 +105,39 @@ NS_ROOT_CLASS
 + (BOOL)hasExecutingNetworkConnections;
 
 /**
- Provide a signal to __TNL__ that a service unavailable HTTP status code was encountered.
- This will be used for backing off requests (within __TNL__) to the provided _URL_ `host`.
+ Provide a signal to __TNL__ that a backoff signaling HTTP response was encountered.
+ This will be used for backing off requests (within __TNL__) to the provided _URL_ `host` (or provided _host_ if a different host from the _URL_ is preferred).
+ @param URL the `NSURL` of the backoff signaling response
+ @param host the optional host to use instead of the _URL_ `host`
+ @param headers the HTTP headers in the response accompanying the backoff signal
  */
-+ (void)serviceUnavailableEncounteredForURL:(NSURL *)URL
-                            retryAfterDelay:(NSTimeInterval)delay;
++ (void)backoffSignalEncounteredForURL:(NSURL *)URL
+                                  host:(nullable NSString *)host
+                   responseHTTPHeaders:(nullable NSDictionary<NSString *, NSString *> *)headers;
 
 /**
  Provide a signal to __TNL__ when an HTTP response was encountered.
- If the `statusCode` is `TNLHTTPStatusCodeServiceUnavailable`, then
- `serviceUnavailableEncounteredForHost:retryAfterDelay:` will be called with the parsed
- `"Retry-After"` value.
+ Checks `[TNLGlobalConfiguration backoffSignaler]` and if backoff is signaled,
+ then `backoffSignalEncounteredForHost:host:responseHTTPHeaders:` will be called with the response's
+ `allHeaderFields`.
+ @param response the `NSHTTPURLResponse` to examine
+ @param host the optional host to use instead of the _response_ `URL.host`
  */
-+ (void)HTTPURLResponseEncounteredOutsideOfTNL:(NSHTTPURLResponse *)response;
++ (void)HTTPURLResponseEncounteredOutsideOfTNL:(NSHTTPURLResponse *)response
+                                          host:(nullable NSString *)host;
 
 /**
  Apply backoff dependencies to a given `NSOperation` (from outside of __TNL__) that depends on a
- service unavailable backoff be resolved before it should start.
+ backoff be resolved before it should start.
+ @param op the `NSOperation` to apply dependencies to
+ @param URL the `NSURL` of the operation
+ @param host the optional host for the operation (will be used instead of the `host` from the given _URL_ for keying off of)
+ @param isLongPoll whether or not the operation is a long polling operation
  */
-+ (void)applyServiceUnavailableBackoffDependenciesToOperation:(NSOperation *)op
-                                                      withURL:(NSURL *)URL
-                                            isLongPollRequest:(BOOL)isLongPoll;
++ (void)applyBackoffDependenciesToOperation:(NSOperation *)op
+                                    withURL:(NSURL *)URL
+                                       host:(nullable NSString *)host
+                          isLongPollRequest:(BOOL)isLongPoll;
 
 @end
 

--- a/Source/TNLNetwork.m
+++ b/Source/TNLNetwork.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 9/15/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNLNetwork.h"

--- a/Source/TNLNetworkObserver.h
+++ b/Source/TNLNetworkObserver.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 6/11/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <TwitterNetworkLayer/TNLAttemptMetrics.h>
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param op              The source `TNLRequestOperation`
  @param URLRequest      The `NSURLRequest` used in the attempt
- @param type            The `TNLAttemptType` of the attempt
+ @param metrics         The `TNLAttemptMetrics` of the attempt
  */
 - (void)tnl_requestOperation:(TNLRequestOperation *)op
       didStartAttemptRequest:(NSURLRequest *)URLRequest

--- a/Source/TNLParameterCollection.h
+++ b/Source/TNLParameterCollection.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/24/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/TNLParameterCollection.m
+++ b/Source/TNLParameterCollection.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/24/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNL_Project.h"

--- a/Source/TNLPriority.h
+++ b/Source/TNLPriority.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 7/17/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/TNLPriority.m
+++ b/Source/TNLPriority.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 7/17/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <sys/sysctl.h>

--- a/Source/TNLPseudoURLProtocol.h
+++ b/Source/TNLPseudoURLProtocol.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/29/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/TNLPseudoURLProtocol.m
+++ b/Source/TNLPseudoURLProtocol.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/29/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "NSData+TNLAdditions.h"
@@ -70,21 +70,21 @@ static void _executeClientBlock(SELF_ARG,
                                                                                userInfo:(config) ? @{ @"config" : [config copy] } : nil
                                                                           storagePolicy:NSURLCacheStorageAllowed];
 
-    dispatch_barrier_async(sOriginQueue, ^{
+    tnl_dispatch_barrier_async_autoreleasing(sOriginQueue, ^{
         sOriginToResponseDictionary[_UnderlyingURLString(endpoint)] = cachedResponse;
     });
 }
 
 + (void)unregisterEndpoint:(NSURL *)endpoint
 {
-    dispatch_barrier_async(sOriginQueue, ^{
+    tnl_dispatch_barrier_async_autoreleasing(sOriginQueue, ^{
         [sOriginToResponseDictionary removeObjectForKey:_UnderlyingURLString(endpoint)];
     });
 }
 
 + (void)unregisterAllEndpoints
 {
-    dispatch_barrier_async(sOriginQueue, ^{
+    tnl_dispatch_barrier_async_autoreleasing(sOriginQueue, ^{
         [sOriginToResponseDictionary removeAllObjects];
     });
 }
@@ -143,7 +143,7 @@ static void _executeClientBlock(SELF_ARG,
 - (void)startLoading
 {
     self.protocolRunLoop = CFRunLoopGetCurrent();
-    dispatch_async(_protocolQueue, ^{
+    tnl_dispatch_async_autoreleasing(_protocolQueue, ^{
         ABORT_IF_NECESSARY();
 
         NSURLRequest *request = self.request;
@@ -156,12 +156,12 @@ static void _executeClientBlock(SELF_ARG,
 
         if (response) {
             if (self.cachedResponse) {
-                dispatch_async(self->_protocolQueue, ^{
+                tnl_dispatch_async_autoreleasing(self->_protocolQueue, ^{
                     ABORT_IF_NECESSARY();
                     _executeClientBlock(self, ^(id<NSURLProtocolClient> client){
                         [client URLProtocol:self cachedResponseIsValid:self.cachedResponse];
                     });
-                    dispatch_async(self->_protocolQueue, ^{
+                    tnl_dispatch_async_autoreleasing(self->_protocolQueue, ^{
                         ABORT_IF_NECESSARY();
                         self.stopped = YES;
                         _executeClientBlock(self, ^(id<NSURLProtocolClient> client){
@@ -186,70 +186,74 @@ static void _executeClientBlock(SELF_ARG,
                 latency = ((double)config.latency) / 1000.0;
 
                 dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)((delay + latency) * NSEC_PER_SEC)), self->_protocolQueue, ^{
-                    ABORT_IF_NECESSARY();
+                    @autoreleasepool {
+                        ABORT_IF_NECESSARY();
 
-                    if (config.failureError) {
-                        self.stopped = YES;
-                        _executeClientBlock(self, ^(id<NSURLProtocolClient> client){
-                            [client URLProtocol:self didFailWithError:config.failureError];
-                        });
-                        return;
-                    }
-
-                    NSHTTPURLResponse *httpResponse = (id)response.response;
-                    NSData *data = response.data;
-                    NSInteger statusCode = (config.statusCode > 0) ? config.statusCode : httpResponse.statusCode;
-
-                    // See if we need to change to a 206
-                    if (200 == statusCode && config.canProvideRange) {
-
-                        const NSRange range = _RangeForRequest(request, data.length, config.stringForIfRange);
-                        if (range.location != NSNotFound) {
-                            // subrange requested, provide it
-                            statusCode = 206;
-                            data = [data subdataWithRange:range];
-                        }
-
-                    }
-
-                    // On 3xx (when `Location` is provided), execute redirection based on config behavior.
-                    if (statusCode >= 300 && statusCode < 400) {
-                        const TNLPseudoURLProtocolRedirectBehavior behavior = (config) ? config.redirectBehavior : TNLPseudoURLProtocolRedirectBehaviorFollowLocation;
-                        if (_handleRedirect(self, request, httpResponse, behavior)) {
-                            // was handled, return
+                        if (config.failureError) {
+                            self.stopped = YES;
+                            _executeClientBlock(self, ^(id<NSURLProtocolClient> client){
+                                [client URLProtocol:self didFailWithError:config.failureError];
+                            });
                             return;
                         }
-                    }
 
-                    httpResponse = _UpdateResponse(httpResponse, data.length, statusCode);
+                        NSHTTPURLResponse *httpResponse = (id)response.response;
+                        NSData *data = response.data;
+                        NSInteger statusCode = (config.statusCode > 0) ? config.statusCode : httpResponse.statusCode;
 
-                    dispatch_async(self->_protocolQueue, ^{
-                        ABORT_IF_NECESSARY();
-                        _executeClientBlock(self, ^(id<NSURLProtocolClient> client){
-                            [client URLProtocol:self
-                             didReceiveResponse:httpResponse
-                             cacheStoragePolicy:response.storagePolicy];
-                        });
+                        // See if we need to change to a 206
+                        if (200 == statusCode && config.canProvideRange) {
 
-                        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(latency * NSEC_PER_SEC)), self->_protocolQueue, ^{
-                            ABORT_IF_NECESSARY();
-
-                            NSUInteger bps = NSUIntegerMax;
-                            if (config.bps > 0) {
-                                bps = (NSUInteger)MIN(config.bps / 8ULL, (uint64_t)NSUIntegerMax);
+                            const NSRange range = _RangeForRequest(request, data.length, config.stringForIfRange);
+                            if (range.location != NSNotFound) {
+                                // subrange requested, provide it
+                                statusCode = 206;
+                                data = [data subdataWithRange:range];
                             }
 
-                            _chunkData(self,
-                                       data,
-                                       bps,
-                                       0 /*bytesSent*/,
-                                       MAX(latency, 0.25) /*latency*/);
+                        }
+
+                        // On 3xx (when `Location` is provided), execute redirection based on config behavior.
+                        if (statusCode >= 300 && statusCode < 400) {
+                            const TNLPseudoURLProtocolRedirectBehavior behavior = (config) ? config.redirectBehavior : TNLPseudoURLProtocolRedirectBehaviorFollowLocation;
+                            if (_handleRedirect(self, request, httpResponse, behavior)) {
+                                // was handled, return
+                                return;
+                            }
+                        }
+
+                        httpResponse = _UpdateResponse(httpResponse, data.length, statusCode);
+
+                        tnl_dispatch_async_autoreleasing(self->_protocolQueue, ^{
+                            ABORT_IF_NECESSARY();
+                            _executeClientBlock(self, ^(id<NSURLProtocolClient> client){
+                                [client URLProtocol:self
+                                 didReceiveResponse:httpResponse
+                                 cacheStoragePolicy:response.storagePolicy];
+                            });
+
+                            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(latency * NSEC_PER_SEC)), self->_protocolQueue, ^{
+                                @autoreleasepool {
+                                    ABORT_IF_NECESSARY();
+
+                                    NSUInteger bps = NSUIntegerMax;
+                                    if (config.bps > 0) {
+                                        bps = (NSUInteger)MIN(config.bps / 8ULL, (uint64_t)NSUIntegerMax);
+                                    }
+
+                                    _chunkData(self,
+                                               data,
+                                               bps,
+                                               0 /*bytesSent*/,
+                                               MAX(latency, 0.25) /*latency*/);
+                                }
+                            });
                         });
-                    });
+                    }
                 });
             }
         } else {
-            dispatch_async(self->_protocolQueue, ^{
+            tnl_dispatch_async_autoreleasing(self->_protocolQueue, ^{
                 ABORT_IF_NECESSARY();
                 self.stopped = YES;
                 _executeClientBlock(self, ^(id<NSURLProtocolClient> client){
@@ -356,7 +360,7 @@ static void _chunkData(SELF_ARG,
     }
 
     if (bytesSent >= data.length) {
-        dispatch_async(self->_protocolQueue, ^{
+        tnl_dispatch_async_autoreleasing(self->_protocolQueue, ^{
             ABORT_IF_NECESSARY();
             self.stopped = YES;
             _executeClientBlock(self, ^(id<NSURLProtocolClient> client){
@@ -365,8 +369,10 @@ static void _chunkData(SELF_ARG,
         });
     } else {
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(latency * NSEC_PER_SEC)), self->_protocolQueue, ^{
-            ABORT_IF_NECESSARY();
-            _chunkData(self, data, bps, bytesSent, latency);
+            @autoreleasepool {
+                ABORT_IF_NECESSARY();
+                _chunkData(self, data, bps, bytesSent, latency);
+            }
         });
     }
 }
@@ -397,7 +403,9 @@ static void _executeClientBlock(SELF_ARG,
     }
 
     CFRunLoopPerformBlock(self->_protocolRunLoop, kCFRunLoopDefaultMode, ^{
-        block(self.client);
+        @autoreleasepool {
+            block(self.client);
+        }
     });
     CFRunLoopWakeUp(self->_protocolRunLoop);
 }

--- a/Source/TNLRequest+Utilities.h
+++ b/Source/TNLRequest+Utilities.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 2/28/15.
-//  Copyright (c) 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #if !APPLEDOC

--- a/Source/TNLRequest.h
+++ b/Source/TNLRequest.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 5/23/14.
-//  Copyright (c) 2014 Twitter, Inc. All rights reserved.
+//  Copyright © 2020 Twitter, Inc. All rights reserved.
 //
 
 #import <TwitterNetworkLayer/TNLHTTP.h>
@@ -412,7 +412,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-#pragma twitter stopignorestylecheck
+#pragma twitter endignorestylecheck
 
 /**
  `NSURLRequest` implicitly conforms to `TNLRequest`.  This category makes that conformance explicit.

--- a/Source/TNLRequest.m
+++ b/Source/TNLRequest.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 5/23/14.
-//  Copyright (c) 2014 Twitter, Inc. All rights reserved.
+//  Copyright © 2020 Twitter, Inc. All rights reserved.
 //
 
 #import "NSDictionary+TNLAdditions.h"

--- a/Source/TNLRequestAuthorizer.h
+++ b/Source/TNLRequestAuthorizer.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 8/14/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/TNLRequestConfiguration.h
+++ b/Source/TNLRequestConfiguration.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 7/15/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <TwitterNetworkLayer/TNLHTTP.h>
@@ -159,12 +159,12 @@ typedef NS_OPTIONS(NSInteger, TNLRequestConnectivityOptions) {
  */
 typedef NS_ENUM(NSInteger, TNLResponseHashComputeAlgorithm) {
     TNLResponseHashComputeAlgorithmNone = 0,
-    TNLResponseHashComputeAlgorithmMD2 __attribute__((deprecated)) = 'md_2',
-    TNLResponseHashComputeAlgorithmMD4 __attribute__((deprecated)) = 'md_4',
-    TNLResponseHashComputeAlgorithmMD5 __attribute__((deprecated)) = 'md_5',
-    TNLResponseHashComputeAlgorithmSHA1 = 'sha1',
-    TNLResponseHashComputeAlgorithmSHA256 = 's256',
-    TNLResponseHashComputeAlgorithmSHA512 = 's512',
+    TNLResponseHashComputeAlgorithmMD2 __attribute__((deprecated)) = 'md_2', // 1835294514
+    TNLResponseHashComputeAlgorithmMD4 __attribute__((deprecated)) = 'md_4', // 1835294516
+    TNLResponseHashComputeAlgorithmMD5 __attribute__((deprecated)) = 'md_5', // 1835294517
+    TNLResponseHashComputeAlgorithmSHA1     = 'sha1', // 1936220465
+    TNLResponseHashComputeAlgorithmSHA256   = 's256', // 1932670262
+    TNLResponseHashComputeAlgorithmSHA512   = 's512', // 1932865842
 };
 
 /**

--- a/Source/TNLRequestConfiguration.m
+++ b/Source/TNLRequestConfiguration.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 7/15/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #include <objc/message.h>
@@ -59,6 +59,17 @@ TNLStaticAssert((sizeof(kAnatomyTimeouts) / sizeof(kAnatomyTimeouts[0])) == kMax
 #define kConfigurationAttemptTimeoutDefault (kAnatomyTimeouts[TNLRequestAnatomyDefault].attemptTimeout) // Apple's default is 7 days (biasing towards background sessions).  We'll bias towards foreground sessions.
 #define kConfigurationOperationTimeoutDefault (kAnatomyTimeouts[TNLRequestAnatomyDefault].operationTimeout)
 static const NSTimeInterval kConfigurationDeferrableIntervalDefault = 0.0;
+
+TNLStaticAssert(TNLResponseHashComputeAlgorithmNone == 0, ALGORITHM_NONE_WRONG_VALUE);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+TNLStaticAssert(TNLResponseHashComputeAlgorithmMD2 == 1835294514, ALGORITHM_MD2_WRONG_VALUE);
+TNLStaticAssert(TNLResponseHashComputeAlgorithmMD4 == 1835294516, ALGORITHM_MD4_WRONG_VALUE);
+TNLStaticAssert(TNLResponseHashComputeAlgorithmMD5 == 1835294517, ALGORITHM_MD5_WRONG_VALUE);
+#pragma clang diagnostic pop
+TNLStaticAssert(TNLResponseHashComputeAlgorithmSHA1 == 1936220465, ALGORITHM_SHA1_WRONG_VALUE);
+TNLStaticAssert(TNLResponseHashComputeAlgorithmSHA256 == 1932670262, ALGORITHM_SHA256_WRONG_VALUE);
+TNLStaticAssert(TNLResponseHashComputeAlgorithmSHA512 == 1932865842, ALGORITHM_SHA512_WRONG_VALUE);
 
 @interface TNLRequestConfiguration ()
 

--- a/Source/TNLRequestConfiguration_Project.h
+++ b/Source/TNLRequestConfiguration_Project.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 8/13/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNLParameterCollection.h"

--- a/Source/TNLRequestDelegate.h
+++ b/Source/TNLRequestDelegate.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 11/20/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <TwitterNetworkLayer/TNLAuthenticationChallengeHandler.h>

--- a/Source/TNLRequestEventHandler.h
+++ b/Source/TNLRequestEventHandler.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 8/14/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <TwitterNetworkLayer/TNLAttemptMetrics.h>

--- a/Source/TNLRequestHydrater.h
+++ b/Source/TNLRequestHydrater.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 8/14/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/TNLRequestOperationCancelSource.h
+++ b/Source/TNLRequestOperationCancelSource.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/21/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/TNLRequestOperationCancelSource.m
+++ b/Source/TNLRequestOperationCancelSource.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/21/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNLRequestOperationCancelSource.h"

--- a/Source/TNLRequestOperationQueue.h
+++ b/Source/TNLRequestOperationQueue.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 5/23/14.
-//  Copyright (c) 2014 Twitter, Inc. All rights reserved.
+//  Copyright © 2020 Twitter, Inc. All rights reserved.
 //
 
 #import <TwitterNetworkLayer/TNLRequestOperation.h>

--- a/Source/TNLRequestOperationQueue_Project.h
+++ b/Source/TNLRequestOperationQueue_Project.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 5/23/14.
-//  Copyright (c) 2014 Twitter, Inc. All rights reserved.
+//  Copyright © 2020 Twitter, Inc. All rights reserved.
 //
 
 #import "TNLAttemptMetrics.h"

--- a/Source/TNLRequestOperationState.h
+++ b/Source/TNLRequestOperationState.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 5/23/14.
-//  Copyright (c) 2014 Twitter, Inc. All rights reserved.
+//  Copyright © 2020 Twitter, Inc. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/TNLRequestOperation_Project.h
+++ b/Source/TNLRequestOperation_Project.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 5/23/14.
-//  Copyright (c) 2014 Twitter, Inc. All rights reserved.
+//  Copyright © 2020 Twitter, Inc. All rights reserved.
 //
 
 #import "TNL_Project.h"

--- a/Source/TNLRequestRedirecter.h
+++ b/Source/TNLRequestRedirecter.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 2/9/15.
-//  Copyright (c) 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/TNLRequestRetryPolicyConfiguration.h
+++ b/Source/TNLRequestRetryPolicyConfiguration.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 5/26/14.
-//  Copyright (c) 2014 Twitter, Inc. All rights reserved.
+//  Copyright © 2020 Twitter, Inc. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/TNLRequestRetryPolicyConfiguration.m
+++ b/Source/TNLRequestRetryPolicyConfiguration.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 5/26/14.
-//  Copyright (c) 2014 Twitter, Inc. All rights reserved.
+//  Copyright © 2020 Twitter, Inc. All rights reserved.
 //
 
 #import "TNL_Project.h"

--- a/Source/TNLRequestRetryPolicyProvider.h
+++ b/Source/TNLRequestRetryPolicyProvider.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 5/26/14.
-//  Copyright (c) 2014 Twitter, Inc. All rights reserved.
+//  Copyright © 2020 Twitter, Inc. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/TNLResponse.h
+++ b/Source/TNLResponse.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 5/23/14.
-//  Copyright (c) 2014 Twitter, Inc. All rights reserved.
+//  Copyright © 2020 Twitter, Inc. All rights reserved.
 //
 
 #import <TwitterNetworkLayer/TNLHTTP.h>
@@ -299,6 +299,9 @@ NS_SWIFT_NAME(response(request:operationError:info:metrics:));
 /** The underlying attempt metrics as `TNLAttemptMetrics` objects */
 @property (nonatomic, readonly, nullable) NSArray<TNLAttemptMetrics *> *attemptMetrics;
 
+/** A description of the response metrics as a serializable dictionary object */
+- (NSDictionary *)dictionaryDescription:(BOOL)verbose;
+
 /**
  Helper init for custom `TNLResponseMetrics`
  */
@@ -354,7 +357,7 @@ NS_SWIFT_NAME(response(request:operationError:info:metrics:));
  mechanism encapsulated by `TNLRequestOperation`.
 
  @param duration    The `totalDuration` of the metrics.  `firstAttemptStartMachTime` will be `0`.
- @param URLRequest  The `NSURLRequest` for the encapsulated attempt
+ @param request  The `NSURLRequest` for the encapsulated attempt
  @param URLResponse The `NSHTTPURLResponse` for the encapsulated attempt
  @param error       The `NSError` for the encapsulated attempt
 

--- a/Source/TNLResponse.m
+++ b/Source/TNLResponse.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 5/23/14.
-//  Copyright (c) 2014 Twitter, Inc. All rights reserved.
+//  Copyright © 2020 Twitter, Inc. All rights reserved.
 //
 
 #import <mach/mach_time.h>
@@ -752,41 +752,31 @@ static void _addAttemptStart(PRIVATE_SELF(TNLResponseMetrics),
     }
 }
 
-- (NSString *)description
+- (NSDictionary *)dictionaryDescription:(BOOL)verbose
 {
     NSMutableDictionary *topDictionary = [NSMutableDictionary dictionary];
     topDictionary[@"complete"] = (_completeMachTime != 0) ? @"true" : @"false";
     topDictionary[@"duration"] = @(self.totalDuration);
-    topDictionary[@"attemptTime"] = @(self.currentAttemptDuration);
-    topDictionary[@"queueTime"] = @(self.queuedDuration);
-    topDictionary[@"allAttemptsTime"] = @(self.allAttemptsDuration);
+    if (verbose) {
+        topDictionary[@"attemptTime"] = @(self.currentAttemptDuration);
+        topDictionary[@"queueTime"] = @(self.queuedDuration);
+        topDictionary[@"allAttemptsTime"] = @(self.allAttemptsDuration);
+    }
 
     NSMutableArray *attempts = [NSMutableArray arrayWithCapacity:self.attemptMetrics.count];
     for (TNLAttemptMetrics *metrics in self.attemptMetrics) {
-        NSMutableDictionary *attemptDict = [NSMutableDictionary dictionary];
-        attemptDict[@"duration"] = @(metrics.duration);
-        attemptDict[@"type"] = TNLAttemptTypeToString(metrics.attemptType);
-        if (metrics.metaData != nil) {
-            attemptDict[@"metadata"] = metrics.metaData;
-        }
-        attemptDict[@"statusCode"] = @(metrics.URLResponse.statusCode);
-        if (metrics.URLResponse.URL) {
-            attemptDict[@"URL"] = metrics.URLResponse.URL;
-        }
-        if (metrics.operationError) {
-            attemptDict[@"error"] = [NSString stringWithFormat:@"%@.%ld", metrics.operationError.domain, (long)metrics.operationError.code];
-        }
-#if DEBUG
-        if (metrics.taskTransactionMetrics) {
-            attemptDict[@"transactionMetrics"] = metrics.taskTransactionMetrics.tnl_dictionaryValue;
-        }
-#endif
+        NSDictionary *attemptDict = [metrics dictionaryDescription:verbose];
         [attempts addObject:attemptDict];
     }
     if (attempts.count > 0) {
         topDictionary[@"attempts"] = attempts;
     }
-    return [NSString stringWithFormat:@"<%@ %p: %@>", NSStringFromClass([self class]), self, topDictionary];
+    return topDictionary;
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@ %p: %@>", NSStringFromClass([self class]), self, [self dictionaryDescription:NO]];
 }
 
 - (NSUInteger)hash

--- a/Source/TNLResponse_Project.h
+++ b/Source/TNLResponse_Project.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 9/17/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNLResponse.h"

--- a/Source/TNLSafeOperation.h
+++ b/Source/TNLSafeOperation.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 6/1/17
-//  Copyright © 2017 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>
@@ -20,4 +20,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
 

--- a/Source/TNLSafeOperation.m
+++ b/Source/TNLSafeOperation.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 6/1/17
-//  Copyright © 2017 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNL_Project.h"
@@ -60,4 +60,5 @@ static BOOL _NSOperationHasCompletionBlockBug(void)
 @end
 
 NS_ASSUME_NONNULL_END
+
 

--- a/Source/TNLSimpleRequestDelegate.h
+++ b/Source/TNLSimpleRequestDelegate.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 11/25/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNLRequestDelegate.h"

--- a/Source/TNLSimpleRequestDelegate.m
+++ b/Source/TNLSimpleRequestDelegate.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 11/25/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNL_Project.h"

--- a/Source/TNLTemporaryFile.h
+++ b/Source/TNLTemporaryFile.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 7/18/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/TNLTemporaryFile.m
+++ b/Source/TNLTemporaryFile.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 7/18/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNL_Project.h"

--- a/Source/TNLTemporaryFile_Project.h
+++ b/Source/TNLTemporaryFile_Project.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 7/18/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNLTemporaryFile.h"

--- a/Source/TNLTimeoutOperation.h
+++ b/Source/TNLTimeoutOperation.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 12/7/17.
-//  Copyright © 2017 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNLSafeOperation.h"

--- a/Source/TNLTimeoutOperation.m
+++ b/Source/TNLTimeoutOperation.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 12/7/17.
-//  Copyright © 2017 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #include <stdatomic.h>
@@ -66,7 +66,9 @@ NS_ASSUME_NONNULL_BEGIN
 
     if (_timeoutDuration > 0.0) {
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(_timeoutDuration * NSEC_PER_SEC)), dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
-            _complete(self);
+            @autoreleasepool {
+                _complete(self);
+            }
         });
     } else {
         _complete(self);

--- a/Source/TNLTiming.h
+++ b/Source/TNLTiming.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 5/12/16.
-//  Copyright © 2016 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/TNLTiming.m
+++ b/Source/TNLTiming.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 5/12/16.
-//  Copyright © 2016 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <mach/mach_time.h>

--- a/Source/TNLURLCoding.h
+++ b/Source/TNLURLCoding.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 7/28/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/Source/TNLURLSessionManager.h
+++ b/Source/TNLURLSessionManager.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/23/15.
-//  Copyright © 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <TwitterNetworkLayer/TNLGlobalConfiguration.h>
@@ -28,11 +28,6 @@ TNLMutableParametersFromURLSessionConfiguration(NSURLSessionConfiguration * __nu
 
 FOUNDATION_EXTERN BOOL
 TNLURLSessionIdentifierIsTaggedForTNL(NSString *identifier);
-
-#pragma mark Constants
-
-FOUNDATION_EXTERN NSTimeInterval TNLGlobalServiceUnavailableRetryAfterBackoffValueDefault;
-FOUNDATION_EXTERN NSTimeInterval TNLGlobalServiceUnavailableRetryAfterMaximumBackoffValueBeforeTreatedAsGoAway;
 
 #pragma mark Declarations
 
@@ -61,12 +56,15 @@ typedef void(^TNLURLSessionManagerGetAllSessionsCallback)(NSArray<NSURLSession *
                                    response:(TNLResponse *)response;
 
 - (void)syncAddURLSessionTaskOperation:(TNLURLSessionTaskOperation *)op;
-- (void)applyServiceUnavailableBackoffDependenciesToOperation:(NSOperation *)op
-                                                      withURL:(NSURL *)URL
-                                            isLongPollRequest:(BOOL)isLongPoll;
-- (void)serviceUnavailableEncounteredForURL:(NSURL *)URL
-                            retryAfterDelay:(NSTimeInterval)delay;
-@property (atomic) TNLGlobalConfigurationServiceUnavailableBackoffMode serviceUnavailableBackoffMode;
+- (void)applyBackoffDependenciesToOperation:(NSOperation *)op
+                                    withURL:(NSURL *)URL
+                                       host:(nullable NSString *)host
+                          isLongPollRequest:(BOOL)isLongPoll;
+- (void)backoffSignalEncounteredForURL:(NSURL *)URL
+                                  host:(nullable NSString *)host
+                   responseHTTPHeaders:(nullable NSDictionary<NSString *, NSString *> *)headers;
+@property (atomic) TNLGlobalConfigurationBackoffMode backoffMode;
+@property (atomic, null_resettable) id<TNLBackoffBehaviorProvider> backoffBehaviorProvider;
 
 - (void)pruneUnusedURLSessions;
 - (void)pruneURLSessionMatchingRequestConfiguration:(TNLRequestConfiguration *)config

--- a/Source/TNLURLSessionTaskOperation.h
+++ b/Source/TNLURLSessionTaskOperation.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 6/11/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNLAttemptMetaData.h"
@@ -70,9 +70,10 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface TNLURLSessionTaskOperation (TNLURLSessionManagerMethods)
-- (void)handler:(id<TNLAuthenticationChallengeHandler>)handler
+- (void)handler:(nullable id<TNLAuthenticationChallengeHandler>)handler
         didCancelAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
-        forURLSession:(NSURLSession *)session;
+        forURLSession:(NSURLSession *)session
+        context:(nullable id)cancelContext;
 @end
 
 @interface TNLURLSessionTaskOperation (TNLRequestOperationMethods)

--- a/Source/TNLURLStringCoding.m
+++ b/Source/TNLURLStringCoding.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 7/28/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNL_Project.h"

--- a/Source/TNL_Project.h
+++ b/Source/TNL_Project.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 5/24/14.
-//  Copyright (c) 2014 Twitter, Inc. All rights reserved.
+//  Copyright © 2020 Twitter, Inc. All rights reserved.
 //
 
 #import "TNL_ProjectCommon.h"
@@ -104,6 +104,7 @@ NS_INLINE void tnl_dispatch_timer_invalidate(dispatch_source_t __nullable timerS
 
 #pragma mark - Threading
 
+FOUNDATION_EXTERN NSOperationQueue *TNLNetworkOperationQueue(void);
 FOUNDATION_EXTERN dispatch_queue_t tnl_network_queue(void);
 FOUNDATION_EXTERN dispatch_queue_t tnl_coding_queue(void);
 

--- a/Source/TNL_Project.m
+++ b/Source/TNL_Project.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 5/24/14.
-//  Copyright (c) 2014 Twitter, Inc. All rights reserved.
+//  Copyright © 2020 Twitter, Inc. All rights reserved.
 //
 
 #include <objc/runtime.h>
@@ -40,6 +40,18 @@ NSString *TNLVersion()
 }
 
 #pragma mark - Threading
+
+NSOperationQueue *TNLNetworkOperationQueue()
+{
+    static NSOperationQueue *sQueue;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sQueue = [[NSOperationQueue alloc] init];
+        sQueue.name = @"tnl.network.queue";
+        sQueue.underlyingQueue = tnl_network_queue();
+    });
+    return sQueue;
+}
 
 dispatch_queue_t tnl_network_queue()
 {
@@ -214,7 +226,7 @@ static void ConnLoad(void)
 
 void TNLIncrementObjectCount(Class class)
 {
-    dispatch_async(sCountsQueue, ^{
+    tnl_dispatch_async_autoreleasing(sCountsQueue, ^{
         NSString *className = NSStringFromClass(class);
         if (className) {
             NSUInteger count = [sCounts[className] unsignedIntegerValue];
@@ -225,7 +237,7 @@ void TNLIncrementObjectCount(Class class)
 
 void TNLDecrementObjectCount(Class class)
 {
-    dispatch_async(sCountsQueue, ^{
+    tnl_dispatch_async_autoreleasing(sCountsQueue, ^{
         NSString *className = NSStringFromClass(class);
         if (className) {
             NSUInteger count = [sCounts[className] unsignedIntegerValue];

--- a/Source/TNL_ProjectCommon.m
+++ b/Source/TNL_ProjectCommon.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 3/5/15.
-//  Copyright (c) 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNL_ProjectCommon.h"
@@ -112,12 +112,10 @@ void TNLSetDebugSTOPOnAssertEnabled(BOOL stopOnAssert)
     sIsDebugSTOPEnabled = stopOnAssert;
 }
 
-void __TNLAssert(BOOL expression)
+void __TNLAssertTriggering()
 {
-    if (!expression) {
-        if (TNLIsDebugSTOPOnAssertEnabled() && TNLIsDebuggerAttached()) {
-            TNLTriggerDebugSTOP(); // trigger debug stop
-        }
+    if (TNLIsDebugSTOPOnAssertEnabled() && TNLIsDebuggerAttached()) {
+        TNLTriggerDebugSTOP(); // trigger debug stop
     }
 }
 

--- a/Source/TwitterNetworkLayer.h
+++ b/Source/TwitterNetworkLayer.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 6/9/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #pragma Headers
@@ -11,6 +11,7 @@
 #import <TwitterNetworkLayer/TNLAttemptMetaData.h>
 #import <TwitterNetworkLayer/TNLAttemptMetrics.h>
 #import <TwitterNetworkLayer/TNLAuthenticationChallengeHandler.h>
+#import <TwitterNetworkLayer/TNLBackoff.h>
 #import <TwitterNetworkLayer/TNLCommunicationAgent.h>
 #import <TwitterNetworkLayer/TNLContentCoding.h>
 #import <TwitterNetworkLayer/TNLError.h>
@@ -55,6 +56,7 @@
 #import <TwitterNetworkLayer/NSNumber+TNLURLCoding.h>
 #import <TwitterNetworkLayer/NSOperationQueue+TNLSafety.h>
 #import <TwitterNetworkLayer/NSURL+TNLAdditions.h>
+#import <TwitterNetworkLayer/NSURLAuthenticationChallenge+TNLAdditions.h>
 #import <TwitterNetworkLayer/NSURLCache+TNLAdditions.h>
 #import <TwitterNetworkLayer/NSURLCredentialStorage+TNLAdditions.h>
 #import <TwitterNetworkLayer/NSURLRequest+TNLAdditions.h>

--- a/TNLCLI/TNLCLIError.h
+++ b/TNLCLI/TNLCLIError.h
@@ -1,0 +1,31 @@
+//
+//  TNLCLIError.h
+//  TNLCLI
+//
+//  Created on 9/11/19.
+//  Copyright © 2020 Twitter. All rights reserved.
+//
+
+@import Foundation;
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, TNLCLIError)
+{
+    TNLCLIErrorException = -1,
+    TNLCLIErrorUnknown = 0,
+    TNLCLIErrorEmptyMainFunctionArguments,
+    TNLCLIErrorMissingPWDEnvironmentVariable,
+    TNLCLIErrorMissingRequestURLArgument,
+    TNLCLIErrorInvalidURLArgument,
+    TNLCLIErrorArgumentInputFileCannotBeRead,
+    TNLCLIErrorJSONParseFailure,
+    TNLCLIErrorResponseBodyCannotPrint,
+    TNLCLIErrorInvalidRequestConfigurationFileFormat, // needs to be JSON of key=value pairs (all strings, even numeric values!)
+};
+
+FOUNDATION_EXTERN NSString * const TNLCLIErrorDomain;
+
+FOUNDATION_EXTERN NSError *TNLCLICreateError(TNLCLIError code, id __nullable userInfoDictionaryOrDescriptionString);
+
+NS_ASSUME_NONNULL_END

--- a/TNLCLI/TNLCLIError.m
+++ b/TNLCLI/TNLCLIError.m
@@ -1,0 +1,27 @@
+//
+//  TNLCLIError.m
+//  TNLCLI
+//
+//  Created on 9/11/19.
+//  Copyright © 2020 Twitter. All rights reserved.
+//
+
+#import "TNLCLIError.h"
+
+NSString * const TNLCLIErrorDomain = @"tnlcli.error";
+
+NSError *TNLCLICreateError(TNLCLIError code, id __nullable userInfoDictionaryOrDescriptionString)
+{
+    NSDictionary *userInfo = nil;
+    if ([userInfoDictionaryOrDescriptionString isKindOfClass:[NSDictionary class]]) {
+        userInfo = userInfoDictionaryOrDescriptionString;
+    } else if ([userInfoDictionaryOrDescriptionString isKindOfClass:[NSString class]]) {
+        userInfo = @{
+                        NSDebugDescriptionErrorKey : [userInfoDictionaryOrDescriptionString copy]
+                    };
+    }
+
+    return [NSError errorWithDomain:TNLCLIErrorDomain
+                               code:code
+                           userInfo:userInfo];
+}

--- a/TNLCLI/TNLCLIExecution.h
+++ b/TNLCLI/TNLCLIExecution.h
@@ -1,0 +1,25 @@
+//
+//  TNLCLIExecution.h
+//  tnlcli
+//
+//  Created on 9/12/19.
+//  Copyright © 2020 Twitter. All rights reserved.
+//
+
+#import "TNLCLIExecutionContext.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface TNLCLIExecution : NSObject
+
+@property (nonatomic, readonly) TNLCLIExecutionContext *context;
+
+- (instancetype)initWithContext:(TNLCLIExecutionContext *)context;
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+- (nullable NSError *)execute;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/TNLCLI/TNLCLIExecution.m
+++ b/TNLCLI/TNLCLIExecution.m
@@ -1,0 +1,416 @@
+//
+//  TNLCLIExecution.m
+//  tnlcli
+//
+//  Created on 9/12/19.
+//  Copyright © 2020 Twitter. All rights reserved.
+//
+
+#import <TwitterNetworkLayer/TwitterNetworkLayer.h>
+
+#import "TNLCLIError.h"
+#import "TNLCLIExecution.h"
+#import "TNLCLIPrint.h"
+#import "TNLCLIUtils.h"
+#import "TNLGlobalConfiguration+TNLCLI.h"
+#import "TNLMutableRequestConfiguration+TNLCLI.h"
+
+#pragma mark - Static Functions
+
+#define FAIL(err) \
+({\
+    _executionError = (err); \
+    TNLCLIPrintError(_executionError); \
+    return; \
+})
+#define SOFT_FAIL(err) \
+({\
+    NSError *err__ = (err); \
+    TNLCLIPrintError(err__); \
+    if (!_executionError) { \
+        _executionError = err__; \
+    } \
+})
+
+#pragma mark - TNLCLIExecution
+
+@interface TNLCLIExecution ()
+@property (nonatomic, readonly, nullable) NSError *executionError;
+@property (nonatomic, readonly, nullable) TNLResponse *response;
+- (NSString *)sanitizePath:(NSString *)path;
+@end
+
+@interface TNLCLIExecution (TNLDelegate) <TNLRequestDelegate, TNLLogger>
+@end
+
+@implementation TNLCLIExecution
+
+- (instancetype)initWithContext:(TNLCLIExecutionContext *)context
+{
+    if (self = [super init]) {
+        _context = context;
+        _executionError = context.contextError;
+    }
+    return self;
+}
+
+- (nullable NSError *)execute
+{
+    @try {
+        [self _execute];
+    } @catch (NSException *exception) {
+        _executionError = TNLCLICreateError(TNLCLIErrorException,
+                                            @{
+                                                NSDebugDescriptionErrorKey : @"Exception when executing",
+                                                @"exception" : exception
+                                            });
+        TNLCLIPrintError(_executionError);
+        tnlcli_fprintf(stderr, "call stack:\n%s\n", exception.callStackSymbols.description.UTF8String);
+    }
+
+    return _executionError;
+}
+
+- (NSString *)sanitizePath:(NSString *)path
+{
+    NSString *newPath = [path stringByExpandingTildeInPath];
+    if (!newPath.isAbsolutePath) {
+        newPath = [self.context.currentDirectory stringByAppendingPathComponent:newPath];
+    }
+    return newPath;
+}
+
+- (void)_execute
+{
+    if (_executionError) {
+        return;
+    }
+
+    TNLCLIExecutionContext *context = _context;
+
+    /// Print the version?
+
+    if (context.printVersion) {
+        tnlcli_printf("%s version %s\n", context.executableName.UTF8String, [TNLGlobalConfiguration version].UTF8String);
+        if (context.requestURLString.length == 0) {
+            // just getting the version
+            return;
+        }
+    }
+
+    /// Global Config
+
+    TNLGlobalConfiguration *globalConfig = [TNLGlobalConfiguration sharedInstance];
+    globalConfig.assertsEnabled = YES;
+    globalConfig.logger = self;
+    [globalConfig addAuthenticationChallengeHandler:self];
+
+    // Optionally update global config
+
+    for (NSString *globalConfigSetting in context.globalConfigurations) {
+        NSString *name, *value;
+        if (TNLCLIParseColonSeparatedKeyValuePair(globalConfigSetting, &name, &value)) {
+            (void)[globalConfig tnlcli_applySettingWithName:name value:value];
+        } else {
+            TNLCLIPrintWarning([NSString stringWithFormat:@"'%@' is not in the expected format for a global configuration: 'name:value'.  Skipping this global configuration.", globalConfigSetting]);
+        }
+    }
+
+    /// Construct the request
+
+    TNLMutableRequestConfiguration *configuration = nil;
+    TNLMutableHTTPRequest *request = nil;
+
+    // Init our request
+
+    request = [[TNLMutableHTTPRequest alloc] initWithURL:[NSURL URLWithString:context.requestURLString]];
+    if (!request.URL) {
+        FAIL(TNLCLICreateError(TNLCLIErrorInvalidURLArgument,
+                               @{
+                                   NSDebugDescriptionErrorKey : @"Request URL argument is not valid",
+                                   @"url_arg" : context.requestURLString ?: @"<null>"
+                               }));
+    }
+
+    // Optionally set method
+
+    if (context.requestMethodValueString) {
+        request.HTTPMethodValue = TNLHTTPMethodFromString(context.requestMethodValueString);
+        if (request.HTTPMethodValue == TNLHTTPMethodGET && ![context.requestMethodValueString isEqualToString:@"GET"]) {
+            TNLCLIPrintWarning([NSString stringWithFormat:@"--request-method arg `%s` is not an HTTP Method, using `GET` instead", context.requestMethodValueString.UTF8String]);
+        }
+    }
+
+    // Optionally set headers
+
+    if (context.requestHeadersFilePath) {
+        NSString *filePath = [self sanitizePath:context.requestHeadersFilePath];
+        NSData *requestHeadersData = [NSData dataWithContentsOfFile:filePath];
+        if (!requestHeadersData) {
+            FAIL(TNLCLICreateError(TNLCLIErrorArgumentInputFileCannotBeRead,
+                                   @{
+                                       NSDebugDescriptionErrorKey : @"--request-headers-file cannot be read",
+                                       @"file_arg" : context.requestHeadersFilePath
+                                    }));
+        }
+        NSError *error;
+        NSDictionary *headers = [NSJSONSerialization JSONObjectWithData:requestHeadersData options:0 error:&error];
+        if (!headers) {
+            FAIL(error ?: TNLCLICreateError(TNLCLIErrorUnknown, nil));
+        }
+        if (![headers isKindOfClass:[NSDictionary class]]) {
+            FAIL(TNLCLICreateError(TNLCLIErrorJSONParseFailure,
+                                   @{
+                                       NSDebugDescriptionErrorKey : @"Failed to parse file's JSON as key-value-pairs",
+                                       @"file_arg" : context.requestHeadersFilePath
+                                    }));
+        }
+        request.allHTTPHeaderFields = headers;
+    }
+
+    // Optionally set more headers
+
+    for (NSString *header in context.requestHeaders) {
+        NSString *field, *value;
+        if (TNLCLIParseColonSeparatedKeyValuePair(header, &field, &value)) {
+            [request setValue:value forHTTPHeaderField:field];
+        } else {
+            TNLCLIPrintWarning([NSString stringWithFormat:@"'%@' is not in the expected format for a header: 'Header: Value'.  Skipping this header.", header]);
+        }
+    }
+
+    // Optionally set body
+
+    if (context.requestBodyFilePath) {
+        request.HTTPBodyFilePath = [self sanitizePath:context.requestBodyFilePath];
+    }
+
+    // Construct configuration
+
+    if (context.requestConfigurationFilePath) {
+        NSString *filePath = [self sanitizePath:context.requestConfigurationFilePath];
+        NSError *error;
+        configuration = [TNLMutableRequestConfiguration tnlcli_configurationWithFile:filePath error:&error];
+        if (!configuration) {
+            FAIL(error);
+        }
+    }
+
+    if (!configuration) {
+        configuration = [[TNLMutableRequestConfiguration alloc] init];
+    }
+
+    // Optionally update the configuration
+
+    for (NSString *config in context.requestConfigurations) {
+        NSString *name, *value;
+        if (TNLCLIParseColonSeparatedKeyValuePair(config, &name, &value)) {
+            [configuration tnlcli_applySettingWithName:name value:value];
+        } else {
+            TNLCLIPrintWarning([NSString stringWithFormat:@"'%@' is not in the expected format for a request config seting: 'Name:Value'.  Skipping this setting.", config]);
+        }
+    }
+
+    /// Run our operation
+
+    TNLRequestOperation *operation = [TNLRequestOperation operationWithRequest:request configuration:configuration delegate:self];
+    [[TNLRequestOperationQueue defaultOperationQueue] enqueueRequestOperation:operation];
+    [operation waitUntilFinishedWithoutBlockingRunLoop];
+
+    /// Handle our response
+
+    // Was there an error
+
+    if (_response.operationError) {
+        SOFT_FAIL(_response.operationError);
+    }
+
+    // Verbose Info
+
+    if (context.verbose) {
+        tnlcli_printf("** STATS **\n");
+        NSDictionary *metricsDescription = [_response.metrics dictionaryDescription:YES];
+        NSError *error;
+        NSData *jsonData = [NSJSONSerialization dataWithJSONObject:metricsDescription
+                                                           options:(NSJSONWritingSortedKeys | NSJSONWritingPrettyPrinted)
+                                                             error:&error];
+        if (jsonData) {
+            jsonData = TNLCLIEnsureDataIsNullTerminated(jsonData);
+            tnlcli_printf("%s\n", (const char *)jsonData.bytes);
+        } else {
+            tnlcli_printf("Failed To Generate Stats! ");
+            TNLCLIPrintError(error);
+        }
+    }
+
+    // Response headers
+
+    do {
+        NSMutableDictionary *dictionary = [[_response.info allHTTPHeaderFields] mutableCopy];
+        dictionary[@"_tnlcli_StatusCode"] = [@(_response.info.statusCode) stringValue];
+        dictionary[@"_tnlcli_URL"] = [_response.info.finalURL absoluteString];
+
+        NSError *error;
+        NSData *jsonData = (dictionary) ? [NSJSONSerialization dataWithJSONObject:dictionary
+                                                                          options:NSJSONWritingSortedKeys | NSJSONWritingPrettyPrinted
+                                                                            error:&error] : nil;
+        if (!jsonData) {
+            SOFT_FAIL(error);
+        } else {
+            jsonData = TNLCLIEnsureDataIsNullTerminated(jsonData);
+            if (context.verbose || [context.responseHeadersOutputModes containsObject:@"print"]) {
+                if (context.verbose) {
+                    tnlcli_printf("** RESPONSE HEADERS **\n");
+                }
+                tnlcli_printf("%s\n", (const char *)jsonData.bytes);
+            }
+            if ([context.responseHeadersOutputModes containsObject:@"file"] && context.requestBodyFilePath) {
+                NSString *filePath = [self sanitizePath:context.requestBodyFilePath];
+                if (![jsonData writeToFile:filePath options:NSDataWritingAtomic | NSDataWritingWithoutOverwriting error:&error]) {
+                    SOFT_FAIL(error);
+                }
+            }
+        }
+    } while (0);
+
+    // Response body
+
+    if (_response.info.data || _response.info.temporarySavedFile) {
+        NSData *data = _response.info.data;
+        BOOL writeToFile = [context.responseBodyOutputModes containsObject:@"file"] && context.responseBodyTargetFilePath;
+        const BOOL print = context.verbose || [context.responseBodyOutputModes containsObject:@"print"];
+        if (_response.info.temporarySavedFile) {
+            NSString *path = nil;
+            if (writeToFile) {
+                path = [self sanitizePath:context.responseBodyTargetFilePath];
+                writeToFile = NO;
+            } else if (print) {
+                [[NSFileManager defaultManager] createDirectoryAtPath:NSTemporaryDirectory() withIntermediateDirectories:YES attributes:nil error:NULL];
+                path = [NSTemporaryDirectory() stringByAppendingPathComponent:[NSUUID UUID].UUIDString];
+            }
+
+            if (path) {
+                NSError *error;
+                if (![_response.info.temporarySavedFile moveToPath:path error:&error]) {
+                    SOFT_FAIL(error);
+                } else {
+                    if (print && !data) {
+                        data = [NSData dataWithContentsOfFile:path];
+                    }
+                }
+            }
+        }
+        if (data) {
+            if (writeToFile) {
+                NSError *error;
+                if (![data writeToFile:[self sanitizePath:context.responseBodyTargetFilePath] options:NSDataWritingAtomic | NSDataWritingWithoutOverwriting error:&error]) {
+                    SOFT_FAIL(error);
+                }
+            }
+            if (print) {
+                data = TNLCLIEnsureDataIsNullTerminated(data);
+                NSString *printable = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+                if (context.verbose) {
+                    tnlcli_printf("** RESPONSE BODY **\n");
+                }
+                if (!printable) {
+                    if (context.verbose && ![context.responseBodyOutputModes containsObject:@"print"]) {
+                        // due to being verbose
+                        tnlcli_printf("Response body is not UTF-8 and cannot be printed.\n");
+                    } else {
+                        SOFT_FAIL(TNLCLICreateError(TNLCLIErrorResponseBodyCannotPrint, @"The response body is not UTF-8 and therefore cannot be printed"));
+                    }
+                } else {
+                    tnlcli_printf("\r\n%s\n", printable.UTF8String);
+                }
+            }
+        }
+    }
+}
+
+@end
+
+@implementation TNLCLIExecution (TNLDelegate)
+
+- (void)tnl_logWithLevel:(TNLLogLevel)level
+                 context:(nullable id)context
+                    file:(NSString *)file
+                function:(NSString *)function
+                    line:(int)line
+                 message:(NSString *)message
+{
+    static const char * sLevelStrings[] = {
+        "EMGCY",
+        "ALERT",
+        "CRTCL",
+        "ERROR",
+        "WARNG",
+        "Notce",
+        "Info ",
+        "Debug"
+    };
+    tnlcli_fprintf((level >= TNLLogLevelNotice) ? stdout : stderr, "%s: %s\n", sLevelStrings[level], message.UTF8String);
+}
+
+- (BOOL)tnl_shouldRedactHTTPHeaderField:(NSString *)headerField
+{
+    return NO;
+}
+
+- (BOOL)tnl_canLogWithLevel:(TNLLogLevel)level context:(nullable id)context
+{
+    if (!_context.verbose) {
+        return NO;
+    }
+    return (level <= TNLLogLevelWarning);
+}
+
+- (BOOL)tnl_shouldLogVerbosely
+{
+    return _context.verbose;
+}
+
+- (void)tnl_requestOperation:(TNLRequestOperation *)op didCompleteWithResponse:(TNLResponse *)response
+{
+    _response = response;
+}
+
+- (void)tnl_networkLayerDidReceiveAuthChallenge:(NSURLAuthenticationChallenge *)challenge
+                               requestOperation:(TNLRequestOperation *)op
+                                     completion:(TNLURLSessionAuthChallengeCompletionBlock)completion
+{
+    if (self.context.certificateChainDumpDirectory) {
+        if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
+            NSString *host = challenge.protectionSpace.host;
+            NSString *dumpDir = [self sanitizePath:self.context.certificateChainDumpDirectory];
+            NSFileManager *fm = [NSFileManager defaultManager];
+            NSError *error;
+            if (![fm createDirectoryAtPath:dumpDir withIntermediateDirectories:YES attributes:nil error:&error]) {
+                TNLCLIPrintError(error);
+            }
+
+            SecTrustRef serverTrust = challenge.protectionSpace.serverTrust;
+            const CFIndex chainLength = SecTrustGetCertificateCount(serverTrust);
+            if (chainLength > 0 && self.context.verbose) {
+                tnlcli_printf("** CERT DUMP **\n");
+            }
+            for (CFIndex i = 0; i < chainLength; i++) {
+                SecCertificateRef certificate = SecTrustGetCertificateAtIndex(serverTrust, i);
+                NSData *DERData = (NSData *)CFBridgingRelease(SecCertificateCopyData(certificate));
+                NSString *DERFilePath = [dumpDir stringByAppendingPathComponent:[NSString stringWithFormat:@"%@_cert_%li.DER", host, i]];
+                NSString *summary = (NSString *)CFBridgingRelease(CFCopyDescription(certificate));
+                if (![DERData writeToFile:DERFilePath options:NSDataWritingWithoutOverwriting error:&error]) {
+                    NSMutableDictionary *errorInfo = [error.userInfo mutableCopy] ?: [[NSMutableDictionary alloc] init];
+                    errorInfo[@"cert.description"] = summary;
+                    TNLCLIPrintError([NSError errorWithDomain:error.domain code:error.code userInfo:errorInfo]);
+                } else if (self.context.verbose) {
+                    tnlcli_printf("'%s' => %s\n", summary.UTF8String, DERFilePath.UTF8String);
+                }
+            }
+        }
+    }
+
+    completion(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+}
+
+@end

--- a/TNLCLI/TNLCLIExecutionContext.h
+++ b/TNLCLI/TNLCLIExecutionContext.h
@@ -1,0 +1,65 @@
+//
+//  TNLCLIExecutionContext.h
+//  TNLCLI
+//
+//  Created on 9/11/19.
+//  Copyright © 2020 Twitter. All rights reserved.
+//
+
+@import Foundation;
+
+@class TNLResponse;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface TNLCLIExecutionContext : NSObject
+
+#pragma mark Context Error
+
+@property (nonatomic, readonly, nullable) NSError *contextError;
+
+#pragma mark Execution Info
+
+@property (nonatomic, readonly, copy, nullable) NSString *executableName;
+@property (nonatomic, readonly, copy, nullable) NSString *executableDirectory;
+@property (nonatomic, readonly, copy, nullable) NSString *currentDirectory;
+
+#pragma mark Global Config
+
+@property (nonatomic, readonly, copy, nullable) NSArray<NSString *> *globalConfigurations;
+
+#pragma mark Request Info
+
+@property (nonatomic, readonly, copy, nullable) NSString *requestConfigurationFilePath;
+@property (nonatomic, readonly, copy, nullable) NSString *requestHeadersFilePath;
+@property (nonatomic, readonly, copy, nullable) NSString *requestBodyFilePath;
+@property (nonatomic, readonly, copy, nullable) NSArray<NSString *> *requestHeaders;
+@property (nonatomic, readonly, copy, nullable) NSArray<NSString *> *requestConfigurations;
+@property (nonatomic, readonly, copy, nullable) NSString *requestMethodValueString;
+@property (nonatomic, readonly, copy, nullable) NSString *requestURLString;
+
+#pragma mark Response Info
+
+@property (nonatomic, readonly, copy, nullable) NSArray<NSString *> *responseBodyOutputModes; // @"file", @"print", @"file,print"
+@property (nonatomic, readonly, copy, nullable) NSString *responseBodyTargetFilePath;
+
+@property (nonatomic, readonly, copy, nullable) NSArray<NSString *> *responseHeadersOutputModes; // @"file", @"print", @"file,print"
+@property (nonatomic, readonly, copy, nullable) NSString *responseHeadersTargetFilePath;
+
+@property (nonatomic, readonly, copy, nullable) NSString *certificateChainDumpDirectory;
+
+#pragma mark Other Info
+
+@property (nonatomic, readonly) BOOL verbose;
+@property (nonatomic, readonly) BOOL printVersion; // --version
+
+#pragma mark Init
+
+- (instancetype)initWithArgC:(int)argc argV:(const char * __nonnull * __nonnull)argv;
+- (instancetype)initWithArgs:(nullable NSArray<NSString *> *)args NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/TNLCLI/TNLCLIExecutionContext.m
+++ b/TNLCLI/TNLCLIExecutionContext.m
@@ -1,0 +1,159 @@
+//
+//  TNLCLIExecutionContext.m
+//  TNLCLI
+//
+//  Created on 9/11/19.
+//  Copyright © 2020 Twitter. All rights reserved.
+//
+
+#import "TNLCLIError.h"
+#import "TNLCLIExecutionContext.h"
+#import "TNLCLIPrint.h"
+
+#pragma mark - Static Functions
+
+static NSArray<NSString *> *parseArgs(int argc, const char * argv[])
+{
+    NSMutableArray<NSString *> *args = [[NSMutableArray alloc] init];
+    for (int c = 0; c < argc; c++) {
+        [args addObject:@(argv[c])];
+    }
+    return [args copy];
+}
+
+#define FAIL(err) \
+({\
+    _contextError = (err); \
+    TNLCLIPrintError(_contextError); \
+    return; \
+})
+#define SOFT_FAIL(err) \
+({\
+    NSError *err__ = (err); \
+    TNLCLIPrintError(err__); \
+    if (!_contextError) { \
+        _contextError = err__; \
+    } \
+})
+
+#pragma mark - TNLCLIExecutionContext
+
+@implementation TNLCLIExecutionContext
+
+#pragma mark Init
+
+- (instancetype)initWithArgC:(int)argc argV:(const char **)argv
+{
+    NSArray<NSString *> *args = parseArgs(argc, argv);
+    return [self initWithArgs:args];
+}
+
+- (instancetype)initWithArgs:(NSArray<NSString *> *)args
+{
+    if (self = [super init]) {
+        [self digestArgs:args];
+    }
+    return self;
+}
+
+- (void)digestArgs:(NSArray<NSString *> *)args
+{
+    if (args.count == 0) {
+        FAIL(TNLCLICreateError(TNLCLIErrorEmptyMainFunctionArguments, @"Expected args for main(...) function"));
+    }
+
+    NSString *str;
+    str = @(getenv("PWD"));
+    if (!str) {
+        FAIL(TNLCLICreateError(TNLCLIErrorMissingPWDEnvironmentVariable, @"Missing PWD environment variable"));
+    } else {
+        _currentDirectory = [str stringByExpandingTildeInPath];
+    }
+
+    str = args.firstObject;
+    if (!str.isAbsolutePath) {
+        str = [_currentDirectory stringByAppendingPathComponent:str];
+    } else {
+        str = [str stringByExpandingTildeInPath];
+    }
+
+    _executableName = str.lastPathComponent;
+    _executableDirectory = [str stringByDeletingLastPathComponent];
+
+    if (args.count == 1) {
+        FAIL(TNLCLICreateError(TNLCLIErrorMissingRequestURLArgument, @"Missing `url` for request (final argument to be passed in)"));
+    }
+
+    if (args.count == 2 && [args[1] isEqualToString:@"--version"]) {
+        _printVersion = YES;
+        return;
+    }
+
+    NSMutableArray<NSString *> *headers = [[NSMutableArray alloc] init];
+    NSMutableArray<NSString *> *configs = [[NSMutableArray alloc] init];
+    NSMutableArray<NSString *> *globals = [[NSMutableArray alloc] init];
+    for (NSUInteger i = 1; i < args.count - 1; ) {
+        NSString *option = args[i++];
+
+        if ([option isEqualToString:@"--verbose"]) {
+            _verbose = YES;
+            continue;
+        }
+
+        if ([option isEqualToString:@"--version"]) {
+            _printVersion = YES;
+            continue;
+        }
+
+        NSString *value = args[i++];
+        if (i == args.count) {
+            FAIL(TNLCLICreateError(TNLCLIErrorMissingRequestURLArgument, @"Missing `url` for request (final argument to be passed in)"));
+        }
+
+#define CASE(arg, ivar) \
+        if ([option isEqualToString: (arg) ]) { \
+            ivar = [value copy]; \
+            continue; \
+        } \
+
+        CASE(@"--request-config-file", _requestConfigurationFilePath);
+        CASE(@"--request-headers-file", _requestHeadersFilePath);
+        CASE(@"--request-body-file", _requestBodyFilePath);
+        CASE(@"--request-method", _requestMethodValueString);
+
+        CASE(@"--response-body-file", _responseBodyTargetFilePath);
+        CASE(@"--response-headers-file", _responseHeadersTargetFilePath);
+        CASE(@"--dump-cert-chain-directory", _certificateChainDumpDirectory);
+
+        if ([option isEqualToString:@"--request-header"]) {
+            [headers addObject:value];
+            continue;
+        }
+        if ([option isEqualToString:@"--request-config"]) {
+            [configs addObject:value];
+            continue;
+        }
+        if ([option isEqualToString:@"--global-config"]) {
+            [globals addObject:value];
+            continue;
+        }
+        if ([option isEqualToString:@"--response-body-mode"]) {
+            _responseBodyOutputModes = [value componentsSeparatedByString:@","];
+            continue;
+        }
+        if ([option isEqualToString:@"--response-headers-mode"]) {
+            _responseHeadersOutputModes = [value componentsSeparatedByString:@","];
+            continue;
+        }
+
+        TNLCLIPrintWarning([NSString stringWithFormat:@"`%@` is an unknown argument.  Skipping it and its value `%@`", option, value]);
+#undef CASE
+    }
+    _requestHeaders = [headers copy];
+    _requestConfigurations = [configs copy];
+    _globalConfigurations = [globals copy];
+    _requestURLString = [args.lastObject copy];
+}
+
+@end
+

--- a/TNLCLI/TNLCLIPrint.h
+++ b/TNLCLI/TNLCLIPrint.h
@@ -1,0 +1,23 @@
+//
+//  TNLCLIPrint.h
+//  tnlcli
+//
+//  Created on 9/12/19.
+//  Copyright © 2020 Twitter. All rights reserved.
+//
+
+@import Foundation;
+
+NS_ASSUME_NONNULL_BEGIN
+
+#define tnlcli_printf   printf
+#define tnlcli_fprintf  fprintf
+
+FOUNDATION_EXTERN void TNLCLIPrintWarning(NSString *warning);
+FOUNDATION_EXTERN void TNLCLIPrintError(NSError *error);
+FOUNDATION_EXTERN void TNLCLIPrintUsage(NSString * __nullable cliName);
+
+FOUNDATION_EXTERN NSData *TNLCLIEnsureDataIsNullTerminated(NSData *data);
+
+
+NS_ASSUME_NONNULL_END

--- a/TNLCLI/TNLCLIPrint.m
+++ b/TNLCLI/TNLCLIPrint.m
@@ -1,0 +1,69 @@
+//
+//  TNLCLIPrint.m
+//  tnlcli
+//
+//  Created on 9/12/19.
+//  Copyright © 2020 Twitter. All rights reserved.
+//
+
+#import "TNLCLIPrint.h"
+
+void TNLCLIPrintWarning(NSString *warning)
+{
+    fprintf(stderr, "WARNING: %s\n", warning.UTF8String);
+}
+
+void TNLCLIPrintError(NSError *error)
+{
+    fprintf(stderr, "ERR: %s:%li %s\n\n", error.domain.UTF8String, error.code, error.userInfo.description.UTF8String ?: "");
+}
+
+NSData *TNLCLIEnsureDataIsNullTerminated(NSData *data)
+{
+    __block BOOL needsNULLTerminator = NO;
+    [data enumerateByteRangesUsingBlock:^(const void * _Nonnull bytes, NSRange byteRange, BOOL * _Nonnull stop) {
+        if (byteRange.location + byteRange.length == data.length) {
+            const char *cStr = bytes;
+            char c = cStr[byteRange.length - 1];
+            needsNULLTerminator = (c != '\0');
+            *stop = YES;
+        }
+    }];
+    if (needsNULLTerminator) {
+        @autoreleasepool {
+            NSMutableData *mData = [data mutableCopy];
+            [mData appendBytes:"" length:1];
+            data = [mData copy];
+        }
+    }
+    return data;
+}
+
+void TNLCLIPrintUsage(NSString * __nullable cliName)
+{
+    // NOTE: when updating the usage, update the README.md too.
+
+    cliName = cliName ?: @"tnlcli";
+    tnlcli_fprintf(stderr, "Usage: %s [options] url\n\n", cliName.UTF8String);
+    tnlcli_fprintf(stderr, "\tExample: %s --request-method HEAD --response-header-mode file,print --response-header-file response_headers.json https://google.com\n\n", cliName.UTF8String);
+    tnlcli_fprintf(stderr, "Argument Options:\n-----------------\n\n");
+    tnlcli_fprintf(stderr, "\t--request-config-file <filepath>     TNLRequestConfiguration as a json file\n");
+    tnlcli_fprintf(stderr, "\t--request-headers-file <filepath>    json file of key-value-pairs for using as headers\n");
+    tnlcli_fprintf(stderr, "\t--request-body-file <filepath>       file for the HTTP body\n");
+    tnlcli_fprintf(stderr, "\n");
+    tnlcli_fprintf(stderr, "\t--request-header \"Field: Value\"      A header to provide with the request (will override the header if also in the request header file). Can provide multiple headers.\n");
+    tnlcli_fprintf(stderr, "\t--request-config \"config: value\"     A config setting for the TNLRequestConfiguration of the request (will override the config if also in the request config file). Can provide multiple configs.\n");
+    tnlcli_fprintf(stderr, "\t--request-method <method>            HTTP Method from Section 9 in HTTP/1.1 spec (RFC 2616), such as GET, POST, HEAD, etc\n");
+    tnlcli_fprintf(stderr, "\n");
+    tnlcli_fprintf(stderr, "\t--response-body-mode <mode>          \"file\" or \"print\" or a combo using commas\n");
+    tnlcli_fprintf(stderr, "\t--response-body-file <filepath>      file for the response body to save to (requires \"file\" for --response-body-mode\n");
+    tnlcli_fprintf(stderr, "\t--response-headers-mode <mode>       \"file\" or \"print\" or a combo using commas\n");
+    tnlcli_fprintf(stderr, "\t--response-headers-file <filepath>   file for the response headers to save to (as json)\n");
+    tnlcli_fprintf(stderr, "\n");
+    tnlcli_fprintf(stderr, "\t--dump-cert-chain-directory <dir>    directory for the certification chain to be dumped to (as DER files)\n");
+    tnlcli_fprintf(stderr, "\n");
+    tnlcli_fprintf(stderr, "\t--verbose                            Will print verbose information and force the --response-body-mode and --responde-headers-mode to have \"print\".\n");
+    tnlcli_fprintf(stderr, "\t--version                            Will print ther version information.\n");
+    tnlcli_fprintf(stderr, "\n");
+}
+

--- a/TNLCLI/TNLCLIUtils.h
+++ b/TNLCLI/TNLCLIUtils.h
@@ -1,0 +1,20 @@
+//
+//  TNLCLIUtils.h
+//  tnlcli
+//
+//  Created on 9/17/19.
+//  Copyright © 2020 Twitter. All rights reserved.
+//
+
+@import Foundation;
+
+NS_ASSUME_NONNULL_BEGIN
+
+FOUNDATION_EXTERN BOOL TNLCLIParseColonSeparatedKeyValuePair(NSString *str,
+                                                             NSString * __nullable * __nullable keyOut,
+                                                             NSString * __nullable * __nullable valueOut);
+
+FOUNDATION_EXTERN NSNumber * __nullable TNLCLINumberValueFromString(NSString *str);
+FOUNDATION_EXTERN NSNumber * __nullable TNLCLIBoolNumberValueFromString(NSString *value);
+
+NS_ASSUME_NONNULL_END

--- a/TNLCLI/TNLCLIUtils.m
+++ b/TNLCLI/TNLCLIUtils.m
@@ -1,0 +1,61 @@
+//
+//  TNLCLIUtils.m
+//  tnlcli
+//
+//  Created on 9/17/19.
+//  Copyright © 2020 Twitter. All rights reserved.
+//
+
+#import "TNLCLIUtils.h"
+
+BOOL TNLCLIParseColonSeparatedKeyValuePair(NSString *str, NSString ** keyOut, NSString ** valueOut)
+{
+    NSString *key, *value;
+    const NSUInteger indexOfColon = [str rangeOfString:@":"].location;
+    if (indexOfColon != NSNotFound) {
+        @autoreleasepool {
+            key = [[str substringToIndex:indexOfColon] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+            value = [[str substringFromIndex:indexOfColon+1] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+        }
+    }
+
+    if (keyOut) {
+        *keyOut = key;
+    }
+    if (valueOut) {
+        *valueOut = value;
+    }
+    return (key && value);
+}
+
+NSNumber *TNLCLINumberValueFromString(NSString *value)
+{
+    NSScanner *scanner = [NSScanner scannerWithString:value];
+    double num;
+    if ([scanner scanDouble:&num] && scanner.atEnd) {
+        return @(num);
+    }
+    return nil;
+}
+
+NSNumber *TNLCLIBoolNumberValueFromString(NSString *value)
+{
+    value = value.lowercaseString;
+
+    static NSSet<NSString *> *sTrueStrings;
+    static NSSet<NSString *> *sFalseStrings;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sTrueStrings = [NSSet setWithObjects:@"true", @"yes", @"1", nil];
+        sFalseStrings = [NSSet setWithObjects:@"false", @"no", @"0", nil];
+    });
+
+    if ([sTrueStrings containsObject:value]) {
+        return @YES;
+    }
+    if ([sFalseStrings containsObject:value]) {
+        return @NO;
+    }
+    return nil;
+}
+

--- a/TNLCLI/TNLGlobalConfiguration+TNLCLI.h
+++ b/TNLCLI/TNLGlobalConfiguration+TNLCLI.h
@@ -1,0 +1,19 @@
+//
+//  TNLGlobalConfiguration+TNLCLI.h
+//  tnlcli
+//
+//  Created on 9/17/19.
+//  Copyright © 2020 Twitter. All rights reserved.
+//
+
+#import <TwitterNetworkLayer/TNLGlobalConfiguration.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface TNLGlobalConfiguration (TNLCLI)
+
+- (BOOL)tnlcli_applySettingWithName:(NSString *)name value:(NSString *)value;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/TNLCLI/TNLGlobalConfiguration+TNLCLI.m
+++ b/TNLCLI/TNLGlobalConfiguration+TNLCLI.m
@@ -1,0 +1,42 @@
+//
+//  TNLGlobalConfiguration+TNLCLI.m
+//  tnlcli
+//
+//  Created on 9/17/19.
+//  Copyright © 2020 Twitter. All rights reserved.
+//
+
+#import <TwitterNetworkLayer/TwitterNetworkLayer.h>
+
+#import "TNLCLIPrint.h"
+#import "TNLCLIUtils.h"
+#import "TNLGlobalConfiguration+TNLCLI.h"
+
+@implementation TNLGlobalConfiguration (TNLCLI)
+
+- (BOOL)tnlcli_applySettingWithName:(NSString *)name value:(NSString *)value
+{
+    if ([name isEqualToString:@"idleTimeoutMode"]) {
+        NSNumber *number = TNLCLINumberValueFromString(value);
+        if (number) {
+            self.idleTimeoutMode = number.integerValue;
+            return YES;
+        } else {
+            TNLCLIPrintWarning([NSString stringWithFormat:@"'%@' should be an integer value matching the 'TNLGlobalConfigurationIdleTimeoutMode' enumeration for global configuration, but '%@' was provided", name, value]);
+        }
+    } else if ([name isEqualToString:@"timeoutIntervalBetweenDataTransfer"]) {
+        NSNumber *number = TNLCLINumberValueFromString(value);
+        if (number) {
+            self.timeoutIntervalBetweenDataTransfer = number.doubleValue;
+            return YES;
+        } else {
+            TNLCLIPrintWarning([NSString stringWithFormat:@"'%@' should be a time interval in seconds as double for global configuration, but '%@' was provided", name, value]);
+        }
+    } else {
+        TNLCLIPrintWarning([NSString stringWithFormat:@"'%@' is not a recognized global configuration setting, ignoring it.", name]);
+    }
+
+    return NO;
+}
+
+@end

--- a/TNLCLI/TNLMutableRequestConfiguration+TNLCLI.h
+++ b/TNLCLI/TNLMutableRequestConfiguration+TNLCLI.h
@@ -1,0 +1,22 @@
+//
+//  TNLMutableRequestConfiguration+TNLCLI.h
+//  tnlcli
+//
+//  Created on 9/17/19.
+//  Copyright © 2020 Twitter. All rights reserved.
+//
+
+#import <TwitterNetworkLayer/TNLRequestConfiguration.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface TNLMutableRequestConfiguration (TNLCLI)
+
++ (nullable instancetype)tnlcli_configurationWithFile:(NSString *)filePath error:(NSError * __nullable * __nullable)errorOut;
++ (instancetype)tnlcli_configurationWithDictionary:(nullable NSDictionary<NSString *, NSString *> *)d;
+
+- (BOOL)tnlcli_applySettingWithName:(NSString *)name value:(NSString *)value;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/TNLCLI/TNLMutableRequestConfiguration+TNLCLI.m
+++ b/TNLCLI/TNLMutableRequestConfiguration+TNLCLI.m
@@ -1,0 +1,170 @@
+//
+//  TNLMutableRequestConfiguration+TNLCLI.m
+//  tnlcli
+//
+//  Created on 9/17/19.
+//  Copyright © 2020 Twitter. All rights reserved.
+//
+
+#import <TwitterNetworkLayer/TwitterNetworkLayer.h>
+
+#import "TNLCLIError.h"
+#import "TNLCLIPrint.h"
+#import "TNLCLIUtils.h"
+#import "TNLMutableRequestConfiguration+TNLCLI.h"
+
+
+@implementation TNLMutableRequestConfiguration (TNLCLI)
+
++ (instancetype)tnlcli_configurationWithFile:(NSString *)filePath error:(NSError * _Nullable __autoreleasing *)errorOut
+{
+    @autoreleasepool {
+        NSError *error;
+        NSDictionary<NSString *, NSString *> *d;
+        NSData *jsonData = [NSData dataWithContentsOfFile:filePath
+                                                  options:0
+                                                    error:&error];
+        if (jsonData) {
+            d = [NSJSONSerialization JSONObjectWithData:jsonData
+                                                options:0
+                                                  error:&error];
+            if (d) {
+                if ([d isKindOfClass:[NSDictionary class]]) {
+                    if (d.count) {
+                        __block BOOL allStrings = YES;
+                        [d enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull key, NSString * _Nonnull obj, BOOL * _Nonnull stop) {
+                            if (![key isKindOfClass:[NSString class]] || ![obj isKindOfClass:[NSString class]]) {
+                                allStrings = NO;
+                                *stop = YES;
+                            }
+                        }];
+                        if (!allStrings) {
+                            d = nil;
+                        }
+                    }
+                } else {
+                    d = nil;
+                }
+            }
+        }
+
+        if (!error && !d) {
+            error = TNLCLICreateError(TNLCLIErrorInvalidRequestConfigurationFileFormat, @{ @"file" : filePath });
+        }
+
+        if (errorOut) {
+            *errorOut = error;
+        }
+        if (error) {
+            return nil;
+        }
+
+        return [self tnlcli_configurationWithDictionary:d];
+    }
+}
+
++ (instancetype)tnlcli_configurationWithDictionary:(NSDictionary<NSString *,NSString *> *)d
+{
+    TNLMutableRequestConfiguration *config = [[self alloc] init];
+    [d enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull key, NSString * _Nonnull obj, BOOL * _Nonnull stop) {
+        (void)[config tnlcli_applySettingWithName:key value:obj];
+    }];
+    return config;
+}
+
+- (BOOL)tnlcli_applySettingWithName:(NSString *)name value:(NSString *)value
+{
+#define BOOL_SETTING(setting) \
+do { \
+    if ([name isEqualToString: @"" #setting ]) { \
+        NSNumber *number = TNLCLIBoolNumberValueFromString(value); \
+        if (number) { \
+            self. setting = number.boolValue; \
+            return YES; \
+        } \
+        TNLCLIPrintWarning([NSString stringWithFormat:@"'%@' should be an BOOL for a `TNLRequestConfiguration`, but '%@' was provided", name, value]); \
+        return NO; \
+    } \
+} while (0)
+
+#define NUMBER_SETTING(setting, accessor) \
+do { \
+    if ([name isEqualToString: @"" #setting ]) { \
+        NSNumber *number = TNLCLINumberValueFromString(value); \
+        if (number) { \
+            self. setting = [number accessor##Value]; \
+            return YES; \
+        } \
+        TNLCLIPrintWarning([NSString stringWithFormat:@"'%@' should be a " #accessor " for `TNLRequestConfiguration`, but '%@' was provided", name, value]); \
+        return NO; \
+    } \
+} while (0)
+
+#define STRING_SETTING(setting) \
+do { \
+    if ([name isEqualToString: @"" #setting ]) { \
+        self. setting = value; \
+        return YES; \
+    } \
+} while (0)
+
+
+    /// BOOL settings
+
+    BOOL_SETTING(contributeToExecutingNetworkConnectionsCount);
+    BOOL_SETTING(skipHostSanitization);
+    BOOL_SETTING(shouldSetCookies);
+    BOOL_SETTING(allowsCellularAccess);
+    BOOL_SETTING(discretionary);
+    BOOL_SETTING(shouldUseExtendedBackgroundIdleMode);
+    BOOL_SETTING(shouldLaunchAppForBackgroundEvents);
+
+
+    /// Double settings
+
+    NUMBER_SETTING(idleTimeout, double);
+    NUMBER_SETTING(attemptTimeout, double);
+    NUMBER_SETTING(operationTimeout, double);
+    NUMBER_SETTING(deferrableInterval, double);
+
+
+    /// Integer settings
+
+    NUMBER_SETTING(executionMode, integer);
+    NUMBER_SETTING(redirectPolicy, integer);
+    NUMBER_SETTING(responseDataConsumptionMode, integer);
+    NUMBER_SETTING(protocolOptions, integer);
+    NUMBER_SETTING(connectivityOptions, integer);
+    NUMBER_SETTING(responseComputeHashAlgorithm, integer);
+    // NUMBER_SETTING(multipathServiceType, integer); -- unavailable on Mac
+
+
+    /// Unsigned Integer settings
+
+    NUMBER_SETTING(cachePolicy, unsignedInteger);
+    NUMBER_SETTING(cookieAcceptPolicy, unsignedInteger);
+    NUMBER_SETTING(networkServiceType, unsignedInteger);
+
+
+    /// String settings
+
+    STRING_SETTING(sharedContainerIdentifier);
+
+
+    /// Unsupported from key-value-pair settings (aka TODO)
+
+    //    @property id<TNLRequestRetryPolicyProvider> retryPolicyProvider;
+    //    @property id<TNLContentEncoder> contentEncoder;
+    //    @property NSArray<id<TNLContentDecoder>> *additionalContentDecoders;
+    //    @property NSURLCredentialStorage *URLCredentialStorage;
+    //    @property NSURLCache *URLCache;
+    //    @property NSHTTPCookieStorage *cookieStorage;
+
+    return NO;
+
+#undef BOOL_SETTING
+#undef NUMBER_SETTING
+#undef STRING_SETTING
+}
+
+@end

--- a/TNLCLI/main.m
+++ b/TNLCLI/main.m
@@ -1,0 +1,29 @@
+//
+//  main.m
+//  TNLCLI
+//
+//  Created on 9/11/19.
+//  Copyright © 2020 Twitter. All rights reserved.
+//
+
+#import "TNLCLIExecution.h"
+#import "TNLCLIPrint.h"
+
+@import Foundation;
+
+int main(int argc, const char * argv[])
+{
+    int result = 0;
+    @autoreleasepool {
+
+        TNLCLIExecutionContext *context = [[TNLCLIExecutionContext alloc] initWithArgC:argc argV:argv];
+        TNLCLIExecution *exe = [[TNLCLIExecution alloc] initWithContext:context];
+        NSError *error = [exe execute];
+        if (error) {
+            TNLCLIPrintUsage(context.executableName);
+            result = (int)error.code ?: -1;
+        }
+
+    }
+    return result;
+}

--- a/TNLExample/TAPI/TAPI.h
+++ b/TNLExample/TAPI/TAPI.h
@@ -3,7 +3,7 @@
 //  TNLExample
 //
 //  Created on 5/25/18.
-//  Copyright © 2018 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 // Twitter API Imports

--- a/TNLExample/TAPI/TAPIClient.h
+++ b/TNLExample/TAPI/TAPIClient.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/17/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <TwitterNetworkLayer/TwitterNetworkLayer.h>

--- a/TNLExample/TAPI/TAPIClient.m
+++ b/TNLExample/TAPI/TAPIClient.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/17/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <CommonCrypto/CommonHMAC.h>

--- a/TNLExample/TAPI/TAPIError.h
+++ b/TNLExample/TAPI/TAPIError.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/17/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/TNLExample/TAPI/TAPIError.m
+++ b/TNLExample/TAPI/TAPIError.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/17/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TAPIError.h"

--- a/TNLExample/TAPI/TAPIFavoriteRequests.h
+++ b/TNLExample/TAPI/TAPIFavoriteRequests.h
@@ -3,7 +3,7 @@
 //  TNLExample
 //
 //  Created on 5/24/18.
-//  Copyright © 2018 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TAPIRequest.h"

--- a/TNLExample/TAPI/TAPIFavoriteRequests.m
+++ b/TNLExample/TAPI/TAPIFavoriteRequests.m
@@ -3,7 +3,7 @@
 //  TNLExample
 //
 //  Created on 5/24/18.
-//  Copyright © 2018 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TAPIFavoriteRequests.h"

--- a/TNLExample/TAPI/TAPIModel.h
+++ b/TNLExample/TAPI/TAPIModel.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/17/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <CoreGraphics/CGGeometry.h>

--- a/TNLExample/TAPI/TAPIModel.m
+++ b/TNLExample/TAPI/TAPIModel.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/17/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <TwitterNetworkLayer/TwitterNetworkLayer.h>

--- a/TNLExample/TAPI/TAPIRequest.h
+++ b/TNLExample/TAPI/TAPIRequest.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/17/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/TNLExample/TAPI/TAPIRequest.m
+++ b/TNLExample/TAPI/TAPIRequest.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/17/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TAPIRequest.h"

--- a/TNLExample/TAPI/TAPIResponse.h
+++ b/TNLExample/TAPI/TAPIResponse.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/17/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <TwitterNetworkLayer/TwitterNetworkLayer.h>

--- a/TNLExample/TAPI/TAPIResponse.m
+++ b/TNLExample/TAPI/TAPIResponse.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/17/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TAPIError.h"

--- a/TNLExample/TAPI/TAPISearchRequests.h
+++ b/TNLExample/TAPI/TAPISearchRequests.h
@@ -3,7 +3,7 @@
 //  TNLExample
 //
 //  Created on 5/24/18.
-//  Copyright © 2018 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TAPIModel.h"

--- a/TNLExample/TAPI/TAPISearchRequests.m
+++ b/TNLExample/TAPI/TAPISearchRequests.m
@@ -3,7 +3,7 @@
 //  TNLExample
 //
 //  Created on 5/24/18.
-//  Copyright © 2018 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TAPIError.h"

--- a/TNLExample/TAPI/TAPIUploadMediaRequest.h
+++ b/TNLExample/TAPI/TAPIUploadMediaRequest.h
@@ -2,8 +2,8 @@
 //  TAPIUploadMediaRequest.h
 //  TNLExample
 //
-//  Created by Nolan O'Brien on 5/30/18.
-//  Copyright © 2018 Twitter. All rights reserved.
+//  Created on 5/30/18.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TAPIRequest.h"

--- a/TNLExample/TAPI/TAPIUploadMediaRequest.m
+++ b/TNLExample/TAPI/TAPIUploadMediaRequest.m
@@ -2,8 +2,8 @@
 //  TAPIUploadMediaRequest.m
 //  TNLExample
 //
-//  Created by Nolan O'Brien on 5/30/18.
-//  Copyright © 2018 Twitter. All rights reserved.
+//  Created on 5/30/18.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TAPIUploadMediaRequest.h"

--- a/TNLExample/TNLExample.entitlements
+++ b/TNLExample/TNLExample.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/TNLExample/TNLXAppDelegate.h
+++ b/TNLExample/TNLXAppDelegate.h
@@ -3,7 +3,7 @@
 //  TNLExample
 //
 //  Created on 7/24/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 @import UIKit;

--- a/TNLExample/TNLXAppDelegate.m
+++ b/TNLExample/TNLXAppDelegate.m
@@ -3,7 +3,7 @@
 //  TNLExample
 //
 //  Created on 7/24/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <TwitterNetworkLayer/TwitterNetworkLayer.h>

--- a/TNLExample/TNLXDummy.h
+++ b/TNLExample/TNLXDummy.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 8/29/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 @import UIKit;

--- a/TNLExample/TNLXDummy.m
+++ b/TNLExample/TNLXDummy.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 8/29/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <TwitterNetworkLayer/TwitterNetworkLayer.h>

--- a/TNLExample/TNLXImageSupport.h
+++ b/TNLExample/TNLXImageSupport.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 8/18/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <TwitterNetworkLayer/TwitterNetworkLayer.h>

--- a/TNLExample/TNLXImageSupport.m
+++ b/TNLExample/TNLXImageSupport.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 8/18/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNLXImageSupport.h"

--- a/TNLExample/TNLXImageTableViewController.h
+++ b/TNLExample/TNLXImageTableViewController.h
@@ -3,7 +3,7 @@
 //  TNLExample
 //
 //  Created on 7/24/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 @import UIKit;

--- a/TNLExample/TNLXImageTableViewController.m
+++ b/TNLExample/TNLXImageTableViewController.m
@@ -3,7 +3,7 @@
 //  TNLExample
 //
 //  Created on 7/24/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <objc/runtime.h>

--- a/TNLExample/TNLXImageViewController.h
+++ b/TNLExample/TNLXImageViewController.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 8/18/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 @import UIKit;

--- a/TNLExample/TNLXImageViewController.m
+++ b/TNLExample/TNLXImageViewController.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 8/18/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <TwitterNetworkLayer/TwitterNetworkLayer.h>

--- a/TNLExample/TNLXLotsOfRequestsViewController.h
+++ b/TNLExample/TNLXLotsOfRequestsViewController.h
@@ -3,7 +3,7 @@
 //  TNLExample
 //
 //  Created on 7/24/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 @import UIKit;

--- a/TNLExample/TNLXLotsOfRequestsViewController.m
+++ b/TNLExample/TNLXLotsOfRequestsViewController.m
@@ -3,7 +3,7 @@
 //  TNLExample
 //
 //  Created on 7/24/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <objc/runtime.h>

--- a/TNLExample/TNLXMultipartFormData.h
+++ b/TNLExample/TNLXMultipartFormData.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 8/22/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNLRequest.h"

--- a/TNLExample/TNLXMultipartFormData.m
+++ b/TNLExample/TNLXMultipartFormData.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 8/22/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "NSDictionary+TNLAdditions.h"

--- a/TNLExample/TNLXNetworkHeuristicObserver.h
+++ b/TNLExample/TNLXNetworkHeuristicObserver.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 1/26/15.
-//  Copyright (c) 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <TwitterNetworkLayer/TwitterNetworkLayer.h>

--- a/TNLExample/TNLXNetworkHeuristicObserver.m
+++ b/TNLExample/TNLXNetworkHeuristicObserver.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 1/26/15.
-//  Copyright (c) 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNLXNetworkHeuristicObserver.h"

--- a/TNLExample/TNLXPlaygroundViewController.h
+++ b/TNLExample/TNLXPlaygroundViewController.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 8/23/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 @import UIKit;

--- a/TNLExample/TNLXPlaygroundViewController.m
+++ b/TNLExample/TNLXPlaygroundViewController.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 8/23/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <TwitterNetworkLayer/TwitterNetworkLayer.h>

--- a/TNLExample/en.lproj/InfoPlist.strings
+++ b/TNLExample/en.lproj/InfoPlist.strings
@@ -1,2 +1,0 @@
-/* Localized versions of Info.plist keys */
-

--- a/TNLExample/main.m
+++ b/TNLExample/main.m
@@ -3,7 +3,7 @@
 //  TNLExample
 //
 //  Created on 7/24/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNLXAppDelegate.h"

--- a/TwitterNetworkLayer.xcodeproj/project.pbxproj
+++ b/TwitterNetworkLayer.xcodeproj/project.pbxproj
@@ -65,6 +65,9 @@
 		8B490DDD22A82B9D002D2296 /* NSCoder+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B490DD622A82B9D002D2296 /* NSCoder+TNLAdditions.m */; };
 		8B490DDE22A82B9D002D2296 /* NSCoder+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B490DD622A82B9D002D2296 /* NSCoder+TNLAdditions.m */; };
 		8B4AA7621E1F297C00BF7EA0 /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B4AA75D1E1F28DF00BF7EA0 /* CoreTelephony.framework */; };
+		8B4AF738245A359A00ABB8D5 /* TNLCommunicationAgentTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B4AF737245A359A00ABB8D5 /* TNLCommunicationAgentTest.m */; };
+		8B4AF739245A359A00ABB8D5 /* TNLCommunicationAgentTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B4AF737245A359A00ABB8D5 /* TNLCommunicationAgentTest.m */; };
+		8B4AF73A245A359A00ABB8D5 /* TNLCommunicationAgentTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B4AF737245A359A00ABB8D5 /* TNLCommunicationAgentTest.m */; };
 		8B4CBEA91A169A6800230318 /* TNLRequestRetryPolicyConfigurationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B4CBEA81A169A6800230318 /* TNLRequestRetryPolicyConfigurationTest.m */; };
 		8B4DEFF91986AA64008A31EB /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B4DEFF81986AA64008A31EB /* SystemConfiguration.framework */; };
 		8B4DEFFC1986AE55008A31EB /* TNLURLCoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B4DEFFA1986AE55008A31EB /* TNLURLCoding.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -102,6 +105,8 @@
 		8B84348A1A13B8E500D006DA /* TNLResponseTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B8434891A13B8E500D006DA /* TNLResponseTest.m */; };
 		8B84348C1A13BF3C00D006DA /* TNLRequestOperationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B84348B1A13BF3C00D006DA /* TNLRequestOperationTest.m */; };
 		8B84348E1A1509F500D006DA /* NSURLCache+TNLAdditionsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B84348D1A1509F500D006DA /* NSURLCache+TNLAdditionsTest.m */; };
+		8B84E5C0232AC621001CC260 /* TNLCLIExecution.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B84E5BF232AC621001CC260 /* TNLCLIExecution.m */; };
+		8B84E5C3232ACB10001CC260 /* TNLCLIPrint.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B84E5C2232ACB10001CC260 /* TNLCLIPrint.m */; };
 		8B86BF3A1A2D0998005AE96B /* TNLGlobalConfiguration_Project.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B86BF381A2D0998005AE96B /* TNLGlobalConfiguration_Project.h */; };
 		8B879D8619F1B5F500FE95FF /* TAPIRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B879D8519F1B5F500FE95FF /* TAPIRequest.m */; };
 		8B879D8919F1B74E00FE95FF /* TAPIError.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B879D8819F1B74E00FE95FF /* TAPIError.m */; };
@@ -251,6 +256,10 @@
 		8BB26ABB1D8B142E00D1AB5A /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B6DCB4B1974598300235576 /* CFNetwork.framework */; };
 		8BB26ABC1D8B143900D1AB5A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B6DCB491974583B00235576 /* UIKit.framework */; };
 		8BB8B87D1A1E710E0093AE63 /* TNLRequestDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BB8B87B1A1E710E0093AE63 /* TNLRequestDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BBF551323297F3900C94709 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BBF551223297F3900C94709 /* main.m */; };
+		8BBF551923297F5800C94709 /* TwitterNetworkLayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF4AA13B1EE61D47001647B5 /* TwitterNetworkLayer.framework */; };
+		8BBF551C23297FEE00C94709 /* TNLCLIExecutionContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BBF551B23297FEE00C94709 /* TNLCLIExecutionContext.m */; };
+		8BBF551F232980FC00C94709 /* TNLCLIError.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BBF551E232980FC00C94709 /* TNLCLIError.m */; };
 		8BC1AC3D19A27559008687EE /* TNLXImageSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BC1AC3C19A27559008687EE /* TNLXImageSupport.m */; };
 		8BCA626419C356AE00F3F8CA /* TNLRequestOperationState.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BCA626319C356AE00F3F8CA /* TNLRequestOperationState.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8BCAF8C519F716370043EB22 /* TNLRequestOperationCancelSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BCAF8C319F716370043EB22 /* TNLRequestOperationCancelSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -266,6 +275,9 @@
 		8BD500E71D8765F200D828C7 /* TNLURLStringCoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD500E61D8765F200D828C7 /* TNLURLStringCoding.m */; };
 		8BD500F51D87762200D828C7 /* TNL_ProjectCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BD500F31D87762200D828C7 /* TNL_ProjectCommon.h */; };
 		8BD500F61D87762200D828C7 /* TNL_ProjectCommon.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD500F41D87762200D828C7 /* TNL_ProjectCommon.m */; };
+		8BD5F4C42331DE3A00C46FAA /* TNLCLIUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD5F4C32331DE3A00C46FAA /* TNLCLIUtils.m */; };
+		8BD5F4C72331DF6800C46FAA /* TNLGlobalConfiguration+TNLCLI.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD5F4C62331DF6800C46FAA /* TNLGlobalConfiguration+TNLCLI.m */; };
+		8BD5F4CA2331E0ED00C46FAA /* TNLMutableRequestConfiguration+TNLCLI.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD5F4C92331E0ED00C46FAA /* TNLMutableRequestConfiguration+TNLCLI.m */; };
 		8BD8715D22AD82360011DACA /* Network.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BCC9EEF22AC36C400A5D1C8 /* Network.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		8BD8715E22AD823A0011DACA /* Network.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BCC9EEF22AC36C400A5D1C8 /* Network.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		8BDA9D2D197881DE00678D90 /* TNLError.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BDA9D2B197881DE00678D90 /* TNLError.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -276,11 +288,18 @@
 		8BDB97E31D24D28700861951 /* TwitterNetworkLayer.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8BE402C61946743D00C7241E /* TwitterNetworkLayer.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8BDC0E3C1BDFE15C0077F8FC /* TNLLRUCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BDC0E391BDFE15C0077F8FC /* TNLLRUCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8BDC0E3E1BDFE15C0077F8FC /* TNLLRUCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BDC0E3A1BDFE15C0077F8FC /* TNLLRUCache.m */; };
+		8BDC839E243408E70001BA82 /* TNLBackoff.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BDC839D243408E70001BA82 /* TNLBackoff.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BDC839F243408E70001BA82 /* TNLBackoff.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BDC839D243408E70001BA82 /* TNLBackoff.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BDC83A0243408E70001BA82 /* TNLBackoff.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BDC839D243408E70001BA82 /* TNLBackoff.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BDC83A2243449220001BA82 /* TNLBackoff.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BDC83A1243449220001BA82 /* TNLBackoff.m */; };
+		8BDC83A3243449220001BA82 /* TNLBackoff.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BDC83A1243449220001BA82 /* TNLBackoff.m */; };
+		8BDC83A4243449220001BA82 /* TNLBackoff.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BDC83A1243449220001BA82 /* TNLBackoff.m */; };
+		8BDC83A5243449220001BA82 /* TNLBackoff.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BDC83A1243449220001BA82 /* TNLBackoff.m */; };
+		8BDC83A6243449280001BA82 /* TNLBackoff.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BDC839D243408E70001BA82 /* TNLBackoff.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8BDDDF1D19C0D0BB00D7C0CD /* TNLXMultipartFormData.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BDDDF1C19C0D0BB00D7C0CD /* TNLXMultipartFormData.m */; };
 		8BDFFC0519814D3100F7F670 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BE402C91946743D00C7241E /* Foundation.framework */; };
 		8BDFFC0719814D3100F7F670 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8BDFFC0619814D3100F7F670 /* CoreGraphics.framework */; };
 		8BDFFC0819814D3100F7F670 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B6DCB491974583B00235576 /* UIKit.framework */; };
-		8BDFFC0E19814D3100F7F670 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8BDFFC0C19814D3100F7F670 /* InfoPlist.strings */; };
 		8BDFFC1019814D3100F7F670 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BDFFC0F19814D3100F7F670 /* main.m */; };
 		8BDFFC1419814D3100F7F670 /* TNLXAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BDFFC1319814D3100F7F670 /* TNLXAppDelegate.m */; };
 		8BDFFC1719814D3100F7F670 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8BDFFC1519814D3100F7F670 /* Main.storyboard */; };
@@ -319,6 +338,14 @@
 		8BE68D021B7E421100A0F853 /* NSOperationQueue+TNLSafety.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE68CFE1B7E421100A0F853 /* NSOperationQueue+TNLSafety.m */; };
 		8BE857661DD396B100F79F3D /* NSURLRequest+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BE857641DD396B100F79F3D /* NSURLRequest+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8BE857671DD396B100F79F3D /* NSURLRequest+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BE857651DD396B100F79F3D /* NSURLRequest+TNLAdditions.m */; };
+		8BEB80B224216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BEB80B024216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BEB80B324216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BEB80B024216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BEB80B424216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BEB80B024216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BEB80B524216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BEB80B024216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BEB80B624216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BEB80B124216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.m */; };
+		8BEB80B724216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BEB80B124216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.m */; };
+		8BEB80B824216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BEB80B124216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.m */; };
+		8BEB80B924216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BEB80B124216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.m */; };
 		8BED1FC11A89480C00279141 /* TNLRequestRedirecter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BED1FBF1A89480C00279141 /* TNLRequestRedirecter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8BEE98C31ADC5E3100A58A92 /* TNLHTTPHeaderProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BEE98C11ADC5E3100A58A92 /* TNLHTTPHeaderProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8BF3D2B71A76EAF800DABD9D /* TNLXNetworkHeuristicObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BF3D2B61A76EAF700DABD9D /* TNLXNetworkHeuristicObserver.m */; };
@@ -656,6 +683,13 @@
 			remoteGlobalIDString = 8BFDF90C2135AB2C002F6A80;
 			remoteInfo = "TwitterNetworkLayer tvOS";
 		};
+		8BBF551723297F4E00C94709 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8BE402BE1946743D00C7241E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BF4AA0C01EE61D46001647B5;
+			remoteInfo = "TwitterNetworkLayer macOS";
+		};
 		BF4765F81EEEFC5B00A23506 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 8BE402BE1946743D00C7241E /* Project object */;
@@ -666,6 +700,15 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		8BBF550E23297F3900C94709 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
 		8BDB97E71D24D28800861951 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -732,6 +775,8 @@
 		8B490DD522A82B9D002D2296 /* NSCoder+TNLAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSCoder+TNLAdditions.h"; sourceTree = "<group>"; };
 		8B490DD622A82B9D002D2296 /* NSCoder+TNLAdditions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSCoder+TNLAdditions.m"; sourceTree = "<group>"; };
 		8B4AA75D1E1F28DF00BF7EA0 /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = System/Library/Frameworks/CoreTelephony.framework; sourceTree = SDKROOT; };
+		8B4AF736245A341E00ABB8D5 /* TNLExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TNLExample.entitlements; sourceTree = "<group>"; };
+		8B4AF737245A359A00ABB8D5 /* TNLCommunicationAgentTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TNLCommunicationAgentTest.m; sourceTree = "<group>"; };
 		8B4CBEA81A169A6800230318 /* TNLRequestRetryPolicyConfigurationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TNLRequestRetryPolicyConfigurationTest.m; sourceTree = "<group>"; };
 		8B4DEFF81986AA64008A31EB /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		8B4DEFFA1986AE55008A31EB /* TNLURLCoding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TNLURLCoding.h; sourceTree = "<group>"; };
@@ -771,6 +816,10 @@
 		8B8434891A13B8E500D006DA /* TNLResponseTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TNLResponseTest.m; sourceTree = "<group>"; };
 		8B84348B1A13BF3C00D006DA /* TNLRequestOperationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TNLRequestOperationTest.m; sourceTree = "<group>"; };
 		8B84348D1A1509F500D006DA /* NSURLCache+TNLAdditionsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURLCache+TNLAdditionsTest.m"; sourceTree = "<group>"; };
+		8B84E5BE232AC621001CC260 /* TNLCLIExecution.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TNLCLIExecution.h; sourceTree = "<group>"; };
+		8B84E5BF232AC621001CC260 /* TNLCLIExecution.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TNLCLIExecution.m; sourceTree = "<group>"; };
+		8B84E5C1232ACB10001CC260 /* TNLCLIPrint.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TNLCLIPrint.h; sourceTree = "<group>"; };
+		8B84E5C2232ACB10001CC260 /* TNLCLIPrint.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TNLCLIPrint.m; sourceTree = "<group>"; };
 		8B86BF381A2D0998005AE96B /* TNLGlobalConfiguration_Project.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TNLGlobalConfiguration_Project.h; sourceTree = "<group>"; };
 		8B879D8419F1B5F500FE95FF /* TAPIRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TAPIRequest.h; path = TAPI/TAPIRequest.h; sourceTree = "<group>"; };
 		8B879D8519F1B5F500FE95FF /* TAPIRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TAPIRequest.m; path = TAPI/TAPIRequest.m; sourceTree = "<group>"; };
@@ -805,6 +854,12 @@
 		8BB1190D1D83537C00E75CD9 /* NSData+TNLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+TNLAdditions.h"; sourceTree = "<group>"; };
 		8BB1190E1D83537C00E75CD9 /* NSData+TNLAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+TNLAdditions.m"; sourceTree = "<group>"; };
 		8BB8B87B1A1E710E0093AE63 /* TNLRequestDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TNLRequestDelegate.h; sourceTree = "<group>"; };
+		8BBF551023297F3900C94709 /* tnlcli */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = tnlcli; sourceTree = BUILT_PRODUCTS_DIR; };
+		8BBF551223297F3900C94709 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		8BBF551A23297FEE00C94709 /* TNLCLIExecutionContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TNLCLIExecutionContext.h; sourceTree = "<group>"; };
+		8BBF551B23297FEE00C94709 /* TNLCLIExecutionContext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TNLCLIExecutionContext.m; sourceTree = "<group>"; };
+		8BBF551D232980FC00C94709 /* TNLCLIError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TNLCLIError.h; sourceTree = "<group>"; };
+		8BBF551E232980FC00C94709 /* TNLCLIError.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TNLCLIError.m; sourceTree = "<group>"; };
 		8BC1AC3B19A27559008687EE /* TNLXImageSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TNLXImageSupport.h; sourceTree = "<group>"; };
 		8BC1AC3C19A27559008687EE /* TNLXImageSupport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TNLXImageSupport.m; sourceTree = "<group>"; };
 		8BCA626319C356AE00F3F8CA /* TNLRequestOperationState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TNLRequestOperationState.h; sourceTree = "<group>"; };
@@ -820,18 +875,25 @@
 		8BD500E61D8765F200D828C7 /* TNLURLStringCoding.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TNLURLStringCoding.m; sourceTree = "<group>"; };
 		8BD500F31D87762200D828C7 /* TNL_ProjectCommon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TNL_ProjectCommon.h; sourceTree = "<group>"; };
 		8BD500F41D87762200D828C7 /* TNL_ProjectCommon.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TNL_ProjectCommon.m; sourceTree = "<group>"; };
+		8BD5F4C22331DE3A00C46FAA /* TNLCLIUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TNLCLIUtils.h; sourceTree = "<group>"; };
+		8BD5F4C32331DE3A00C46FAA /* TNLCLIUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TNLCLIUtils.m; sourceTree = "<group>"; };
+		8BD5F4C52331DF6800C46FAA /* TNLGlobalConfiguration+TNLCLI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TNLGlobalConfiguration+TNLCLI.h"; sourceTree = "<group>"; };
+		8BD5F4C62331DF6800C46FAA /* TNLGlobalConfiguration+TNLCLI.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "TNLGlobalConfiguration+TNLCLI.m"; sourceTree = "<group>"; };
+		8BD5F4C82331E0ED00C46FAA /* TNLMutableRequestConfiguration+TNLCLI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TNLMutableRequestConfiguration+TNLCLI.h"; sourceTree = "<group>"; };
+		8BD5F4C92331E0ED00C46FAA /* TNLMutableRequestConfiguration+TNLCLI.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "TNLMutableRequestConfiguration+TNLCLI.m"; sourceTree = "<group>"; };
 		8BDA9D2B197881DE00678D90 /* TNLError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TNLError.h; sourceTree = "<group>"; };
 		8BDA9D2C197881DE00678D90 /* TNLError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TNLError.m; sourceTree = "<group>"; };
 		8BDA9D311978822300678D90 /* TNLPriority.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TNLPriority.h; sourceTree = "<group>"; };
 		8BDA9D321978822300678D90 /* TNLPriority.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TNLPriority.m; sourceTree = "<group>"; };
 		8BDC0E391BDFE15C0077F8FC /* TNLLRUCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TNLLRUCache.h; sourceTree = "<group>"; };
 		8BDC0E3A1BDFE15C0077F8FC /* TNLLRUCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TNLLRUCache.m; sourceTree = "<group>"; };
+		8BDC839D243408E70001BA82 /* TNLBackoff.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TNLBackoff.h; sourceTree = "<group>"; };
+		8BDC83A1243449220001BA82 /* TNLBackoff.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TNLBackoff.m; sourceTree = "<group>"; };
 		8BDDDF1B19C0D0BB00D7C0CD /* TNLXMultipartFormData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TNLXMultipartFormData.h; sourceTree = "<group>"; };
 		8BDDDF1C19C0D0BB00D7C0CD /* TNLXMultipartFormData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TNLXMultipartFormData.m; sourceTree = "<group>"; };
 		8BDFFC0419814D3100F7F670 /* TNLExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TNLExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8BDFFC0619814D3100F7F670 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		8BDFFC0B19814D3100F7F670 /* TNLExample-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "TNLExample-Info.plist"; sourceTree = "<group>"; };
-		8BDFFC0D19814D3100F7F670 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		8BDFFC0F19814D3100F7F670 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		8BDFFC1219814D3100F7F670 /* TNLXAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TNLXAppDelegate.h; sourceTree = "<group>"; };
 		8BDFFC1319814D3100F7F670 /* TNLXAppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TNLXAppDelegate.m; sourceTree = "<group>"; };
@@ -872,6 +934,8 @@
 		8BE68CFE1B7E421100A0F853 /* NSOperationQueue+TNLSafety.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSOperationQueue+TNLSafety.m"; sourceTree = "<group>"; };
 		8BE857641DD396B100F79F3D /* NSURLRequest+TNLAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURLRequest+TNLAdditions.h"; sourceTree = "<group>"; };
 		8BE857651DD396B100F79F3D /* NSURLRequest+TNLAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURLRequest+TNLAdditions.m"; sourceTree = "<group>"; };
+		8BEB80B024216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSURLAuthenticationChallenge+TNLAdditions.h"; sourceTree = "<group>"; };
+		8BEB80B124216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSURLAuthenticationChallenge+TNLAdditions.m"; sourceTree = "<group>"; };
 		8BED1FBF1A89480C00279141 /* TNLRequestRedirecter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TNLRequestRedirecter.h; sourceTree = "<group>"; };
 		8BEE98C11ADC5E3100A58A92 /* TNLHTTPHeaderProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TNLHTTPHeaderProvider.h; sourceTree = "<group>"; };
 		8BF3D2B51A76EAF700DABD9D /* TNLXNetworkHeuristicObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TNLXNetworkHeuristicObserver.h; sourceTree = "<group>"; };
@@ -903,6 +967,14 @@
 				8B9EBDE82135B4B100E6E466 /* Foundation.framework in Frameworks */,
 				8B9EBDE92135B4B100E6E466 /* Security.framework in Frameworks */,
 				8B9EBDEB2135B4B100E6E466 /* UIKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8BBF550D23297F3900C94709 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8BBF551923297F5800C94709 /* TwitterNetworkLayer.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1079,6 +1151,28 @@
 			name = Private;
 			sourceTree = "<group>";
 		};
+		8BBF551123297F3900C94709 /* TNLCLI */ = {
+			isa = PBXGroup;
+			children = (
+				8BBF551223297F3900C94709 /* main.m */,
+				8BBF551D232980FC00C94709 /* TNLCLIError.h */,
+				8BBF551E232980FC00C94709 /* TNLCLIError.m */,
+				8B84E5BE232AC621001CC260 /* TNLCLIExecution.h */,
+				8B84E5BF232AC621001CC260 /* TNLCLIExecution.m */,
+				8BBF551A23297FEE00C94709 /* TNLCLIExecutionContext.h */,
+				8BBF551B23297FEE00C94709 /* TNLCLIExecutionContext.m */,
+				8B84E5C1232ACB10001CC260 /* TNLCLIPrint.h */,
+				8B84E5C2232ACB10001CC260 /* TNLCLIPrint.m */,
+				8BD5F4C22331DE3A00C46FAA /* TNLCLIUtils.h */,
+				8BD5F4C32331DE3A00C46FAA /* TNLCLIUtils.m */,
+				8BD5F4C52331DF6800C46FAA /* TNLGlobalConfiguration+TNLCLI.h */,
+				8BD5F4C62331DF6800C46FAA /* TNLGlobalConfiguration+TNLCLI.m */,
+				8BD5F4C82331E0ED00C46FAA /* TNLMutableRequestConfiguration+TNLCLI.h */,
+				8BD5F4C92331E0ED00C46FAA /* TNLMutableRequestConfiguration+TNLCLI.m */,
+			);
+			path = TNLCLI;
+			sourceTree = "<group>";
+		};
 		8BDFFC0919814D3100F7F670 /* TNLExample */ = {
 			isa = PBXGroup;
 			children = (
@@ -1087,6 +1181,7 @@
 				8BDFFC1519814D3100F7F670 /* Main.storyboard */,
 				8BDFFC0A19814D3100F7F670 /* Supporting Files */,
 				8B879D8019F1B5CB00FE95FF /* TAPI */,
+				8B4AF736245A341E00ABB8D5 /* TNLExample.entitlements */,
 				8BDFFC1219814D3100F7F670 /* TNLXAppDelegate.h */,
 				8BDFFC1319814D3100F7F670 /* TNLXAppDelegate.m */,
 				8B2EC95019B13F1700EE8816 /* TNLXDummy.h */,
@@ -1109,7 +1204,6 @@
 			isa = PBXGroup;
 			children = (
 				8BDFFC0B19814D3100F7F670 /* TNLExample-Info.plist */,
-				8BDFFC0C19814D3100F7F670 /* InfoPlist.strings */,
 				8BDFFC0F19814D3100F7F670 /* main.m */,
 			);
 			name = "Supporting Files";
@@ -1125,6 +1219,7 @@
 				8BE402C71946743D00C7241E /* Products */,
 				8B109D6B20B63F15000D10AA /* README.md */,
 				8BE402CB1946743E00C7241E /* Source */,
+				8BBF551123297F3900C94709 /* TNLCLI */,
 				8BDFFC0919814D3100F7F670 /* TNLExample */,
 				8BE402DF1946743E00C7241E /* TwitterNetworkLayerTests */,
 			);
@@ -1141,6 +1236,7 @@
 				8BFDF98D2135AB2C002F6A80 /* TwitterNetworkLayer.framework */,
 				8BFDF9BD2135ACDB002F6A80 /* TwitterNetworkLayerTests tvOS.xctest */,
 				8B9EBE362135B4B100E6E466 /* TwitterNetworkLayer.framework */,
+				8BBF551023297F3900C94709 /* tnlcli */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1187,6 +1283,8 @@
 				8BE68CFE1B7E421100A0F853 /* NSOperationQueue+TNLSafety.m */,
 				8B87BA3D1E09DA20005A8926 /* NSURL+TNLAdditions.h */,
 				8B87BA3E1E09DA20005A8926 /* NSURL+TNLAdditions.m */,
+				8BEB80B024216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.h */,
+				8BEB80B124216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.m */,
 				8B8434831A13B77700D006DA /* NSURLCache+TNLAdditions.h */,
 				8B8434841A13B77700D006DA /* NSURLCache+TNLAdditions.m */,
 				8BA336D81A3271A0005D7B35 /* NSURLCredentialStorage+TNLAdditions.h */,
@@ -1208,6 +1306,8 @@
 				8BF953DC1A67DD3F00E9C1AA /* TNLAttemptMetrics.m */,
 				8B153161207D1DA400A1288F /* TNLAuthenticationChallengeHandler.h */,
 				8B2924BC1992E42900AC139A /* TNLBackgroundURLSessionTaskOperationManager.m */,
+				8BDC839D243408E70001BA82 /* TNLBackoff.h */,
+				8BDC83A1243449220001BA82 /* TNLBackoff.m */,
 				8B00D5A91CFF512100D1728D /* TNLCommunicationAgent.h */,
 				8B00D5AA1CFF512100D1728D /* TNLCommunicationAgent.m */,
 				8B6E34241DE0B755004A35C7 /* TNLContentCoding.h */,
@@ -1283,6 +1383,7 @@
 				8BE402E01946743E00C7241E /* Supporting Files */,
 				5C7E65741B0298670037AD91 /* TNLAttemptMetaDataTest.m */,
 				8B68AA5C1D95BF2E00AFD0C8 /* TNLAutoDependencyTest.m */,
+				8B4AF737245A359A00ABB8D5 /* TNLCommunicationAgentTest.m */,
 				8B6E34261DE35F71004A35C7 /* TNLContentEncodingTests.m */,
 				8B986C641BE3EF1D0053BB14 /* TNLHTTPTests.m */,
 				8B8A684219FF13F0008623E8 /* TNLNetworkTests.m */,
@@ -1354,6 +1455,7 @@
 				8B9EBE0B2135B4B100E6E466 /* TNL_ProjectCommon.h in Headers */,
 				8B9EBE0C2135B4B100E6E466 /* TNLNetworkObserver.h in Headers */,
 				8B9EBE0D2135B4B100E6E466 /* TNLTiming.h in Headers */,
+				8BEB80B524216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.h in Headers */,
 				8B9EBE0E2135B4B100E6E466 /* TNLRequestOperationCancelSource.h in Headers */,
 				8B9EBE0F2135B4B100E6E466 /* TNLError.h in Headers */,
 				8B9EBE102135B4B100E6E466 /* TNLAttemptMetrics_Project.h in Headers */,
@@ -1382,6 +1484,7 @@
 				8B9EBE272135B4B100E6E466 /* TNLRequestOperationQueue.h in Headers */,
 				8B9EBE282135B4B100E6E466 /* TNLRequestOperationState.h in Headers */,
 				8B9EBE292135B4B100E6E466 /* TNLRequestRedirecter.h in Headers */,
+				8BDC83A6243449280001BA82 /* TNLBackoff.h in Headers */,
 				8B9EBE2A2135B4B100E6E466 /* TNLCommunicationAgent_Project.h in Headers */,
 				8B9EBE2B2135B4B100E6E466 /* TNLNetwork.h in Headers */,
 				8B9EBE2C2135B4B100E6E466 /* TNLResponse_Project.h in Headers */,
@@ -1430,6 +1533,7 @@
 				8BD500F51D87762200D828C7 /* TNL_ProjectCommon.h in Headers */,
 				8B82A5A71948D3E900A16237 /* TNLNetworkObserver.h in Headers */,
 				8B5141231CE530E100830987 /* TNLTiming.h in Headers */,
+				8BEB80B224216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.h in Headers */,
 				8BCAF8C519F716370043EB22 /* TNLRequestOperationCancelSource.h in Headers */,
 				8BDA9D2D197881DE00678D90 /* TNLError.h in Headers */,
 				8BF953E31A67E73E00E9C1AA /* TNLAttemptMetrics_Project.h in Headers */,
@@ -1456,6 +1560,7 @@
 				8B86BF3A1A2D0998005AE96B /* TNLGlobalConfiguration_Project.h in Headers */,
 				8B9038E219799D7C001A3DDD /* TNLTemporaryFile_Project.h in Headers */,
 				8BE403211946794300C7241E /* TNLRequestOperationQueue.h in Headers */,
+				8BDC839E243408E70001BA82 /* TNLBackoff.h in Headers */,
 				8BCA626419C356AE00F3F8CA /* TNLRequestOperationState.h in Headers */,
 				8BED1FC11A89480C00279141 /* TNLRequestRedirecter.h in Headers */,
 				8B5DBBFE206D8F9D007EF65B /* TNLCommunicationAgent_Project.h in Headers */,
@@ -1506,6 +1611,7 @@
 				8BFDF9622135AB2C002F6A80 /* TNL_ProjectCommon.h in Headers */,
 				8BFDF9632135AB2C002F6A80 /* TNLNetworkObserver.h in Headers */,
 				8BFDF9642135AB2C002F6A80 /* TNLTiming.h in Headers */,
+				8BEB80B424216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.h in Headers */,
 				8BFDF9652135AB2C002F6A80 /* TNLRequestOperationCancelSource.h in Headers */,
 				8BFDF9662135AB2C002F6A80 /* TNLError.h in Headers */,
 				8BFDF9672135AB2C002F6A80 /* TNLAttemptMetrics_Project.h in Headers */,
@@ -1532,6 +1638,7 @@
 				8BFDF97C2135AB2C002F6A80 /* TNLGlobalConfiguration_Project.h in Headers */,
 				8BFDF97D2135AB2C002F6A80 /* TNLTemporaryFile_Project.h in Headers */,
 				8BFDF97E2135AB2C002F6A80 /* TNLRequestOperationQueue.h in Headers */,
+				8BDC83A0243408E70001BA82 /* TNLBackoff.h in Headers */,
 				8BFDF97F2135AB2C002F6A80 /* TNLRequestOperationState.h in Headers */,
 				8BFDF9802135AB2C002F6A80 /* TNLRequestRedirecter.h in Headers */,
 				8BFDF9812135AB2C002F6A80 /* TNLCommunicationAgent_Project.h in Headers */,
@@ -1598,6 +1705,7 @@
 				BF4AA1241EE61D46001647B5 /* NSURLResponse+TNLAdditions.h in Headers */,
 				BF4AA1251EE61D46001647B5 /* TNLURLCoding.h in Headers */,
 				BF4AA1261EE61D46001647B5 /* TNLPseudoURLProtocol.h in Headers */,
+				8BEB80B324216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.h in Headers */,
 				BF4AA1271EE61D46001647B5 /* TNLLogger.h in Headers */,
 				8BD083CB1FD9C20E0090B7C3 /* TNLTimeoutOperation.h in Headers */,
 				BF4AA1281EE61D46001647B5 /* TwitterNetworkLayer.h in Headers */,
@@ -1613,6 +1721,7 @@
 				BF4AA1311EE61D46001647B5 /* TNLNetwork.h in Headers */,
 				BF4AA1321EE61D46001647B5 /* TNLResponse_Project.h in Headers */,
 				BF4AA1331EE61D46001647B5 /* TNLLRUCache.h in Headers */,
+				8BDC839F243408E70001BA82 /* TNLBackoff.h in Headers */,
 				8B153163207D1DA400A1288F /* TNLAuthenticationChallengeHandler.h in Headers */,
 				BF4AA1341EE61D46001647B5 /* TNLRequestConfiguration_Project.h in Headers */,
 				BF4AA1351EE61D46001647B5 /* NSURL+TNLAdditions.h in Headers */,
@@ -1640,6 +1749,24 @@
 			productName = TwitterNetworkLayer;
 			productReference = 8B9EBE362135B4B100E6E466 /* TwitterNetworkLayer.framework */;
 			productType = "com.apple.product-type.framework";
+		};
+		8BBF550F23297F3900C94709 /* tnlcli */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8BBF551623297F3900C94709 /* Build configuration list for PBXNativeTarget "tnlcli" */;
+			buildPhases = (
+				8BBF550C23297F3900C94709 /* Sources */,
+				8BBF550D23297F3900C94709 /* Frameworks */,
+				8BBF550E23297F3900C94709 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				8BBF551823297F4E00C94709 /* PBXTargetDependency */,
+			);
+			name = tnlcli;
+			productName = TNLCLI;
+			productReference = 8BBF551023297F3900C94709 /* tnlcli */;
+			productType = "com.apple.product-type.tool";
 		};
 		8BDFFC0319814D3100F7F670 /* TNLExample */ = {
 			isa = PBXNativeTarget;
@@ -1772,11 +1899,15 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = TNL;
-				LastUpgradeCheck = 1030;
+				LastUpgradeCheck = 1140;
 				ORGANIZATIONNAME = Twitter;
 				TargetAttributes = {
 					8B9EBDB52135B4B100E6E466 = {
 						ProvisioningStyle = Manual;
+					};
+					8BBF550F23297F3900C94709 = {
+						CreatedOnToolsVersion = 11.0;
+						ProvisioningStyle = Automatic;
 					};
 					8BDFFC0319814D3100F7F670 = {
 						ProvisioningStyle = Manual;
@@ -1823,6 +1954,7 @@
 				8BFDF90C2135AB2C002F6A80 /* TwitterNetworkLayer tvOS */,
 				8BFDF98F2135ACDB002F6A80 /* TwitterNetworkLayerTests tvOS */,
 				8B9EBDB52135B4B100E6E466 /* TwitterNetworkLayer watchOS */,
+				8BBF550F23297F3900C94709 /* tnlcli */,
 			);
 		};
 /* End PBXProject section */
@@ -1833,7 +1965,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				8BDFFC1F19814D3100F7F670 /* Images.xcassets in Resources */,
-				8BDFFC0E19814D3100F7F670 /* InfoPlist.strings in Resources */,
 				8BDFFC1719814D3100F7F670 /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1899,6 +2030,7 @@
 				8B9EBDCC2135B4B100E6E466 /* NSCachedURLResponse+TNLAdditions.m in Sources */,
 				8B9EBDCD2135B4B100E6E466 /* TNLLRUCache.m in Sources */,
 				8B9EBDCE2135B4B100E6E466 /* TNLParameterCollection.m in Sources */,
+				8BDC83A5243449220001BA82 /* TNLBackoff.m in Sources */,
 				8B9EBDCF2135B4B100E6E466 /* TNLPseudoURLProtocol.m in Sources */,
 				8B9EBDD02135B4B100E6E466 /* TNL_ProjectCommon.m in Sources */,
 				8B9EBDD12135B4B100E6E466 /* TNLPriority.m in Sources */,
@@ -1910,6 +2042,7 @@
 				8B9EBDD62135B4B100E6E466 /* TNLAttemptMetrics.m in Sources */,
 				8B9EBDD72135B4B100E6E466 /* TNLCommunicationAgent.m in Sources */,
 				8B9EBDD82135B4B100E6E466 /* TNLTemporaryFile.m in Sources */,
+				8BEB80B924216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.m in Sources */,
 				8B9EBDD92135B4B100E6E466 /* TNLRequestOperationQueue.m in Sources */,
 				8B9EBDDA2135B4B100E6E466 /* TNLHTTP.m in Sources */,
 				8B9EBDDB2135B4B100E6E466 /* TNLError.m in Sources */,
@@ -1920,6 +2053,21 @@
 				8B9EBDE02135B4B100E6E466 /* TNLBackgroundURLSessionTaskOperationManager.m in Sources */,
 				8B9EBDE12135B4B100E6E466 /* TNLTimeoutOperation.m in Sources */,
 				8B9EBDE22135B4B100E6E466 /* TNLRequestOperationCancelSource.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8BBF550C23297F3900C94709 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8BBF551C23297FEE00C94709 /* TNLCLIExecutionContext.m in Sources */,
+				8BBF551323297F3900C94709 /* main.m in Sources */,
+				8B84E5C0232AC621001CC260 /* TNLCLIExecution.m in Sources */,
+				8BBF551F232980FC00C94709 /* TNLCLIError.m in Sources */,
+				8BD5F4CA2331E0ED00C46FAA /* TNLMutableRequestConfiguration+TNLCLI.m in Sources */,
+				8BD5F4C72331DF6800C46FAA /* TNLGlobalConfiguration+TNLCLI.m in Sources */,
+				8B84E5C3232ACB10001CC260 /* TNLCLIPrint.m in Sources */,
+				8BD5F4C42331DE3A00C46FAA /* TNLCLIUtils.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1976,6 +2124,7 @@
 				8B277E4C1C022B5C00279EA9 /* NSCachedURLResponse+TNLAdditions.m in Sources */,
 				8BDC0E3E1BDFE15C0077F8FC /* TNLLRUCache.m in Sources */,
 				8B4E017219FB0632004D3CED /* TNLParameterCollection.m in Sources */,
+				8BDC83A2243449220001BA82 /* TNLBackoff.m in Sources */,
 				8B0AFAA91A018EBE00C8C81F /* TNLPseudoURLProtocol.m in Sources */,
 				8BD500F61D87762200D828C7 /* TNL_ProjectCommon.m in Sources */,
 				8BDA9D351978822300678D90 /* TNLPriority.m in Sources */,
@@ -1987,6 +2136,7 @@
 				8BF953E01A67DD3F00E9C1AA /* TNLAttemptMetrics.m in Sources */,
 				8B00D5AC1CFF512100D1728D /* TNLCommunicationAgent.m in Sources */,
 				8B9038DE19799D4A001A3DDD /* TNLTemporaryFile.m in Sources */,
+				8BEB80B624216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.m in Sources */,
 				8BE403221946794300C7241E /* TNLRequestOperationQueue.m in Sources */,
 				8BE4032619467A1400C7241E /* TNLHTTP.m in Sources */,
 				8BDA9D2F197881DE00678D90 /* TNLError.m in Sources */,
@@ -2014,6 +2164,7 @@
 				8B8A683E19FEEB51008623E8 /* TNLParameterCollectionTests.m in Sources */,
 				8B84348C1A13BF3C00D006DA /* TNLRequestOperationTest.m in Sources */,
 				8B84348E1A1509F500D006DA /* NSURLCache+TNLAdditionsTest.m in Sources */,
+				8B4AF738245A359A00ABB8D5 /* TNLCommunicationAgentTest.m in Sources */,
 				8BFF0A6319FFEFED001F42B7 /* NSURLSessionConfiguration+TNLAdditionsTest.m in Sources */,
 				8B5F44861A1903A100720DEA /* TNLXMultipartFormData.m in Sources */,
 				8B4CBEA91A169A6800230318 /* TNLRequestRetryPolicyConfigurationTest.m in Sources */,
@@ -2059,6 +2210,7 @@
 				8BFDF9232135AB2C002F6A80 /* NSCachedURLResponse+TNLAdditions.m in Sources */,
 				8BFDF9242135AB2C002F6A80 /* TNLLRUCache.m in Sources */,
 				8BFDF9252135AB2C002F6A80 /* TNLParameterCollection.m in Sources */,
+				8BDC83A4243449220001BA82 /* TNLBackoff.m in Sources */,
 				8BFDF9262135AB2C002F6A80 /* TNLPseudoURLProtocol.m in Sources */,
 				8BFDF9272135AB2C002F6A80 /* TNL_ProjectCommon.m in Sources */,
 				8BFDF9282135AB2C002F6A80 /* TNLPriority.m in Sources */,
@@ -2070,6 +2222,7 @@
 				8BFDF92D2135AB2C002F6A80 /* TNLAttemptMetrics.m in Sources */,
 				8BFDF92E2135AB2C002F6A80 /* TNLCommunicationAgent.m in Sources */,
 				8BFDF92F2135AB2C002F6A80 /* TNLTemporaryFile.m in Sources */,
+				8BEB80B824216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.m in Sources */,
 				8BFDF9302135AB2C002F6A80 /* TNLRequestOperationQueue.m in Sources */,
 				8BFDF9312135AB2C002F6A80 /* TNLHTTP.m in Sources */,
 				8BFDF9322135AB2C002F6A80 /* TNLError.m in Sources */,
@@ -2097,6 +2250,7 @@
 				8BFDF9992135ACDB002F6A80 /* TNLParameterCollectionTests.m in Sources */,
 				8BFDF99A2135ACDB002F6A80 /* TNLRequestOperationTest.m in Sources */,
 				8BFDF99B2135ACDB002F6A80 /* NSURLCache+TNLAdditionsTest.m in Sources */,
+				8B4AF73A245A359A00ABB8D5 /* TNLCommunicationAgentTest.m in Sources */,
 				8BFDF99C2135ACDB002F6A80 /* NSURLSessionConfiguration+TNLAdditionsTest.m in Sources */,
 				8BFDF99D2135ACDB002F6A80 /* TNLXMultipartFormData.m in Sources */,
 				8BFDF99E2135ACDB002F6A80 /* TNLRequestRetryPolicyConfigurationTest.m in Sources */,
@@ -2142,6 +2296,7 @@
 				BF4AA0D71EE61D46001647B5 /* NSCachedURLResponse+TNLAdditions.m in Sources */,
 				BF4AA0D81EE61D46001647B5 /* TNLLRUCache.m in Sources */,
 				BF4AA0D91EE61D46001647B5 /* TNLParameterCollection.m in Sources */,
+				8BDC83A3243449220001BA82 /* TNLBackoff.m in Sources */,
 				BF4AA0DA1EE61D46001647B5 /* TNLPseudoURLProtocol.m in Sources */,
 				BF4AA0DB1EE61D46001647B5 /* TNL_ProjectCommon.m in Sources */,
 				BF4AA0DC1EE61D46001647B5 /* TNLPriority.m in Sources */,
@@ -2153,6 +2308,7 @@
 				BF4AA0E11EE61D46001647B5 /* TNLAttemptMetrics.m in Sources */,
 				BF4AA0E21EE61D46001647B5 /* TNLCommunicationAgent.m in Sources */,
 				BF4AA0E31EE61D46001647B5 /* TNLTemporaryFile.m in Sources */,
+				8BEB80B724216AF900FEF7BC /* NSURLAuthenticationChallenge+TNLAdditions.m in Sources */,
 				BF4AA0E41EE61D46001647B5 /* TNLRequestOperationQueue.m in Sources */,
 				BF4AA0E51EE61D46001647B5 /* TNLHTTP.m in Sources */,
 				BF4AA0E61EE61D46001647B5 /* TNLError.m in Sources */,
@@ -2180,6 +2336,7 @@
 				BF4AA1481EE626ED001647B5 /* TNLParameterCollectionTests.m in Sources */,
 				BF4AA1491EE626ED001647B5 /* TNLRequestOperationTest.m in Sources */,
 				BF4AA14A1EE626ED001647B5 /* NSURLCache+TNLAdditionsTest.m in Sources */,
+				8B4AF739245A359A00ABB8D5 /* TNLCommunicationAgentTest.m in Sources */,
 				BF4AA14B1EE626ED001647B5 /* NSURLSessionConfiguration+TNLAdditionsTest.m in Sources */,
 				BF4AA14C1EE626ED001647B5 /* TNLXMultipartFormData.m in Sources */,
 				BF4AA14D1EE626ED001647B5 /* TNLRequestRetryPolicyConfigurationTest.m in Sources */,
@@ -2215,6 +2372,11 @@
 			target = 8BFDF90C2135AB2C002F6A80 /* TwitterNetworkLayer tvOS */;
 			targetProxy = 8B9EBDB32135B2D700E6E466 /* PBXContainerItemProxy */;
 		};
+		8BBF551823297F4E00C94709 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BF4AA0C01EE61D46001647B5 /* TwitterNetworkLayer macOS */;
+			targetProxy = 8BBF551723297F4E00C94709 /* PBXContainerItemProxy */;
+		};
 		BF4765F91EEEFC5B00A23506 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = BF4AA0C01EE61D46001647B5 /* TwitterNetworkLayer macOS */;
@@ -2223,14 +2385,6 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
-		8BDFFC0C19814D3100F7F670 /* InfoPlist.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				8BDFFC0D19814D3100F7F670 /* en */,
-			);
-			name = InfoPlist.strings;
-			sourceTree = "<group>";
-		};
 		8BDFFC1519814D3100F7F670 /* Main.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -2278,6 +2432,63 @@
 			};
 			name = Release;
 		};
+		8BBF551423297F3900C94709 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = NO;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path . /usr/local/lib";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		8BBF551523297F3900C94709 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = NO;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path . /usr/local/lib";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
 		8BDFFC3219814D3100F7F670 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2301,6 +2512,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.twitter.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTS_MACCATALYST = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
 			};
@@ -2326,6 +2538,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.twitter.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTS_MACCATALYST = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
 			};
@@ -2363,8 +2576,9 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 2.8;
+				CURRENT_PROJECT_VERSION = 2.14;
 				DEAD_CODE_STRIPPING = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
 				DYLIB_CURRENT_VERSION = "$(CURRENT_PROJECT_VERSION)";
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
@@ -2430,7 +2644,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2.8;
+				CURRENT_PROJECT_VERSION = 2.14;
 				DEAD_CODE_STRIPPING = NO;
 				DYLIB_CURRENT_VERSION = "$(CURRENT_PROJECT_VERSION)";
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -2478,6 +2692,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_MODULES_AUTOLINK = NO;
+				"DEBUG_INFORMATION_FORMAT[sdk=macosx*]" = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twitter.TwitterNetworkLayer;
@@ -2490,6 +2705,7 @@
 		8BE402ED1946743E00C7241E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				INFOPLIST_FILE = "TwitterNetworkLayerTests/TwitterNetworkLayerTests-Info.plist";
 				OTHER_LDFLAGS = (
@@ -2506,6 +2722,7 @@
 		8BE402EE1946743E00C7241E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				INFOPLIST_FILE = "TwitterNetworkLayerTests/TwitterNetworkLayerTests-Info.plist";
 				ONLY_ACTIVE_ARCH = YES;
@@ -2650,6 +2867,15 @@
 			buildConfigurations = (
 				8B9EBE342135B4B100E6E466 /* Debug */,
 				8B9EBE352135B4B100E6E466 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8BBF551623297F3900C94709 /* Build configuration list for PBXNativeTarget "tnlcli" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8BBF551423297F3900C94709 /* Debug */,
+				8BBF551523297F3900C94709 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TNLCLI.xcscheme
+++ b/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TNLCLI.xcscheme
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1140"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8BBF550F23297F3900C94709"
+               BuildableName = "tnlcli"
+               BlueprintName = "tnlcli"
+               ReferencedContainer = "container:TwitterNetworkLayer.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8BBF550F23297F3900C94709"
+            BuildableName = "tnlcli"
+            BlueprintName = "tnlcli"
+            ReferencedContainer = "container:TwitterNetworkLayer.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "--global-config idleTimeoutMode:face"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--global-config face:face"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--global-config idleTimeoutMode:300.00"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--global-config idleTimeoutMode:0"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--request-config idleTimeout:face"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--request-config idleTimeout:300"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--request-config &quot;executionMode: 8&quot;"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--request-config responseDataConsumptionMode:2"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--request-config connectivityOptions:5"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--request-config responseComputeHashAlgorithm:1932670262"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--request-config redirectPolicy:2"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--request-method GET"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--response-headers-mode print"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--response-body-mode print"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--verbose"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--version"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--request-header &quot;Name: Nolan O:Brien&quot;"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--request-header &quot;Color: green;blue&quot;"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--dump-cert-chain-directory &quot;~/Desktop/cert.dump&quot;"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "https://google.com"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8BBF550F23297F3900C94709"
+            BuildableName = "tnlcli"
+            BlueprintName = "tnlcli"
+            ReferencedContainer = "container:TwitterNetworkLayer.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TNLExample.xcscheme
+++ b/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TNLExample.xcscheme
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1030"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer macOS.xcscheme
+++ b/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1030"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -41,6 +41,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BF4AA0C01EE61D46001647B5"
+            BuildableName = "TwitterNetworkLayer.framework"
+            BlueprintName = "TwitterNetworkLayer macOS"
+            ReferencedContainer = "container:TwitterNetworkLayer.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO"
@@ -54,17 +63,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "BF4AA0C01EE61D46001647B5"
-            BuildableName = "TwitterNetworkLayer.framework"
-            BlueprintName = "TwitterNetworkLayer macOS"
-            ReferencedContainer = "container:TwitterNetworkLayer.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -85,8 +83,6 @@
             ReferencedContainer = "container:TwitterNetworkLayer.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer tvOS.xcscheme
+++ b/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer tvOS.xcscheme
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1030"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8BFDF90C2135AB2C002F6A80"
+            BuildableName = "TwitterNetworkLayer.framework"
+            BlueprintName = "TwitterNetworkLayer tvOS"
+            ReferencedContainer = "container:TwitterNetworkLayer.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO"
@@ -40,17 +49,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "8BFDF90C2135AB2C002F6A80"
-            BuildableName = "TwitterNetworkLayer.framework"
-            BlueprintName = "TwitterNetworkLayer tvOS"
-            ReferencedContainer = "container:TwitterNetworkLayer.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -71,8 +69,6 @@
             ReferencedContainer = "container:TwitterNetworkLayer.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer watchOS.xcscheme
+++ b/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer watchOS.xcscheme
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1030"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:TwitterNetworkLayer.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -60,8 +58,6 @@
             ReferencedContainer = "container:TwitterNetworkLayer.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer.xcscheme
+++ b/TwitterNetworkLayer.xcodeproj/xcshareddata/xcschemes/TwitterNetworkLayer.xcscheme
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1030"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/TwitterNetworkLayerTests/NSDictionary+TNLAdditionsTest.m
+++ b/TwitterNetworkLayerTests/NSDictionary+TNLAdditionsTest.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/27/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "NSDictionary+TNLAdditions.h"

--- a/TwitterNetworkLayerTests/NSOperationQueue+TNLSafetyTest.m
+++ b/TwitterNetworkLayerTests/NSOperationQueue+TNLSafetyTest.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/6/15.
-//  Copyright © 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #include <stdatomic.h>

--- a/TwitterNetworkLayerTests/NSURLCache+TNLAdditionsTest.m
+++ b/TwitterNetworkLayerTests/NSURLCache+TNLAdditionsTest.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/28/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "NSURLCache+TNLAdditions.h"
@@ -73,7 +73,20 @@
 
     NSString *path = [NSTemporaryDirectory() stringByAppendingPathComponent:NSStringFromSelector(_cmd)];
     [[NSFileManager defaultManager] removeItemAtPath:path error:NULL];
-    NSURLCache *cache = [[NSURLCache alloc] initWithMemoryCapacity:1024*1024*10 diskCapacity:1024*1024*10 diskPath:path];
+    NSURLCache *cache;
+    if (tnl_available_ios_13) {
+        cache = [[NSURLCache alloc] initWithMemoryCapacity:1024*1024*10
+                                              diskCapacity:1024*1024*10
+                                              directoryURL:[NSURL URLWithString:path]];
+    }
+#if !TARGET_OS_MACCATALYST
+    else {
+        cache = [[NSURLCache alloc] initWithMemoryCapacity:1024*1024*10
+                                              diskCapacity:1024*1024*10
+                                                  diskPath:path];
+
+    }
+#endif
     [cache removeAllCachedResponses];
     [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:2.0]]; // give cache time to purge
     tnl_defer(^{

--- a/TwitterNetworkLayerTests/NSURLSessionConfiguration+TNLAdditionsTest.m
+++ b/TwitterNetworkLayerTests/NSURLSessionConfiguration+TNLAdditionsTest.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/28/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "NSURLSessionConfiguration+TNLAdditions.h"

--- a/TwitterNetworkLayerTests/TNLAttemptMetaDataTest.m
+++ b/TwitterNetworkLayerTests/TNLAttemptMetaDataTest.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created by Kevin Goodier on 05/12/15.
-//  Copyright (c) 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNL_Project.h"

--- a/TwitterNetworkLayerTests/TNLAutoDependencyTest.m
+++ b/TwitterNetworkLayerTests/TNLAutoDependencyTest.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 9/23/16.
-//  Copyright © 2016 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <XCTest/XCTest.h>

--- a/TwitterNetworkLayerTests/TNLCommunicationAgentTest.m
+++ b/TwitterNetworkLayerTests/TNLCommunicationAgentTest.m
@@ -1,0 +1,59 @@
+//
+//  TNLCommunicationAgentTest.m
+//  TwitterNetworkLayer
+//
+//  Created by Nolan on 4/29/20.
+//  Copyright © 2020 Twitter. All rights reserved.
+//
+
+#import "TNLCommunicationAgent.h"
+
+@import XCTest;
+
+#define TEST_COMM_AGENT 0
+
+@interface TNLCommunicationAgentTest : XCTestCase
+@end
+
+// This "test" mostly just excercises the communication agent and logs the state.
+// It is best to avoid the network interfaces of a machine during unit tests,
+// so this "test" is disable but available for local testing by setting TEST_COMM_AGENT to 1.
+@implementation TNLCommunicationAgentTest
+
+#if TEST_COMM_AGENT
+- (void)testCommunicationAgent
+{
+    TNLCommunicationAgent *agent = [[TNLCommunicationAgent alloc] initWithInternetReachabilityHost:@"api.twitter.com"];
+
+    XCTestExpectation *reachExpectation = [self expectationWithDescription:@"reachability"];
+    [agent identifyReachability:^(TNLNetworkReachabilityFlags flags, TNLNetworkReachabilityStatus status) {
+        [reachExpectation fulfill];
+    }];
+    XCTestExpectation *carrierExpectation = [self expectationWithDescription:@"carrier"];
+    [agent identifyCarrierInfo:^(id<TNLCarrierInfo>  _Nullable info) {
+        [carrierExpectation fulfill];
+    }];
+    XCTestExpectation *radioExpectation = [self expectationWithDescription:@"radio"];
+    [agent identifyWWANRadioAccessTechnology:^(NSString * _Nullable info) {
+        [radioExpectation fulfill];
+    }];
+    XCTestExpectation *captivePortalExpectation = [self expectationWithDescription:@"captive.portal"];
+    [agent identifyCaptivePortalStatus:^(TNLCaptivePortalStatus status) {
+        [captivePortalExpectation fulfill];
+    }];
+
+    [self waitForExpectations:@[reachExpectation,
+                                carrierExpectation,
+                                radioExpectation,
+                                captivePortalExpectation]
+                      timeout:10.0];
+
+    NSLog(@"Reach.Status: %@", TNLNetworkReachabilityStatusToString(agent.currentReachabilityStatus));
+    NSLog(@"Reach.Flags:  %@", TNLDebugStringFromNetworkReachabilityFlags(agent.currentReachabilityFlags));
+    NSLog(@"Radio.Tech:   %@", agent.currentWWANRadioAccessTechnology);
+    NSLog(@"Carrier:      %@", agent.currentCarrierInfo);
+    NSLog(@"Captive:      %@", TNLCaptivePortalStatusToString(agent.currentCaptivePortalStatus));
+}
+#endif // TEST_COMM_AGENT
+
+@end

--- a/TwitterNetworkLayerTests/TNLContentEncodingTests.m
+++ b/TwitterNetworkLayerTests/TNLContentEncodingTests.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 11/21/16.
-//  Copyright © 2016 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <TwitterNetworkLayer/TwitterNetworkLayer.h>

--- a/TwitterNetworkLayerTests/TNLHTTPTests.m
+++ b/TwitterNetworkLayerTests/TNLHTTPTests.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/30/15.
-//  Copyright © 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNLHTTP.h"

--- a/TwitterNetworkLayerTests/TNLNetworkTests.m
+++ b/TwitterNetworkLayerTests/TNLNetworkTests.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/27/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNLNetwork.h"

--- a/TwitterNetworkLayerTests/TNLParameterCollectionTests.m
+++ b/TwitterNetworkLayerTests/TNLParameterCollectionTests.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/27/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #include <objc/runtime.h>

--- a/TwitterNetworkLayerTests/TNLPseudoRequestOperationTest.m
+++ b/TwitterNetworkLayerTests/TNLPseudoRequestOperationTest.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/29/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "NSDictionary+TNLAdditions.h"

--- a/TwitterNetworkLayerTests/TNLRequestConfigurationTest.m
+++ b/TwitterNetworkLayerTests/TNLRequestConfigurationTest.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 11/11/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "NSHTTPCookieStorage+TNLAdditions.h"

--- a/TwitterNetworkLayerTests/TNLRequestOperationQueueTest.m
+++ b/TwitterNetworkLayerTests/TNLRequestOperationQueueTest.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 5/1/15.
-//  Copyright (c) 2015 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNLRequestOperationQueue.h"

--- a/TwitterNetworkLayerTests/TNLRequestRetryPolicyConfigurationTest.m
+++ b/TwitterNetworkLayerTests/TNLRequestRetryPolicyConfigurationTest.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 11/14/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNLHTTPRequest.h"

--- a/TwitterNetworkLayerTests/TNLRequestRetryPolicyTest.m
+++ b/TwitterNetworkLayerTests/TNLRequestRetryPolicyTest.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayerTests
 //
 //  Created on 8/24/18.
-//  Copyright © 2018 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNL_Project.h"
@@ -12,23 +12,67 @@
 @import TwitterNetworkLayer;
 @import XCTest;
 
+#define kDELAY_TIME_INTERVAL (0.2)
+
 @interface BrokenContentEncoder : NSObject <TNLContentEncoder>
 @end
 
 @interface TestRetryPolicy : NSObject <TNLConfiguringRetryPolicyProvider>
+@property (nonatomic) NSTimeInterval retryDelay;
+@property (nonatomic) NSUInteger maxAttempts;
 @end
 
-@interface TNLRequestRetryPolicyTest : XCTestCase
+@interface TimerOperation : NSOperation
+- (instancetype)initWithTimeout:(NSTimeInterval)timeout;
+@end
+
+@interface TNLRequestRetryPolicyTest : XCTestCase <TNLRequestDelegate>
 @end
 
 @implementation TNLRequestRetryPolicyTest
+{
+    TNLResponse *_response;
+    NSTimeInterval _dependencyDuration;
+    NSTimeInterval _dependencyDelay;
+    NSTimeInterval _retryDelay;
+    dispatch_block_t _onNextRetry;
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+    _response = nil;
+    _dependencyDuration = 0;
+    _dependencyDelay = 0;
+    _retryDelay = 0;
+    _onNextRetry = nil;
+}
 
 - (void)testRetryPolicy
 {
+    for (_retryDelay = 0.0; _retryDelay < (kDELAY_TIME_INTERVAL * 1.5); _retryDelay += kDELAY_TIME_INTERVAL) {
+        for (_dependencyDuration = 0.0; _dependencyDuration < (kDELAY_TIME_INTERVAL * 1.5); _dependencyDuration += kDELAY_TIME_INTERVAL) {
+            for (_dependencyDelay = 0.0; _dependencyDelay < (kDELAY_TIME_INTERVAL * 1.5); _dependencyDelay += kDELAY_TIME_INTERVAL) {
+                NSString *cmdStr = NSStringFromSelector(_cmd);
+                NSLog(@"%@: retry-delay=%fs, dependency-duration=%fs, dependency-delay=%fs", cmdStr, _retryDelay, _dependencyDuration, _dependencyDelay);
+                const CFAbsoluteTime start = CFAbsoluteTimeGetCurrent();
+                [self _runRetryPolicyTest];
+                const NSTimeInterval duration = CFAbsoluteTimeGetCurrent() - start;
+                NSLog(@"%@: run=%fs", cmdStr, duration);
+                _response = nil;
+            }
+        }
+    }
+}
+
+- (void)_runRetryPolicyTest
+{
+    TestRetryPolicy *retryPolicy = [[TestRetryPolicy alloc] initWithConfiguration:[TNLRequestRetryPolicyConfiguration standardConfiguration]];
+    retryPolicy.retryDelay = _retryDelay;
     NSURL *URL = [NSURL URLWithString:@"https://fake.domain.com/post/results"];
     TNLMutableRequestConfiguration *config = [TNLMutableRequestConfiguration defaultConfiguration];
     config.contentEncoder = [[BrokenContentEncoder alloc] init];
-    config.retryPolicyProvider = [[TestRetryPolicy alloc] initWithConfiguration:[TNLRequestRetryPolicyConfiguration standardConfiguration]];
+    config.retryPolicyProvider = retryPolicy;
     config.protocolOptions = TNLRequestProtocolOptionPseudo;
 
     NSHTTPURLResponse *URLResponse = [[NSHTTPURLResponse alloc] initWithURL:URL
@@ -43,7 +87,6 @@
         [TNLPseudoURLProtocol unregisterEndpoint:URL];
     });
 
-    __block TNLResponse *response = nil;
     NSDictionary *results = @{
                               @"player1" : @{
                                       @"name" : @"Montoya",
@@ -62,19 +105,21 @@
                                                                       HTTPBody:requestBody];
     TNLRequestOperation *op = [TNLRequestOperation operationWithRequest:request
                                                           configuration:config
-                                                             completion:^(TNLRequestOperation * _Nonnull operation, TNLResponse * _Nonnull opResponse) {
-                                                                 response = opResponse;
-                                                             }];
+                                                               delegate:self];
     [[TNLRequestOperationQueue defaultOperationQueue] enqueueRequestOperation:op];
     [op waitUntilFinishedWithoutBlockingRunLoop];
 
-    XCTAssertNotNil(response);
-    XCTAssertEqual((int)response.info.statusCode, 200);
-    XCTAssertNil(response.operationError);
-    XCTAssertEqual((int)response.metrics.attemptCount, 2);
+    XCTAssertNotNil(_response);
+    XCTAssertEqual((int)_response.info.statusCode, 200);
+    XCTAssertNil(_response.operationError);
+    XCTAssertEqual((int)_response.metrics.attemptCount, 2);
+    XCTAssertGreaterThan(_response.metrics.totalDuration, MAX(_retryDelay, _dependencyDuration + _dependencyDelay));
+#if 0 // disable this since the CI machines can have really slow performance -- feel free to enable when running locally
+    XCTAssertLessThan(_response.metrics.totalDuration, MAX(_retryDelay, _dependencyDuration + _dependencyDelay) + kDELAY_TIME_INTERVAL);
+#endif
 
     do {
-        TNLAttemptMetrics *firstAttemptMetrics = response.metrics.attemptMetrics.firstObject;
+        TNLAttemptMetrics *firstAttemptMetrics = _response.metrics.attemptMetrics.firstObject;
         XCTAssertNotNil(firstAttemptMetrics);
         XCTAssertNotNil(firstAttemptMetrics.operationError);
         XCTAssertEqualObjects(firstAttemptMetrics.operationError.domain, TNLErrorDomain);
@@ -85,12 +130,170 @@
         NSData *requestBodyBase64 = [requestBody base64EncodedDataWithOptions:(NSDataBase64Encoding64CharacterLineLength |
                                                                                NSDataBase64EncodingEndLineWithCarriageReturn |
                                                                                NSDataBase64EncodingEndLineWithLineFeed)];
-        TNLAttemptMetrics *lastAttemptMetrics = response.metrics.attemptMetrics.lastObject;
+        TNLAttemptMetrics *lastAttemptMetrics = _response.metrics.attemptMetrics.lastObject;
         XCTAssertNotNil(lastAttemptMetrics);
         XCTAssertNil(lastAttemptMetrics.operationError);
         XCTAssertEqualObjects([lastAttemptMetrics.URLRequest valueForHTTPHeaderField:@"Content-Encoding"], @"base64");
         XCTAssertEqualObjects(lastAttemptMetrics.URLRequest.HTTPBody, requestBodyBase64);
     } while (0);
+}
+
+#pragma mark Test specific scenarios
+
+- (void)testSuccessfulRequestDoesNotRetry
+{
+    NSURL *URL = [NSURL URLWithString:@"https://fake.domain.com/"];
+    TNLMutableHTTPRequest *request = [TNLMutableHTTPRequest GETRequestWithURL:URL HTTPHeaderFields:nil];
+
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:URL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil];
+    [TNLPseudoURLProtocol registerURLResponse:response body:nil withEndpoint:URL];
+    tnl_defer(^{
+        [TNLPseudoURLProtocol unregisterEndpoint:URL];
+    });
+
+    TNLRequestRetryPolicyConfiguration *retryConfig = [[TNLRequestRetryPolicyConfiguration alloc] initWithAllMethodsRetriableAndRetriableStatusCodes:@[@200] URLErrorCodes:nil POSIXErrorCodes:nil];
+    TestRetryPolicy *retryPolicy = [[TestRetryPolicy alloc] initWithConfiguration:retryConfig];
+
+    TNLMutableRequestConfiguration *config = [TNLMutableRequestConfiguration defaultConfiguration];
+    config.retryPolicyProvider = retryPolicy;
+    config.protocolOptions = TNLRequestProtocolOptionPseudo;
+
+    TNLRequestOperation *operation = [TNLRequestOperation operationWithRequest:request configuration:config delegate:self];
+    [[TNLRequestOperationQueue defaultOperationQueue] enqueueRequestOperation:operation];
+    [operation waitUntilFinishedWithoutBlockingRunLoop];
+
+    XCTAssertEqual(operation.attemptCount, 1);
+    XCTAssertEqual(operation.retryCount, 0);
+    XCTAssertEqual(operation.response.info.statusCode, 200);
+}
+
+- (void)testRetryWhenSubsequentRequestSucceeds
+{
+    NSURL *URL = [NSURL URLWithString:@"https://fake.domain.com/"];
+    TNLMutableHTTPRequest *request = [TNLMutableHTTPRequest GETRequestWithURL:URL HTTPHeaderFields:nil];
+
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:URL statusCode:503 HTTPVersion:@"HTTP/1.1" headerFields:nil];
+    NSHTTPURLResponse *successResponse = [[NSHTTPURLResponse alloc] initWithURL:URL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:nil];
+    [TNLPseudoURLProtocol registerURLResponse:response body:nil withEndpoint:URL];
+    _onNextRetry = ^{
+        [TNLPseudoURLProtocol registerURLResponse:successResponse body:nil withEndpoint:URL];
+    };
+    tnl_defer(^{
+        [TNLPseudoURLProtocol unregisterEndpoint:URL];
+    });
+
+    TestRetryPolicy *retryPolicy = [[TestRetryPolicy alloc] initWithConfiguration:[TNLRequestRetryPolicyConfiguration standardConfiguration]];
+
+    TNLMutableRequestConfiguration *config = [TNLMutableRequestConfiguration defaultConfiguration];
+    config.retryPolicyProvider = retryPolicy;
+    config.protocolOptions = TNLRequestProtocolOptionPseudo;
+
+    TNLRequestOperation *operation = [TNLRequestOperation operationWithRequest:request configuration:config delegate:self];
+    [[TNLRequestOperationQueue defaultOperationQueue] enqueueRequestOperation:operation];
+    [operation waitUntilFinishedWithoutBlockingRunLoop];
+
+    XCTAssertEqual(operation.attemptCount, 2);
+    XCTAssertEqual(operation.retryCount, 1);
+    XCTAssertEqual(operation.response.info.statusCode, 200);
+}
+
+- (void)testOperationTimeoutCancelsRetry
+{
+    // The actual timeout here does not matter, as long as it is enough for
+    // the initial attempt to complete. If the retryDelay is longer than the
+    // operationTimeout the retry should not be attempted.
+    static const NSTimeInterval operationTimeout = 30.0;
+    static const NSTimeInterval retryDelay = 40.0;
+
+    NSURL *URL = [NSURL URLWithString:@"https://fake.domain.com/"];
+    TNLMutableHTTPRequest *request = [TNLMutableHTTPRequest GETRequestWithURL:URL HTTPHeaderFields:nil];
+
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:URL statusCode:503 HTTPVersion:@"HTTP/1.1" headerFields:nil];
+    [TNLPseudoURLProtocol registerURLResponse:response body:nil withEndpoint:URL];
+    tnl_defer(^{
+        [TNLPseudoURLProtocol unregisterEndpoint:URL];
+    });
+
+    TestRetryPolicy *retryPolicy = [[TestRetryPolicy alloc] initWithConfiguration:[TNLRequestRetryPolicyConfiguration standardConfiguration]];
+    retryPolicy.retryDelay = retryDelay;
+
+    TNLMutableRequestConfiguration *config = [TNLMutableRequestConfiguration defaultConfiguration];
+    config.retryPolicyProvider = retryPolicy;
+    config.protocolOptions = TNLRequestProtocolOptionPseudo;
+    config.operationTimeout = operationTimeout;
+    config.attemptTimeout = operationTimeout;
+    config.idleTimeout = operationTimeout;
+
+    TNLRequestOperation *operation = [TNLRequestOperation operationWithRequest:request configuration:config delegate:self];
+    [[TNLRequestOperationQueue defaultOperationQueue] enqueueRequestOperation:operation];
+    [operation waitUntilFinishedWithoutBlockingRunLoop];
+
+    XCTAssertEqual(operation.attemptCount, 1);
+    XCTAssertEqual(operation.retryCount, 0);
+    XCTAssertEqual(operation.response.info.statusCode, 503);
+}
+
+- (void)testRetryWithNoOperationTimeout
+{
+    // The operation should retry if the `operationTimeout` is unlimited (less than 0.1 per docs).
+    // There used to be a bug where `operationTimeout` less than 0.1 would NEVER retry.
+    // This test prevents regression from fixing this particular bug.
+
+    NSURL *URL = [NSURL URLWithString:@"https://fake.domain.com/"];
+    TNLMutableHTTPRequest *request = [TNLMutableHTTPRequest GETRequestWithURL:URL HTTPHeaderFields:nil];
+
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:URL statusCode:503 HTTPVersion:@"HTTP/1.1" headerFields:nil];
+    [TNLPseudoURLProtocol registerURLResponse:response body:nil withEndpoint:URL];
+    tnl_defer(^{
+        [TNLPseudoURLProtocol unregisterEndpoint:URL];
+    });
+
+    TestRetryPolicy *retryPolicy = [[TestRetryPolicy alloc] initWithConfiguration:[TNLRequestRetryPolicyConfiguration standardConfiguration]];
+    retryPolicy.maxAttempts = 1;
+
+    TNLMutableRequestConfiguration *config = [TNLMutableRequestConfiguration defaultConfiguration];
+    config.retryPolicyProvider = retryPolicy;
+    config.protocolOptions = TNLRequestProtocolOptionPseudo;
+    config.operationTimeout = -1;
+
+    TNLRequestOperation *operation = [TNLRequestOperation operationWithRequest:request configuration:config delegate:self];
+    [[TNLRequestOperationQueue defaultOperationQueue] enqueueRequestOperation:operation];
+    [operation waitUntilFinishedWithoutBlockingRunLoop];
+
+    XCTAssertEqual(operation.attemptCount, 2);
+    XCTAssertEqual(operation.retryCount, 1);
+    XCTAssertEqual(operation.response.info.statusCode, 503);
+}
+
+#pragma mark - TNLRequestDelegate
+
+- (void)tnl_requestOperation:(TNLRequestOperation *)op
+  willStartRetryFromResponse:(TNLResponse *)responseBeforeRetry
+              policyProvider:(id<TNLRequestRetryPolicyProvider>)policyProvider
+                  afterDelay:(NSTimeInterval)delay
+{
+    if (_onNextRetry) {
+        _onNextRetry();
+        _onNextRetry = nil;
+    }
+
+    if (_dependencyDelay < 0.1 && _dependencyDuration < 0.1) {
+        return;
+    }
+
+    NSOperation *timeoutOp = [[TimerOperation alloc] initWithTimeout:_dependencyDuration];
+    [op addDependency:timeoutOp];
+    NSOperation *delayOp = [[TimerOperation alloc] initWithTimeout:_dependencyDelay];
+    [timeoutOp addDependency:delayOp];
+    NSOperationQueue *q = [NSOperationQueue currentQueue] ?: [NSOperationQueue mainQueue];
+    [q addOperation:timeoutOp];
+    [q addOperation:delayOp];
+}
+
+- (void)tnl_requestOperation:(TNLRequestOperation *)op
+     didCompleteWithResponse:(TNLResponse *)response
+{
+    _response = response;
 }
 
 @end
@@ -136,6 +339,10 @@
 - (BOOL)tnl_shouldRetryRequestOperation:(TNLRequestOperation *)op
                            withResponse:(TNLResponse *)response
 {
+    if (_maxAttempts && op.attemptCount > _maxAttempts) {
+        return NO;
+    }
+
     if ([response.operationError.domain isEqualToString:TNLErrorDomain] && response.operationError.code == TNLErrorCodeRequestOperationRequestContentEncodingFailed) {
         if (response.metrics.attemptCount > 3) {
             return NO;
@@ -149,7 +356,7 @@
 - (NSTimeInterval)tnl_delayBeforeRetryForRequestOperation:(TNLRequestOperation *)op
                                              withResponse:(TNLResponse *)response
 {
-    return 0.5;
+    return _retryDelay;
 }
 
 - (nullable TNLRequestConfiguration *)tnl_configurationOfRetryForRequestOperation:(TNLRequestOperation *)op
@@ -180,3 +387,68 @@
 }
 
 @end
+
+@implementation TimerOperation
+{
+    NSTimeInterval _timeout;
+    BOOL _finished;
+    BOOL _executing;
+}
+
+- (instancetype)initWithTimeout:(NSTimeInterval)timeout
+{
+    if (self = [super init]) {
+        _timeout = timeout;
+    }
+    return self;
+}
+
+- (void)start
+{
+    if ([self isCancelled]) {
+        [self willChangeValueForKey:@"isFinished"];
+        _finished = YES;
+        [self didChangeValueForKey:@"isFinished"];
+        return;
+    }
+
+    [self willChangeValueForKey:@"isExecuting"];
+    _executing = YES;
+    [self didChangeValueForKey:@"isExecuting"];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(_timeout * NSEC_PER_SEC)), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        [self completeOperation];
+    });
+}
+
+- (BOOL)isExecuting
+{
+    return _executing;
+}
+
+- (BOOL)isFinished
+{
+    return _finished;
+}
+
+- (BOOL)isConcurrent
+{
+    return YES;
+}
+
+- (BOOL)isAsynchronous
+{
+    return YES;
+}
+
+- (void)completeOperation
+{
+    [self willChangeValueForKey:@"isFinished"];
+    [self willChangeValueForKey:@"isExecuting"];
+    _executing = NO;
+    _finished = YES;
+    [self didChangeValueForKey:@"isExecuting"];
+    [self didChangeValueForKey:@"isFinished"];
+}
+
+@end
+

--- a/TwitterNetworkLayerTests/TNLRequestTests.m
+++ b/TwitterNetworkLayerTests/TNLRequestTests.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/28/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNLError.h"

--- a/TwitterNetworkLayerTests/TNLResponseTest.m
+++ b/TwitterNetworkLayerTests/TNLResponseTest.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 11/12/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "NSURLResponse+TNLAdditions.h"
@@ -172,8 +172,10 @@
     if (tnl_available_ios_11) {
         error = nil;
         archive = [NSKeyedArchiver archivedDataWithRootObject:response requiringSecureCoding:YES error:&error];
+#if !TARGET_OS_MACCATALYST
     } else {
         archive = [NSKeyedArchiver archivedDataWithRootObject:response];
+#endif
     }
 
     XCTAssertNotEqual(0UL, archive.length);
@@ -181,8 +183,10 @@
     if (tnl_available_ios_11) {
         error = nil;
         decodedResponse = [NSKeyedUnarchiver unarchivedObjectOfClass:[TNLResponse class] fromData:archive error:&error];
+#if !TARGET_OS_MACCATALYST
     } else {
         decodedResponse = [NSKeyedUnarchiver unarchiveObjectWithData:archive];
+#endif
     }
 
     XCTAssertTrue([decodedResponse isKindOfClass:[TNLResponse class]]);
@@ -227,8 +231,10 @@
     if (tnl_available_ios_11) {
         error = nil;
         archive = [NSKeyedArchiver archivedDataWithRootObject:response requiringSecureCoding:YES error:&error];
+#if !TARGET_OS_MACCATALYST
     } else {
         archive = [NSKeyedArchiver archivedDataWithRootObject:response];
+#endif
     }
 
     XCTAssertNotEqual(0UL, archive.length);
@@ -236,8 +242,10 @@
     if (tnl_available_ios_11) {
         error = nil;
         decodedResponse = [NSKeyedUnarchiver unarchivedObjectOfClass:[TNLResponse class] fromData:archive error:&error];
+#if !TARGET_OS_MACCATALYST
     } else {
         decodedResponse = [NSKeyedUnarchiver unarchiveObjectWithData:archive];
+#endif
     }
 
     XCTAssertTrue([decodedResponse isKindOfClass:[TNLResponse class]]);

--- a/TwitterNetworkLayerTests/TNLTemporaryFileTest.m
+++ b/TwitterNetworkLayerTests/TNLTemporaryFileTest.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 10/28/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import "TNLTemporaryFile_Project.h"

--- a/TwitterNetworkLayerTests/TNLURLCodingTest.m
+++ b/TwitterNetworkLayerTests/TNLURLCodingTest.m
@@ -3,9 +3,10 @@
 //  TwitterNetworkLayer
 //
 //  Created on 11/12/14.
-//  Copyright (c) 2014 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
+#import "NSNumber+TNLURLCoding.h"
 #import "TNLURLCoding.h"
 
 @import XCTest;
@@ -75,6 +76,103 @@
     mDict[@"ok"] = @"not-empty";
     query = TNLURLEncodeDictionary(mDict, 0);
     XCTAssertEqualObjects(query, @"ok=not-empty");
+}
+
+- (void)testNumberCoding
+{
+    NSArray<NSNumber *> *numbers = @[
+        @((BOOL)YES),
+        @((BOOL)NO),
+        @((BOOL)7),
+
+        @((uint8_t)0),
+        @((uint8_t)UINT8_MAX),
+        @((int8_t)INT8_MIN),
+        @((int8_t)0),
+        @((int8_t)INT8_MAX),
+
+        @((uint16_t)0),
+        @((uint16_t)UINT16_MAX),
+        @((int16_t)INT16_MIN),
+        @((int16_t)0),
+        @((int16_t)INT16_MAX),
+
+        @((uint32_t)0),
+        @((uint32_t)UINT32_MAX),
+        @((int32_t)INT32_MIN),
+        @((int32_t)0),
+        @((int32_t)INT32_MAX),
+
+        @((uint64_t)0),
+        @((uint64_t)UINT64_MAX),
+        @((int64_t)INT64_MIN),
+        @((int64_t)0),
+        @((int64_t)INT64_MAX),
+
+        @(FLT_MIN),
+        @(0.f),
+        @(FLT_MAX),
+        @((float)M_PI),
+
+        @(DBL_MIN),
+        @(0.f),
+        @(DBL_MAX),
+        @(M_PI),
+    ];
+
+    NSTimeInterval nsDuration, tnlDuration;
+    const NSUInteger iterations = 20000;
+#define PRINT_NUMBERS 0
+
+    {
+#if PRINT_NUMBERS
+        BOOL didPrint = NO;
+#endif
+        const CFAbsoluteTime nsStart = CFAbsoluteTimeGetCurrent();
+        for (NSUInteger i = 0; i < iterations; i++) {
+            for (NSNumber *number in numbers) {
+                NSString *value = [number stringValue];
+#if PRINT_NUMBERS
+                if (!didPrint) {
+                    NSLog(@"%@", value);
+                }
+#endif
+                (void)value;
+            }
+#if PRINT_NUMBERS
+            didPrint = YES;
+#endif
+        }
+        const CFAbsoluteTime nsEnd = CFAbsoluteTimeGetCurrent();
+        nsDuration = nsEnd - nsStart;
+        NSLog(@"-[NSNumber stringValue] = %fs", nsDuration);
+    }
+
+    {
+#if PRINT_NUMBERS
+        BOOL didPrint = NO;
+#endif
+        const CFAbsoluteTime tnlStart = CFAbsoluteTimeGetCurrent();
+        for (NSUInteger i = 0; i < iterations; i++) {
+            for (NSNumber *number in numbers) {
+                NSString *value = [number tnl_quickStringValue];
+#if PRINT_NUMBERS
+                if (!didPrint) {
+                    NSLog(@"%@", value);
+                }
+#endif
+                (void)value;
+            }
+#if PRINT_NUMBERS
+            didPrint = YES;
+#endif
+        }
+        const CFAbsoluteTime tnlEnd = CFAbsoluteTimeGetCurrent();
+        tnlDuration = tnlEnd - tnlStart;
+        NSLog(@"-[NSNumber tnl_quickStringValue] = %fs", tnlDuration);
+    }
+
+    XCTAssertLessThan(tnlDuration, nsDuration, @"-[NSNumber tnl_quickStringValue] ought to be faster than -[NSNumber stringValue]!");
 }
 
 @end

--- a/TwitterNetworkLayerTests/TNLURLSessionManagerTest.m
+++ b/TwitterNetworkLayerTests/TNLURLSessionManagerTest.m
@@ -2,8 +2,8 @@
 //  TNLURLSessionManagerTest.m
 //  TwitterNetworkLayer
 //
-//  Created by Nolan on 4/1/19.
-//  Copyright © 2019 Twitter. All rights reserved.
+//  Created on 4/1/19.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <XCTest/XCTest.h>

--- a/TwitterNetworkLayerTests/TNLXContentEncoding.h
+++ b/TwitterNetworkLayerTests/TNLXContentEncoding.h
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 11/21/16.
-//  Copyright © 2016 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/TwitterNetworkLayerTests/TNLXContentEncoding.m
+++ b/TwitterNetworkLayerTests/TNLXContentEncoding.m
@@ -3,7 +3,7 @@
 //  TwitterNetworkLayer
 //
 //  Created on 11/21/16.
-//  Copyright © 2016 Twitter. All rights reserved.
+//  Copyright © 2020 Twitter. All rights reserved.
 //
 
 #include <zlib.h>


### PR DESCRIPTION
### 2.14.0

- Update `TNLCommunicationAgent` to handle reachability behavior changes
  - The `Network.framwork` can yield an "other" interface when VPN is enabled (on Mac binaries)
    - Coerce these into _WiFi_ since we don't have a good way to determine the actual interface used at the moment
  - The `Network.framework` used to yield _WiFi_ for any network connection on a simulator, but now yields _Wired_
    - Rename `TNLNetworkReachabilityReachableViaWiFi` to `TNLNetworkReachabilityReachableViaEthernet` and handle both cases as _Ethernet_

### 2.13.0

- Refactor _Service Unavailable Backoff_ system to be more abstract and support *any* trigger for backoff
  - All `*serviceUnavailableBackoff*` APIs are refactored into `*backoff*` APIs
  - Introduce `[TNLGlobalConfiguration backoffSignaler]`
    - Implement your own `TNLBackoffSignaler` to customize behavior ... or ...
    - Default will use `TNLSimpleBackoffSignaler` which will signal on *HTTP 503*

### 2.12.0

- Abstract out _Service Unavailable Backoff Behavior_ for customization to be applied
  - See `[TNLGlobalConfiguration serviceUnavailableBackoffBehaviorProvider]` for providing a custom backoff behavior
    - Implement your own `TNLServiceUnavailableBackoffBehaviorProvider` to customize behavior
    - Due to _Service Unavailable_ signaling being opaque, only the HTTP Headers and the URL can be provided
  - Default will use `TNLSimpleServiceUnavailableBackoffBehaviorProvider`
    - Exact same behavior as before (introduced in **TNL** prior to v2.0 open sourcing)

### 2.11.0

- Change the `TNLURLSessionAuthChallengeCompletionBlock` arguments
  - Leave the _disposition_ parameter
  - Change the _credentials_ parameter of `NSURLCredentials` to be _credentialsOrCancelContext_ of `id`
    - This will permit `TNLAuthenticationChallengeHandler` instance to be able to cancel the challenge and provide extra context in the resulting error code
    - Twitter will use this to cancel _401_ login auth challenges when we don't want a redundant request to be made (since it just yields the same response)
      - This is to facilitate working around the behavior in `NSURLSession` where an _HTTP 401_ response with `WWW-Authenticate` header will always be transparently be retried (even when unmodified yielding the identical _401_ response).
      - An additionaly problem is that canceling the _401_ response will discard the response's body.  If there is information needed in the response body, it will be lost.
      - Twitter has updated its `WWW-Authenticate` header responses to include additional metadata since the response body cannot be used.
        - See https://tools.ietf.org/html/rfc7235#section-4.1
      - Apple Feedback: `FB7697492`

### 2.10.0

- Add retriable dependencies to `TNLRequestOperation`
  - Whenever a `TNLRetryPolicyProvider` would yield a retry, that retry will be delayed by the longer of 2 things:
    1. The delay provided by the retry policy provider (minimum of 100 milliseconds)
    2. Waiting for all `dependencies` on the `TNLRequestOperation` to complete
    - Normally, all `dependencies` of a retrying `TNLRequestOperation` will be complete before it has started but it is now possible to add dependencies after the request operation has already started to increase the dependencies on a retry starting.

### 2.9.0

- Introduce `tnlcli`, a command-line-interface for __TNL__
  - Like _cURL_ but with __TNL__ features
  - Verbose mode provides all __TNL__ logging to stdout / stderr along with lots of other details